### PR TITLE
fix(zepto): do not leak Zepto, restore it if necessary

### DIFF
--- a/src/standalone/index.js
+++ b/src/standalone/index.js
@@ -1,9 +1,16 @@
 'use strict';
 
 var current$ = window.$;
-require('../../zepto.js');
-var zepto = window.Zepto;
+var currentZepto = window.Zepto;
+
+require('../../zepto.js'); // this will inject Zepto in window, unfortunately no easy commonJS zepto build
+var zepto = window.Zepto; // save zepto for our own usage
 window.$ = current$; // restore the `$` (we don't want Zepto here)
+window.Zepto = currentZepto; // restore potential Zepto
+if (!currentZepto) {
+  // cleanup the environement so we do not inject bad things
+  delete window.Zepto;
+}
 
 // setup DOM element
 var DOM = require('../common/dom.js');


### PR DESCRIPTION
Some jQuery module will register plugins inside Zepto.fn if window.Zepto is present.

So if Zepto was not present before we leaked it in window, now we remove it.
We also set back the previous window.Zepto global if necessary.

Ultimately a better solution would be to be able to not leak Zepto in window by having a good commonJS build of it.