### PR TITLE
Trigger a `autocomplete:empty` when all datasets are empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,8 @@ The autocomplete component triggers the following custom events.
 * `autocomplete:shown` – Triggered when the dropdown menu of the autocomplete is 
   shown (opened and non-empty).
 
+* `autocomplete:empty` – Triggered when all datasets are empty. 
+
 * `autocomplete:closed` – Triggered when the dropdown menu of the autocomplete is 
   closed.
 

--- a/src/autocomplete/dropdown.js
+++ b/src/autocomplete/dropdown.js
@@ -114,6 +114,7 @@ _.mixin(Dropdown.prototype, EventEmitter, {
     this.isEmpty = _.every(this.datasets, isDatasetEmpty);
 
     if (this.isEmpty) {
+      this.trigger('empty');
       if (this.$empty) {
         if (!query) {
           this._hide();

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -70,6 +70,7 @@ function Typeahead(o) {
     .onSync('opened', this._onOpened, this)
     .onSync('closed', this._onClosed, this)
     .onSync('shown', this._onShown, this)
+    .onSync('empty', this._onEmpty, this)
     .onAsync('datasetRendered', this._onDatasetRendered, this);
 
   this.input = new Typeahead.Input({input: $input, hint: $hint})
@@ -128,6 +129,10 @@ _.mixin(Typeahead.prototype, {
     this._updateHint();
 
     this.eventBus.trigger('opened');
+  },
+
+  _onEmpty: function onEmpty() {
+    this.eventBus.trigger('empty');
   },
 
   _onShown: function onShown() {

--- a/test/unit/dropdown_spec.js
+++ b/test/unit/dropdown_spec.js
@@ -102,6 +102,18 @@ describe('Dropdown', function() {
       expect(this.$menu.find('.aa-empty').children().length).toEqual(1);
       expect(this.$menu.find('.aa-empty').find('h3.empty').length).toEqual(1);
     });
+
+    it('should trigger empty', function() {
+      var spy;
+
+      this.view.datasets[0].isEmpty.and.returnValue(true);
+      this.view.onSync('empty', spy = jasmine.createSpy());
+
+      this.view.open();
+      this.view._onRendered('rendered', 'a query');
+
+      expect(spy).toHaveBeenCalled();
+    });
   });
 
   describe('when mouseenter is triggered on a suggestion', function() {

--- a/test/unit/typeahead_spec.js
+++ b/test/unit/typeahead_spec.js
@@ -500,6 +500,18 @@ describe('Typeahead', function() {
     });
   });
 
+  describe('when dropdown is empty', function() {
+    it('should trigger autocomplete:empty', function() {
+      var spy;
+
+      this.$input.on('autocomplete:empty', spy = jasmine.createSpy());
+
+      this.dropdown.trigger('empty');
+
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
   describe('when input triggers leftKeyed', function() {
     it('should autocomplete if language is rtl', function() {
       var spy;


### PR DESCRIPTION
Fix #87