### PR TITLE
fix(postMessage): avoid using postMessage when feasible

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "grunt-step": "^1.0.0",
     "grunt-umd": "^2.3.6",
     "grunt-webpack": "^1.0.14",
+    "immediate": "^3.2.3",
     "istanbul-instrumenter-loader": "^1.0.0",
     "jasmine-core": "^2.5.2",
     "jasmine-jquery": "^2.1.1",

--- a/src/autocomplete/event_emitter.js
+++ b/src/autocomplete/event_emitter.js
@@ -1,7 +1,7 @@
 'use strict';
 
+var immediate = require('immediate');
 var splitter = /\s+/;
-var nextTick = getNextTick();
 
 module.exports = {
   onSync: onSync,
@@ -73,7 +73,7 @@ function trigger(types) {
     asyncFlush = getFlush(callbacks.async, this, [type].concat(args));
 
     if (syncFlush()) {
-      nextTick(asyncFlush);
+      immediate(asyncFlush);
     }
   }
 
@@ -93,22 +93,6 @@ function getFlush(callbacks, context, args) {
 
     return !cancelled;
   }
-}
-
-function getNextTick() {
-  var nextTickFn;
-
-  if (window.setImmediate) { // IE10+
-    nextTickFn = function nextTickSetImmediate(fn) {
-      setImmediate(function() { fn(); });
-    };
-  } else { // old browsers
-    nextTickFn = function nextTickSetTimeout(fn) {
-      setTimeout(function() { fn(); }, 0);
-    };
-  }
-
-  return nextTickFn;
 }
 
 function bindContext(fn, context) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2527,6 +2527,10 @@ ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
+immediate@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
+
 indent-string@^2.0.0, indent-string@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
@@ -3573,7 +3577,7 @@ minimist@0.0.8, minimist@~0.0.1, minimist@~0.0.7:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@1.2.0, minimist@^1.1.3, minimist@^1.2.0:
+minimist@1.2.0, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -3581,7 +3585,7 @@ minimist@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.2.0.tgz#4dffe525dae2b864c66c2e23c6271d7afdecefce"
 
-minimist@~1.1.0:
+minimist@^1.1.3, minimist@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
 


### PR DESCRIPTION
Before this commit, we were using setImmediate which was then
polyfilled by webpack in a way that is not efficient
and led to issues like #142 where postMessage was used
no matter what.

Now we use the `immediate` dependency which will first try
to use nextTick, then mutation observers (IE11) then fallback
to postMessage but in a way that should not bug any user
registering for global messages.

fixes #142