### PR TITLE
fix(angular): do not launch the directive if autocomplete has a value

### DIFF
--- a/src/angular/directive.js
+++ b/src/angular/directive.js
@@ -36,6 +36,7 @@ angular.module('algolia.autocomplete', [])
         datasets: '&aaDatasets'
       },
       link: function(scope, element, attrs) {
+        if (!element.hasClass('autocomplete') && attrs.autocomplete !== '') return;
         attrs = attrs; // no-unused-vars
         scope.options = $parse(scope.options)(scope);
         if (!scope.options) {


### PR DESCRIPTION
Closes #136

**Summary**

As described in #136 , we're bugging out the behavior of the HTML `autocomplete` attribute.
You can't use `autocomplete="off"` in the current setup, this PR fixes it.

**Result**

Checked in `test/playground_angular.html`.
Attribute mode:
- `autocomplete` =>  our autocomplete triggers
- `autocomplete=""` => our autocomplete triggers
- `autocomplete="off"` => our autocomplete *doesn't* trigger and it correctly prevents the browser from autocompleting
- `data-autocomplete` => our autocomplete triggers

I've also checked that the class mode of the directive still works.