### PR TITLE
feat(appendTo): new parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ When initializing an autocomplete, there are a number of options you can configu
 
 * `openOnFocus` – If `true`, the dropdown menu will open when the input is focused. Defaults to `false`.
 
+* `appendTo` – If set with a DOM selector, doesn't wrap the input and appends the wrapper and dropdown menu to the first DOM element matching the selector. It automatically positions the wrapper under the input, and sets it to the same width as the input. Can't be used with `hint: true`, because `hint` requires the wrapper around the input.
+
 * `dropdownMenuContainer` – If set with a DOM selector, it overrides the container of the dropdown menu.
 
 * `templates` – An optional hash overriding the default templates.
@@ -531,6 +533,8 @@ The autocomplete component triggers the following custom events.
   Autocompleted means the query was changed to the hint. The event handler will
   be invoked with 3 arguments: the jQuery event object, the suggestion object,
   and the name of the dataset the suggestion belongs to.
+
+* `autocomplete:redrawn` – Triggered when `appendTo` is used and the wrapper is resized/repositionned.
 
 All custom events are triggered on the element initialized as the autocomplete.
 

--- a/src/angular/directive.js
+++ b/src/angular/directive.js
@@ -75,7 +75,8 @@ angular.module('algolia.autocomplete', [])
             debug: scope.options.debug,
             cssClasses: scope.options.cssClasses,
             datasets: scope.datasets,
-            keyboardShortcuts: scope.options.keyboardShortcuts
+            keyboardShortcuts: scope.options.keyboardShortcuts,
+            appendTo: scope.options.appendTo
           });
         }
 

--- a/src/autocomplete/css.js
+++ b/src/autocomplete/css.js
@@ -61,6 +61,18 @@ var css = {
     cursor: 'cursor',
     dataset: 'dataset',
     empty: 'empty'
+  },
+  appendTo: {
+    wrapper: {
+      position: 'absolute',
+      zIndex: '100',
+      display: 'none'
+    },
+    input: {},
+    inputWithNoHint: {},
+    dropdown: {
+      display: 'block'
+    }
   }
 };
 

--- a/src/autocomplete/css.js
+++ b/src/autocomplete/css.js
@@ -62,6 +62,7 @@ var css = {
     dataset: 'dataset',
     empty: 'empty'
   },
+  // will be merged with the default ones if appendTo is used
   appendTo: {
     wrapper: {
       position: 'absolute',

--- a/src/autocomplete/dataset.js
+++ b/src/autocomplete/dataset.js
@@ -37,6 +37,7 @@ function Dataset(o) {
 
   this.templates = getTemplates(o.templates, this.displayFn);
 
+  this.css = _.mixin({}, css, o.appendTo ? css.appendTo : {});
   this.cssClasses = _.mixin({}, css.defaultClasses, o.cssClasses || {});
 
   var clazz = _.className(this.cssClasses.prefix, this.cssClasses.dataset);
@@ -126,7 +127,7 @@ _.mixin(Dataset.prototype, EventEmitter, {
       var suggestionsHtml = html.suggestions.
         replace('%PREFIX%', this.cssClasses.prefix).
         replace('%SUGGESTIONS%', this.cssClasses.suggestions);
-      $suggestions = DOM.element(suggestionsHtml).css(css.suggestions);
+      $suggestions = DOM.element(suggestionsHtml).css(this.css.suggestions);
 
       // jQuery#append doesn't support arrays as the first argument
       // until version 1.8, see http://bugs.jquery.com/ticket/11231
@@ -147,7 +148,7 @@ _.mixin(Dataset.prototype, EventEmitter, {
         $el.data(datasetKey, that.name);
         $el.data(valueKey, that.displayFn(suggestion) || undefined); // this led to undefined return value
         $el.data(datumKey, JSON.stringify(suggestion));
-        $el.children().each(function() { DOM.element(this).css(css.suggestionChild); });
+        $el.children().each(function() { DOM.element(this).css(self.css.suggestionChild); });
 
         return $el;
       }

--- a/src/autocomplete/dropdown.js
+++ b/src/autocomplete/dropdown.js
@@ -31,8 +31,10 @@ function Dropdown(o) {
   this.isOpen = false;
   this.isEmpty = true;
   this.minLength = o.minLength || 0;
-  this.cssClasses = _.mixin({}, css.defaultClasses, o.cssClasses || {});
   this.templates = {};
+  this.appendTo = o.appendTo || false;
+  this.css = _.mixin({}, css, o.appendTo ? css.appendTo : {});
+  this.cssClasses = o.cssClasses = _.mixin({}, css.defaultClasses, o.cssClasses || {});
 
   // bound functions
   onSuggestionClick = _.bind(this._onSuggestionClick, this);
@@ -44,6 +46,11 @@ function Dropdown(o) {
     .on('click.aa', cssClass, onSuggestionClick)
     .on('mouseenter.aa', cssClass, onSuggestionMouseEnter)
     .on('mouseleave.aa', cssClass, onSuggestionMouseLeave);
+
+  this.$input = o.input;
+  this.$wrapper = o.wrapper;
+
+  this.$container = o.appendTo ? this.$wrapper : this.$menu;
 
   if (o.templates && o.templates.header) {
     this.templates.header = _.templatify(o.templates.header);
@@ -73,6 +80,11 @@ function Dropdown(o) {
     this.templates.footer = _.templatify(o.templates.footer);
     this.$menu.append(this.templates.footer());
   }
+
+  var self = this;
+  DOM.element(window).resize(function() {
+    self._redraw();
+  });
 }
 
 // instance methods
@@ -162,15 +174,36 @@ _.mixin(Dropdown.prototype, EventEmitter, {
   },
 
   _hide: function() {
-    this.$menu.hide();
+    this.$container.hide();
   },
 
   _show: function() {
     // can't use jQuery#show because $menu is a span element we want
     // display: block; not dislay: inline;
-    this.$menu.css('display', 'block');
+    this.$container.css('display', 'block');
+
+    this._redraw();
 
     this.trigger('shown');
+  },
+
+  _redraw: function redraw() {
+    if (!this.isOpen || !this.appendTo) return;
+
+    var inputRect = this.$input[0].getBoundingClientRect();
+
+    this.$wrapper.css('width', inputRect.width + 'px');
+    this.$wrapper.css('top', 0 + 'px');
+    this.$wrapper.css('left', 0 + 'px');
+
+    var wrapperRect = this.$wrapper[0].getBoundingClientRect();
+
+    var top = inputRect.bottom - wrapperRect.top;
+    this.$wrapper.css('top', top + 'px');
+    var left = inputRect.left - wrapperRect.left;
+    this.$wrapper.css('left', left + 'px');
+
+    this.trigger('redrawn');
   },
 
   _getSuggestions: function getSuggestions() {
@@ -272,7 +305,7 @@ _.mixin(Dropdown.prototype, EventEmitter, {
   },
 
   setLanguageDirection: function setLanguageDirection(dir) {
-    this.$menu.css(dir === 'ltr' ? css.ltr : css.rtl);
+    this.$menu.css(dir === 'ltr' ? this.css.ltr : this.css.rtl);
   },
 
   moveCursorUp: function moveCursorUp() {

--- a/src/autocomplete/dropdown.js
+++ b/src/autocomplete/dropdown.js
@@ -47,10 +47,7 @@ function Dropdown(o) {
     .on('mouseenter.aa', cssClass, onSuggestionMouseEnter)
     .on('mouseleave.aa', cssClass, onSuggestionMouseLeave);
 
-  this.$input = o.input;
-  this.$wrapper = o.wrapper;
-
-  this.$container = o.appendTo ? this.$wrapper : this.$menu;
+  this.$container = o.appendTo ? o.wrapper : this.$menu;
 
   if (o.templates && o.templates.header) {
     this.templates.header = _.templatify(o.templates.header);
@@ -189,19 +186,6 @@ _.mixin(Dropdown.prototype, EventEmitter, {
 
   _redraw: function redraw() {
     if (!this.isOpen || !this.appendTo) return;
-
-    var inputRect = this.$input[0].getBoundingClientRect();
-
-    this.$wrapper.css('width', inputRect.width + 'px');
-    this.$wrapper.css('top', 0 + 'px');
-    this.$wrapper.css('left', 0 + 'px');
-
-    var wrapperRect = this.$wrapper[0].getBoundingClientRect();
-
-    var top = inputRect.bottom - wrapperRect.top;
-    this.$wrapper.css('top', top + 'px');
-    var left = inputRect.left - wrapperRect.left;
-    this.$wrapper.css('left', left + 'px');
 
     this.trigger('redrawn');
   },

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -91,6 +91,7 @@ function Typeahead(o) {
     .onSync('closed', this._onClosed, this)
     .onSync('shown', this._onShown, this)
     .onSync('empty', this._onEmpty, this)
+    .onSync('redrawn', this._onRedrawn, this)
     .onAsync('datasetRendered', this._onDatasetRendered, this);
 
   this.input = new Typeahead.Input({input: $input, hint: $hint})
@@ -188,6 +189,10 @@ _.mixin(Typeahead.prototype, {
 
   _onEmpty: function onEmpty() {
     this.eventBus.trigger('empty');
+  },
+
+  _onRedrawn: function onRedrawn() {
+    this.eventBus.trigger('redrawn');
   },
 
   _onShown: function onShown() {

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -16,7 +16,6 @@ var css = require('./css.js');
 // THOUGHT: what if datasets could dynamically be added/removed?
 function Typeahead(o) {
   var $menu;
-  var $input;
   var $hint;
 
   o = o || {};
@@ -44,8 +43,8 @@ function Typeahead(o) {
   var domElts = buildDom(o);
 
   this.$node = domElts.wrapper;
+  var $input = this.$input = domElts.input;
   $menu = domElts.menu;
-  $input = domElts.input;
   $hint = domElts.hint;
 
   if (o.dropdownMenuContainer) {
@@ -75,7 +74,6 @@ function Typeahead(o) {
   this.eventBus = o.eventBus || new EventBus({el: $input});
 
   this.dropdown = new Typeahead.Dropdown({
-    input: $input,
     appendTo: o.appendTo,
     wrapper: this.$node,
     menu: $menu,
@@ -107,7 +105,7 @@ function Typeahead(o) {
     .onSync('queryChanged', this._onQueryChanged, this)
     .onSync('whitespaceChanged', this._onWhitespaceChanged, this);
 
-  this._bindKeyboardShortcuts($input, o);
+  this._bindKeyboardShortcuts(o);
 
   this._setLanguageDirection();
 }
@@ -118,10 +116,11 @@ function Typeahead(o) {
 _.mixin(Typeahead.prototype, {
   // ### private
 
-  _bindKeyboardShortcuts: function($input, options) {
+  _bindKeyboardShortcuts: function(options) {
     if (!options.keyboardShortcuts) {
       return;
     }
+    var $input = this.$input;
     var keyboardShortcuts = [];
     _.each(options.keyboardShortcuts, function(key) {
       if (typeof key === 'string') {
@@ -192,6 +191,19 @@ _.mixin(Typeahead.prototype, {
   },
 
   _onRedrawn: function onRedrawn() {
+    var inputRect = this.$input[0].getBoundingClientRect();
+
+    this.$node.css('width', inputRect.width + 'px');
+    this.$node.css('top', 0 + 'px');
+    this.$node.css('left', 0 + 'px');
+
+    var wrapperRect = this.$node[0].getBoundingClientRect();
+
+    var top = inputRect.bottom - wrapperRect.top;
+    this.$node.css('top', top + 'px');
+    var left = inputRect.left - wrapperRect.left;
+    this.$node.css('left', left + 'px');
+
     this.eventBus.trigger('redrawn');
   },
 

--- a/src/jquery/plugin.js
+++ b/src/jquery/plugin.js
@@ -62,7 +62,8 @@ methods = {
         debug: o.debug,
         cssClasses: o.cssClasses,
         datasets: datasets,
-        keyboardShortcuts: o.keyboardShortcuts
+        keyboardShortcuts: o.keyboardShortcuts,
+        appendTo: o.appendTo
       });
 
       $input.data(typeaheadKey, typeahead);

--- a/src/standalone/index.js
+++ b/src/standalone/index.js
@@ -46,7 +46,8 @@ function autocomplete(selector, options, datasets, typeaheadObject) {
       debug: options.debug,
       cssClasses: options.cssClasses,
       datasets: datasets,
-      keyboardShortcuts: options.keyboardShortcuts
+      keyboardShortcuts: options.keyboardShortcuts,
+      appendTo: options.appendTo
     });
 
     $input.data(typeaheadKey, typeahead);

--- a/test/integration/test.html
+++ b/test/integration/test.html
@@ -95,24 +95,33 @@
         'this is a very long value so deal with it otherwise you gonna have a hard time'
       ];
 
-      $('#states').autocomplete({ }, [
-        {
-          displayKey: 'name',
-          source: function(q, cb) {
-            var res = [];
-            if (!q) {
-              cb([]);
-              return;
-            }
-            for (var i = 0; i < states.length; ++i) {
-              if (states[i].toLowerCase().indexOf(q.toLowerCase()) === 0) {
-                res.push({ name: states[i] });
-              }
-            }
-            cb(res);
-          }
+      function buildAutocomplete (options) {
+        if (options === undefined) options = { };
+        if (window.autocomplete) {
+          window.autocomplete.autocomplete.destroy();
+          window.autocomplete = null;
         }
-      ]);
+        window.autocomplete = $('#states').autocomplete(options, [
+          {
+            displayKey: 'name',
+            source: function(q, cb) {
+              var res = [];
+              if (!q) {
+                cb([]);
+                return;
+              }
+              for (var i = 0; i < states.length; ++i) {
+                if (states[i].toLowerCase().indexOf(q.toLowerCase()) === 0) {
+                  res.push({ name: states[i] });
+                }
+              }
+              cb(res);
+            }
+          }
+        ]);
+      }
+
+      buildAutocomplete();
     </script>
   </body>
 </html>

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -99,303 +99,329 @@ describe('jquery-typeahead.js', function() {
     });
   });
 
-  describe('on blur', function() {
-    it('should close dropdown', function(done) {
-      driver.run(function*() {
-        yield input.click();
-        yield input.type('mi');
-        expect(yield dropdown.isDisplayed()).to.equal(true);
+  function testSuite () {
+    describe('on blur', function() {
+      it('should close dropdown', function(done) {
+        driver.run(function*() {
+          yield input.click();
+          yield input.type('mi');
+          expect(yield dropdown.isDisplayed()).to.equal(true);
 
-        yield body.click();
-        expect(yield dropdown.isDisplayed()).to.equal(false);
+          yield body.click();
+          expect(yield dropdown.isDisplayed()).to.equal(false);
 
-        done();
+          done();
+        });
+      });
+
+      it('should clear hint', function(done) {
+        driver.run(function*() {
+          yield input.click();
+          yield input.type('mi');
+          expect(yield hint.getValue()).to.equal('michigan');
+
+          yield body.click();
+          expect(yield hint.getValue()).to.equal('');
+
+          done();
+        });
       });
     });
 
-    it('should clear hint', function(done) {
-      driver.run(function*() {
-        yield input.click();
-        yield input.type('mi');
-        expect(yield hint.getValue()).to.equal('michigan');
+    describe('on query change', function() {
+      it('should open dropdown if suggestions', function(done) {
+        driver.run(function*() {
+          yield input.click();
+          yield input.type('mi');
 
-        yield body.click();
-        expect(yield hint.getValue()).to.equal('');
+          expect(yield dropdown.isDisplayed()).to.equal(true);
 
-        done();
+          done();
+        });
       });
-    });
-  });
 
-  describe('on query change', function() {
-    it('should open dropdown if suggestions', function(done) {
-      driver.run(function*() {
-        yield input.click();
-        yield input.type('mi');
+      it('should position the dropdown correctly', function(done) {
+        driver.run(function*() {
+          yield input.click();
+          yield input.type('mi');
 
-        expect(yield dropdown.isDisplayed()).to.equal(true);
+          var inputPos = yield input.getLocation();
+          var dropdownPos = yield dropdown.getLocation();
 
-        done();
+          expect(inputPos.x >= dropdownPos.x - 2 && inputPos.x <= dropdownPos.x + 2).to.equal(true);
+          expect(dropdownPos.y > inputPos.y).to.equal(true);
+
+          done();
+        });
       });
-    });
 
-    it('should close dropdown if no suggestions', function(done) {
-      driver.run(function*() {
-        yield input.click();
-        yield input.type('huh?');
+      it('should close dropdown if no suggestions', function(done) {
+        driver.run(function*() {
+          yield input.click();
+          yield input.type('huh?');
 
-        expect(yield dropdown.isDisplayed()).to.equal(false);
+          expect(yield dropdown.isDisplayed()).to.equal(false);
 
-        done();
+          done();
+        });
       });
-    });
 
-    it('should render suggestions if suggestions', function(done) {
-      driver.run(function*() {
-        var suggestions;
+      it('should render suggestions if suggestions', function(done) {
+        driver.run(function*() {
+          var suggestions;
 
-        yield input.click();
-        yield input.type('mi');
+          yield input.click();
+          yield input.type('mi');
 
-        suggestions = yield dropdown.elementsByClassName('aa-suggestion');
+          suggestions = yield dropdown.elementsByClassName('aa-suggestion');
 
-        expect(suggestions).to.have.length('4');
-        expect(yield suggestions[0].text()).to.equal('Michigan');
-        expect(yield suggestions[1].text()).to.equal('Minnesota');
-        expect(yield suggestions[2].text()).to.equal('Mississippi');
-        expect(yield suggestions[3].text()).to.equal('Missouri');
+          expect(suggestions).to.have.length('4');
+          expect(yield suggestions[0].text()).to.equal('Michigan');
+          expect(yield suggestions[1].text()).to.equal('Minnesota');
+          expect(yield suggestions[2].text()).to.equal('Mississippi');
+          expect(yield suggestions[3].text()).to.equal('Missouri');
 
-        done();
+          done();
+        });
       });
-    });
 
-    it('should show hint if top suggestion is a match', function(done) {
-      driver.run(function*() {
-        yield input.click();
-        yield input.type('mi');
+      it('should show hint if top suggestion is a match', function(done) {
+        driver.run(function*() {
+          yield input.click();
+          yield input.type('mi');
 
-        expect(yield hint.getValue()).to.equal('michigan');
+          expect(yield hint.getValue()).to.equal('michigan');
 
-        done();
+          done();
+        });
       });
-    });
 
-    it('should not show hint if top suggestion is not a match', function(done) {
-      driver.run(function*() {
-        yield input.click();
-        yield input.type('ham');
+      it('should not show hint if top suggestion is not a match', function(done) {
+        driver.run(function*() {
+          yield input.click();
+          yield input.type('ham');
 
-        expect(yield hint.getValue()).to.equal('');
+          expect(yield hint.getValue()).to.equal('');
 
-        done();
+          done();
+        });
       });
-    });
 
-    it('should not show hint if there is query overflow', function(done) {
-      driver.run(function*() {
-        yield input.click();
-        yield input.type('this is a very long value so deal with it otherwise');
+      it('should not show hint if there is query overflow', function(done) {
+        driver.run(function*() {
+          yield input.click();
+          yield input.type('this is a very long value so deal with it otherwise');
 
-        expect(yield hint.getValue()).to.equal('');
+          expect(yield hint.getValue()).to.equal('');
 
-        done();
-      });
-    });
-  });
-
-  describe('on up arrow', function() {
-    it('should cycle through suggestions', function(done) {
-      driver.run(function*() {
-        var suggestions;
-
-        yield input.click();
-        yield input.type('mi');
-
-        suggestions = yield dropdown.elementsByClassName('aa-suggestion');
-
-        yield input.type(wd.SPECIAL_KEYS['Up arrow']);
-        expect(yield input.getValue()).to.equal('Missouri');
-        expect(yield suggestions[3].getAttribute('class')).to.equal('aa-suggestion aa-cursor');
-
-        yield input.type(wd.SPECIAL_KEYS['Up arrow']);
-        expect(yield input.getValue()).to.equal('Mississippi');
-        expect(yield suggestions[2].getAttribute('class')).to.equal('aa-suggestion aa-cursor');
-
-        yield input.type(wd.SPECIAL_KEYS['Up arrow']);
-        expect(yield input.getValue()).to.equal('Minnesota');
-        expect(yield suggestions[1].getAttribute('class')).to.equal('aa-suggestion aa-cursor');
-
-        yield input.type(wd.SPECIAL_KEYS['Up arrow']);
-        expect(yield input.getValue()).to.equal('Michigan');
-        expect(yield suggestions[0].getAttribute('class')).to.equal('aa-suggestion aa-cursor');
-
-        yield input.type(wd.SPECIAL_KEYS['Up arrow']);
-        expect(yield input.getValue()).to.equal('mi');
-        expect(yield suggestions[0].getAttribute('class')).to.equal('aa-suggestion');
-        expect(yield suggestions[1].getAttribute('class')).to.equal('aa-suggestion');
-        expect(yield suggestions[2].getAttribute('class')).to.equal('aa-suggestion');
-        expect(yield suggestions[3].getAttribute('class')).to.equal('aa-suggestion');
-
-        done();
-      });
-    });
-  });
-
-  describe('on down arrow', function() {
-    it('should cycle through suggestions', function(done) {
-      driver.run(function*() {
-        var suggestions;
-
-        yield input.click();
-        yield input.type('mi');
-
-        suggestions = yield dropdown.elementsByClassName('aa-suggestion');
-
-        yield input.type(wd.SPECIAL_KEYS['Down arrow']);
-        expect(yield input.getValue()).to.equal('Michigan');
-        expect(yield suggestions[0].getAttribute('class')).to.equal('aa-suggestion aa-cursor');
-
-        yield input.type(wd.SPECIAL_KEYS['Down arrow']);
-        expect(yield input.getValue()).to.equal('Minnesota');
-        expect(yield suggestions[1].getAttribute('class')).to.equal('aa-suggestion aa-cursor');
-
-        yield input.type(wd.SPECIAL_KEYS['Down arrow']);
-        expect(yield input.getValue()).to.equal('Mississippi');
-        expect(yield suggestions[2].getAttribute('class')).to.equal('aa-suggestion aa-cursor');
-
-        yield input.type(wd.SPECIAL_KEYS['Down arrow']);
-        expect(yield input.getValue()).to.equal('Missouri');
-        expect(yield suggestions[3].getAttribute('class')).to.equal('aa-suggestion aa-cursor');
-
-        yield input.type(wd.SPECIAL_KEYS['Down arrow']);
-        expect(yield input.getValue()).to.equal('mi');
-        expect(yield suggestions[0].getAttribute('class')).to.equal('aa-suggestion');
-        expect(yield suggestions[1].getAttribute('class')).to.equal('aa-suggestion');
-        expect(yield suggestions[2].getAttribute('class')).to.equal('aa-suggestion');
-        expect(yield suggestions[3].getAttribute('class')).to.equal('aa-suggestion');
-
-        done();
-      });
-    });
-  });
-
-  describe('on escape', function() {
-    it('should close dropdown', function(done) {
-      driver.run(function*() {
-        yield input.click();
-        yield input.type('mi');
-        expect(yield dropdown.isDisplayed()).to.equal(true);
-
-        yield input.type(wd.SPECIAL_KEYS['Escape']);
-        expect(yield dropdown.isDisplayed()).to.equal(false);
-
-        done();
+          done();
+        });
       });
     });
 
-    it('should clear hint', function(done) {
-      driver.run(function*() {
-        yield input.click();
-        yield input.type('mi');
-        expect(yield hint.getValue()).to.equal('michigan');
+    describe('on up arrow', function() {
+      it('should cycle through suggestions', function(done) {
+        driver.run(function*() {
+          var suggestions;
 
-        yield input.type(wd.SPECIAL_KEYS['Escape']);
-        expect(yield hint.getValue()).to.equal('');
+          yield input.click();
+          yield input.type('mi');
 
-        done();
+          suggestions = yield dropdown.elementsByClassName('aa-suggestion');
+
+          yield input.type(wd.SPECIAL_KEYS['Up arrow']);
+          expect(yield input.getValue()).to.equal('Missouri');
+          expect(yield suggestions[3].getAttribute('class')).to.equal('aa-suggestion aa-cursor');
+
+          yield input.type(wd.SPECIAL_KEYS['Up arrow']);
+          expect(yield input.getValue()).to.equal('Mississippi');
+          expect(yield suggestions[2].getAttribute('class')).to.equal('aa-suggestion aa-cursor');
+
+          yield input.type(wd.SPECIAL_KEYS['Up arrow']);
+          expect(yield input.getValue()).to.equal('Minnesota');
+          expect(yield suggestions[1].getAttribute('class')).to.equal('aa-suggestion aa-cursor');
+
+          yield input.type(wd.SPECIAL_KEYS['Up arrow']);
+          expect(yield input.getValue()).to.equal('Michigan');
+          expect(yield suggestions[0].getAttribute('class')).to.equal('aa-suggestion aa-cursor');
+
+          yield input.type(wd.SPECIAL_KEYS['Up arrow']);
+          expect(yield input.getValue()).to.equal('mi');
+          expect(yield suggestions[0].getAttribute('class')).to.equal('aa-suggestion');
+          expect(yield suggestions[1].getAttribute('class')).to.equal('aa-suggestion');
+          expect(yield suggestions[2].getAttribute('class')).to.equal('aa-suggestion');
+          expect(yield suggestions[3].getAttribute('class')).to.equal('aa-suggestion');
+
+          done();
+        });
       });
     });
-  });
 
-  describe('on tab', function() {
-    it('should autocomplete if hint is present', function(done) {
-      driver.run(function*() {
-        yield input.click();
-        yield input.type('mi');
+    describe('on down arrow', function() {
+      it('should cycle through suggestions', function(done) {
+        driver.run(function*() {
+          var suggestions;
 
-        yield input.type(wd.SPECIAL_KEYS['Tab']);
-        expect(yield input.getValue()).to.equal('Michigan');
+          yield input.click();
+          yield input.type('mi');
 
-        done();
+          suggestions = yield dropdown.elementsByClassName('aa-suggestion');
+
+          yield input.type(wd.SPECIAL_KEYS['Down arrow']);
+          expect(yield input.getValue()).to.equal('Michigan');
+          expect(yield suggestions[0].getAttribute('class')).to.equal('aa-suggestion aa-cursor');
+
+          yield input.type(wd.SPECIAL_KEYS['Down arrow']);
+          expect(yield input.getValue()).to.equal('Minnesota');
+          expect(yield suggestions[1].getAttribute('class')).to.equal('aa-suggestion aa-cursor');
+
+          yield input.type(wd.SPECIAL_KEYS['Down arrow']);
+          expect(yield input.getValue()).to.equal('Mississippi');
+          expect(yield suggestions[2].getAttribute('class')).to.equal('aa-suggestion aa-cursor');
+
+          yield input.type(wd.SPECIAL_KEYS['Down arrow']);
+          expect(yield input.getValue()).to.equal('Missouri');
+          expect(yield suggestions[3].getAttribute('class')).to.equal('aa-suggestion aa-cursor');
+
+          yield input.type(wd.SPECIAL_KEYS['Down arrow']);
+          expect(yield input.getValue()).to.equal('mi');
+          expect(yield suggestions[0].getAttribute('class')).to.equal('aa-suggestion');
+          expect(yield suggestions[1].getAttribute('class')).to.equal('aa-suggestion');
+          expect(yield suggestions[2].getAttribute('class')).to.equal('aa-suggestion');
+          expect(yield suggestions[3].getAttribute('class')).to.equal('aa-suggestion');
+
+          done();
+        });
       });
     });
 
-    it('should select if cursor is on suggestion', function(done) {
-      driver.run(function*() {
-        var suggestions;
+    describe('on escape', function() {
+      it('should close dropdown', function(done) {
+        driver.run(function*() {
+          yield input.click();
+          yield input.type('mi');
+          expect(yield dropdown.isDisplayed()).to.equal(true);
 
-        yield input.click();
-        yield input.type('mi');
+          yield input.type(wd.SPECIAL_KEYS['Escape']);
+          expect(yield dropdown.isDisplayed()).to.equal(false);
 
-        suggestions = yield dropdown.elementsByClassName('aa-suggestion');
-        yield input.type(wd.SPECIAL_KEYS['Down arrow']);
-        yield input.type(wd.SPECIAL_KEYS['Down arrow']);
-        yield input.type(wd.SPECIAL_KEYS['Tab']);
+          done();
+        });
+      });
 
-        expect(yield dropdown.isDisplayed()).to.equal(false);
-        expect(yield input.getValue()).to.equal('Minnesota');
+      it('should clear hint', function(done) {
+        driver.run(function*() {
+          yield input.click();
+          yield input.type('mi');
+          expect(yield hint.getValue()).to.equal('michigan');
 
-        done();
+          yield input.type(wd.SPECIAL_KEYS['Escape']);
+          expect(yield hint.getValue()).to.equal('');
+
+          done();
+        });
       });
     });
-  });
 
-  describe('on right arrow', function() {
-    it('should autocomplete if hint is present', function(done) {
-      driver.run(function*() {
-        yield input.click();
-        yield input.type('mi');
+    describe('on tab', function() {
+      it('should autocomplete if hint is present', function(done) {
+        driver.run(function*() {
+          yield input.click();
+          yield input.type('mi');
 
-        yield input.type(wd.SPECIAL_KEYS['Right arrow']);
-        expect(yield input.getValue()).to.equal('Michigan');
+          yield input.type(wd.SPECIAL_KEYS['Tab']);
+          expect(yield input.getValue()).to.equal('Michigan');
 
-        done();
+          done();
+        });
+      });
+
+      it('should select if cursor is on suggestion', function(done) {
+        driver.run(function*() {
+          var suggestions;
+
+          yield input.click();
+          yield input.type('mi');
+
+          suggestions = yield dropdown.elementsByClassName('aa-suggestion');
+          yield input.type(wd.SPECIAL_KEYS['Down arrow']);
+          yield input.type(wd.SPECIAL_KEYS['Down arrow']);
+          yield input.type(wd.SPECIAL_KEYS['Tab']);
+
+          expect(yield dropdown.isDisplayed()).to.equal(false);
+          expect(yield input.getValue()).to.equal('Minnesota');
+
+          done();
+        });
       });
     });
-  });
 
-  describe('on suggestion click', function() {
-    it('should select suggestion', function(done) {
-      if (browser[0] === 'firefox') {
-        // crazy Firefox issue, skip it
-        done();
-        return;
-      }
-      driver.run(function*() {
-        var suggestions;
+    describe('on right arrow', function() {
+      it('should autocomplete if hint is present', function(done) {
+        driver.run(function*() {
+          yield input.click();
+          yield input.type('mi');
 
-        yield input.click();
-        yield input.type('mi');
+          yield input.type(wd.SPECIAL_KEYS['Right arrow']);
+          expect(yield input.getValue()).to.equal('Michigan');
 
-        suggestions = yield dropdown.elementsByClassName('aa-suggestion');
-        yield suggestions[1].click();
-
-        expect(yield dropdown.isDisplayed()).to.equal(false);
-        expect(yield input.getValue()).to.equal('Minnesota');
-
-        done();
+          done();
+        });
       });
     });
-  });
 
-  describe('on enter', function() {
-    it('should select if cursor is on suggestion', function(done) {
-      driver.run(function*() {
-        var suggestions;
+    describe('on suggestion click', function() {
+      it('should select suggestion', function(done) {
+        if (browser[0] === 'firefox') {
+          // crazy Firefox issue, skip it
+          done();
+          return;
+        }
+        driver.run(function*() {
+          var suggestions;
 
-        yield input.click();
-        yield input.type('mi');
+          yield input.click();
+          yield input.type('mi');
 
-        suggestions = yield dropdown.elementsByClassName('aa-suggestion');
-        yield input.type(wd.SPECIAL_KEYS['Down arrow']);
-        yield input.type(wd.SPECIAL_KEYS['Down arrow']);
-        yield input.type(wd.SPECIAL_KEYS['Return']);
+          suggestions = yield dropdown.elementsByClassName('aa-suggestion');
+          yield suggestions[1].click();
 
-        expect(yield dropdown.isDisplayed()).to.equal(false);
-        expect(yield input.getValue()).to.equal('Minnesota');
+          expect(yield dropdown.isDisplayed()).to.equal(false);
+          expect(yield input.getValue()).to.equal('Minnesota');
 
-        done();
+          done();
+        });
       });
     });
+
+    describe('on enter', function() {
+      it('should select if cursor is on suggestion', function(done) {
+        driver.run(function*() {
+          var suggestions;
+
+          yield input.click();
+          yield input.type('mi');
+
+          suggestions = yield dropdown.elementsByClassName('aa-suggestion');
+          yield input.type(wd.SPECIAL_KEYS['Down arrow']);
+          yield input.type(wd.SPECIAL_KEYS['Down arrow']);
+          yield input.type(wd.SPECIAL_KEYS['Return']);
+
+          expect(yield dropdown.isDisplayed()).to.equal(false);
+          expect(yield input.getValue()).to.equal('Minnesota');
+
+          done();
+        });
+      });
+    });
+  }
+
+  testSuite();
+  describe('appendTo', function () {
+    before('all', function*() {
+      yield this.execute("buildAutocomplete({hint: false, appendTo: 'body'})");
+    });
+
+    testSuite();
   });
 });

--- a/test/playground.html
+++ b/test/playground.html
@@ -50,7 +50,7 @@
       var actors = client.initIndex('actors');
       var movies = client.initIndex('movies');
 
-      autocomplete('#contacts, #contacts1', { hint: false, templates: { empty: 'empty' }, autoselect: true }, [
+      autocomplete('#contacts, #contacts1', { hint: false, templates: { empty: 'empty' }, autoselect: true, appendTo: 'body' }, [
         {
           source: autocomplete.sources.hits(index, { hitsPerPage: 5 }),
           displayKey: 'name',
@@ -72,6 +72,8 @@
       autocomplete('#contacts2', {
         debug: true,
         keyboardShortcuts: [191, 's'],
+        hint: false,
+        appendTo: 'h4',
         templates: {
           empty: function(data) {
             return 'No results for "<strong>' + data.query.replace(/[^-_'a-zA-Z0-9 ]/, ' ') + '</strong>"';

--- a/test/playground_angular.html
+++ b/test/playground_angular.html
@@ -12,7 +12,7 @@
             <div class="col-sm-4">
               <h4>Simple auto-complete</h4>
               <div class="input-group">
-                <input id="contacts" name="contacts" class="form-control" type="text" ng-model="q" autocomplete aa-datasets="getDatasets()" />
+                <input id="contacts" name="contacts" class="form-control" type="text" ng-model="q" autocomplete aa-datasets="getDatasets()" aa-options="{ appendTo: 'body', debug: true, hint: false }" />
                 <span class="input-group-addon">Go</span>
               </div>
             </div>

--- a/test/playground_jquery.html
+++ b/test/playground_jquery.html
@@ -98,6 +98,8 @@
 
       $('#contacts2').autocomplete({
         debug: true,
+        hint: false,
+        appendTo: 'body',
         templates: {
           dropdownMenu: '#my-custom-menu-template',
           footer: '<div class="aa-dropdown-footer">Search by<img class="aa-logo" src="https://www.algolia.com/assets/algolia128x40.png" width=80/></div>'

--- a/test/unit/dropdown_spec.js
+++ b/test/unit/dropdown_spec.js
@@ -252,6 +252,20 @@ describe('Dropdown', function() {
 
       expect(spy).toHaveBeenCalled();
     });
+
+
+    it('should trigger redrawn', function() {
+      var spy;
+
+      this.view.onSync('redrawn', spy = jasmine.createSpy());
+
+      this.view.close();
+      this.view.isEmpty = false;
+      this.view.appendTo = 'body';
+      this.view.open();
+
+      expect(spy).toHaveBeenCalled();
+    });
   });
 
   describe('#close', function() {

--- a/test/unit/typeahead_spec.js
+++ b/test/unit/typeahead_spec.js
@@ -40,6 +40,20 @@ describe('Typeahead', function() {
     this.dropdown = this.view.dropdown;
   });
 
+
+  describe('appendTo', function() {
+    it('should throw if used with hint', function(done) {
+      expect(function() {
+        return new Typeahead({
+          input: this.$input,
+          hint: true,
+          appendTo: 'body'
+        });
+      }).toThrow();
+      done();
+    });
+  });
+
   describe('when dropdown triggers suggestionClicked', function() {
     beforeEach(function() {
       this.dropdown.getDatumForSuggestion.and.returnValue(testDatum);

--- a/test/unit/typeahead_spec.js
+++ b/test/unit/typeahead_spec.js
@@ -209,6 +209,16 @@ describe('Typeahead', function() {
 
       expect(spy).toHaveBeenCalled();
     });
+
+    it('should trigger autocomplete:redrawn', function() {
+      var spy;
+
+      this.$input.on('autocomplete:redrawn', spy = jasmine.createSpy());
+
+      this.dropdown.trigger('redrawn');
+
+      expect(spy).toHaveBeenCalled();
+    });
   });
 
   describe('when dropdown triggers closed', function() {

--- a/test/unit/typeahead_spec.js
+++ b/test/unit/typeahead_spec.js
@@ -52,6 +52,28 @@ describe('Typeahead', function() {
       }).toThrow();
       done();
     });
+
+    it('should be appended to the target of appendTo', function(done) {
+      var node = document.createElement('div');
+      document.querySelector('body').appendChild(node);
+
+      expect(node.children.length).toEqual(0);
+
+      this.view.destroy();
+
+      this.view = new Typeahead({
+        input: this.$input,
+        hint: false,
+        appendTo: node
+      });
+
+      expect(document.querySelectorAll('.algolia-autocomplete').length).toEqual(1);
+      expect(node.children.length).toEqual(1);
+
+      this.view.destroy();
+
+      done();
+    });
   });
 
   describe('when dropdown triggers suggestionClicked', function() {


### PR DESCRIPTION
**Summary**

See #135
New parameter: `appendToBody`.
Allows to not wrap the input in `.algolia-autocomplete`.

Automatically repositions itself on resize.
Limitation: requires `hint: false`. Indeed, we're not wrapping the input anymore, so we can't have it behind the input.

**Result**
Without much surprise, it looks the same way:
![Autocomplete with appendToBody](https://cloud.githubusercontent.com/assets/5095856/21457054/98380df8-c92c-11e6-8171-8c5a25f28565.png)

However, on the playground, it ends up "breaking" the example in `playground.html`.
But this is actually expected based on the bootstrap layout we're using, it's supposed to fail.

```html
<div class="input-group">
  <input class="form-control" />
  <input class="form-control" />
  <span class="input-group-addon">Go</span>
</div>
```

![image](https://cloud.githubusercontent.com/assets/5095856/21457188/80e91df8-c92d-11e6-8c44-bbb9a6103a49.png)
