### PR TITLE
Fix autoselectOnBlur select top suggestion even on click of other sug…

### DIFF
--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -200,11 +200,16 @@ _.mixin(Typeahead.prototype, {
   },
 
   _onBlurred: function onBlurred() {
+    var cursorDatum;
     var topSuggestionDatum;
+
+    cursorDatum = this.dropdown.getDatumForCursor();
     topSuggestionDatum = this.dropdown.getDatumForTopSuggestion();
 
     if (!this.debug) {
-      if (this.autoselectOnBlur && topSuggestionDatum) {
+      if (this.autoselectOnBlur && cursorDatum) {
+        this._select(cursorDatum);
+      } else if (this.autoselectOnBlur && topSuggestionDatum) {
         this._select(topSuggestionDatum);
       } else {
         this.isActivated = false;


### PR DESCRIPTION
#113 

as for test I'm not familiar with Jasmine, can't dig into it right now something like this I suppose:
````
    it('should select the clicked suggestion instead of top suggestion if autoselectOnBlur is true', function() {
      this.view.autoselectOnBlur = true;
      this.dropdown.getDatumForTopSuggestion.and.returnValue(testDatum);
      this.dropdown.getDatumForCursor.and.returnValue(testDatum2);

      var spy;

      this.$input.on('autocomplete:selected', spy = jasmine.createSpy());
      // this.input.trigger('blurred');
      // trigger a specific value click and check that it's actually selected instead of top suggestion

      expect(spy).toHaveBeenCalled();
      expect(this.input.setQuery).toHaveBeenCalledWith(testDatum2.value);
      expect(this.input.setInputValue)
        .toHaveBeenCalledWith(testDatum2.value, true);
    });
````