### PR TITLE
Event sent when cursorRemoved

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,9 @@ The autocomplete component triggers the following custom events.
   event object, the suggestion object, and the name of the dataset the 
   suggestion belongs to.
 
+* `autocomplete:cursorremoved` – Triggered when the cursor leaves the selections
+  or its current index is lower than 0
+
 * `autocomplete:autocompleted` – Triggered when the query is autocompleted. 
   Autocompleted means the query was changed to the hint. The event handler will 
   be invoked with 3 arguments: the jQuery event object, the suggestion object, 

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -151,6 +151,7 @@ _.mixin(Typeahead.prototype, {
   _onCursorRemoved: function onCursorRemoved() {
     this.input.resetInputValue();
     this._updateHint();
+    this.eventBus.trigger('cursorremoved');
   },
 
   _onDatasetRendered: function onDatasetRendered() {


### PR DESCRIPTION
Hello,

I need an event to be sent when the cursor is removed. Right now, its is not possible to listen to the event 'autocomplete:cursorRemoved' 
Thanks !