### PR TITLE
Remove peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,6 @@
     "type": "git",
     "url": "https://github.com/algolia/autocomplete.js.git"
   },
-  "peerDependencies": {
-    "angular": "< 2.0.0",
-    "jquery": ">= 3.1.0"
-  },
   "devDependencies": {
     "angular": "^1.5.8",
     "angular-mocks": "^1.5.8",


### PR DESCRIPTION
`autocomplete.js` works just fine without jQuery or Angular. By including them as peer dependencies, `npm` triggers an error if they are not installed. I don't think this is the desired behavior.