### PR TITLE
Ensure empty template displays from first keystroke

### DIFF
--- a/src/autocomplete/dropdown.js
+++ b/src/autocomplete/dropdown.js
@@ -120,13 +120,14 @@ _.mixin(Dropdown.prototype, EventEmitter, {
       }
 
       if (this.$empty) {
-        if (!query) {
+        if (query.length < this.minLength) {
           this._hide();
         } else {
           var html = this.templates.empty({
             query: this.datasets[0] && this.datasets[0].query
           });
           this.$empty.html(html);
+          this._show();
         }
       } else {
         this._hide();
@@ -135,6 +136,7 @@ _.mixin(Dropdown.prototype, EventEmitter, {
       if (this.$empty) {
         this.$empty.empty();
       }
+
       if (query.length >= this.minLength) {
         this._show();
       } else {


### PR DESCRIPTION
This will make sure that even if there have been no results matching yet
and the minLength has been reached, we correctly display the empty template.

Resolves: #102