### PR TITLE
feat(a11y): Add support for screen readers

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,7 +62,6 @@ module.exports = function(grunt) {
         externals: ['angular']
       },
       standalone: {
-        devtool: 'source-map',
         entry: './index.js',
         output: {
           path: '<%= buildDir %>',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,6 +62,7 @@ module.exports = function(grunt) {
         externals: ['angular']
       },
       standalone: {
+        devtool: 'source-map',
         entry: './index.js',
         output: {
           path: '<%= buildDir %>',

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This JavaScript library adds a fast and fully-featured auto-completion menu to y
   - [Standalone](#standalone-1)
 - [Development](#development)
 - [Tests](#tests)
+  - [Testing accessibility](#testing-accessibility)
 - [Release](#release)
 - [Credits](#credits)
 
@@ -676,6 +677,33 @@ yarn server
 ngrok 8888
 TEST_HOST=http://YOUR_NGROK_ID.ngrok.com SAUCE_ACCESS_KEY=YOUR_KEY SAUCE_USERNAME=YOUR_USERNAME./node_modules/mocha/bin/mocha --harmony -R spec ./test/integration/test.js
 ```
+
+### Testing accessibility
+
+Autocomplete.js is accessible to screen readers, and here's how to test how most blind users will experience it:
+
+#### Steps
+
+1. Run `yarn dev` on your development machine
+1. Start the screen reader
+1. Open a browser to http://YOUR_IP:8888/test/playground.html
+1. Tab to the field
+1. Type a search query
+1. Use the arrow keys to navigate through the results
+
+✔ SUCCESS: results are read (not necessarily in sync with the visually selected cursor)  
+𐄂 FAIL: no text is read or the screen reader keeps reading the typed query
+
+#### Recommended testing platforms
+
+- VoiceOver (CMD+F5 in macOS): Safari, Chrome
+- [JAWS](http://www.freedomscientific.com/Products/Blindness/JAWS): IE11, Chrome (Windows 7 VM available at [modern.ie](https://modern.ie))
+- [NVDA](http://www.nvaccess.org/): IE11, Chrome (Windows 8.1 VM available at [modern.ie](https://modern.ie))
+
+#### Tips
+
+- All screen readers work slightly differently - which makes making accessible pages tricky.
+- Don't worry if the usability isn't 100% perfect, but make sure the functionality is there.
 
 ## Release
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ var autocomplete = require('autocomplete.js');
  1. Initialize the auto-completion menu calling the `autocomplete` function
 
 ```html
-<input type="text" id="search-input" />
+<input type="text" id="search-input" placeholder="Search unicorns..." />
 
 <!-- [ ... ] -->
 <script src="https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js"></script>

--- a/src/autocomplete/dataset.js
+++ b/src/autocomplete/dataset.js
@@ -147,7 +147,10 @@ _.mixin(Dataset.prototype, EventEmitter, {
           replace('%PREFIX%', self.cssClasses.prefix).
           replace('%SUGGESTION%', self.cssClasses.suggestion);
         $el = DOM.element(suggestionHtml)
-          .attr('role', 'option')
+          .attr({
+            'role': 'option',
+            'id': ['option', Math.floor(Math.random() * 100000000)].join('-')
+          })
           .append(that.templates.suggestion.apply(this, [suggestion].concat(args)));
 
         $el.data(datasetKey, that.name);

--- a/src/autocomplete/dataset.js
+++ b/src/autocomplete/dataset.js
@@ -127,7 +127,11 @@ _.mixin(Dataset.prototype, EventEmitter, {
       var suggestionsHtml = html.suggestions.
         replace('%PREFIX%', this.cssClasses.prefix).
         replace('%SUGGESTIONS%', this.cssClasses.suggestions);
-      $suggestions = DOM.element(suggestionsHtml).css(this.css.suggestions);
+      $suggestions = DOM
+        .element(suggestionsHtml)
+        .css(this.css.suggestions)
+        .attr('role', 'group')
+        .attr('aria-label', this.name);
 
       // jQuery#append doesn't support arrays as the first argument
       // until version 1.8, see http://bugs.jquery.com/ticket/11231
@@ -143,6 +147,7 @@ _.mixin(Dataset.prototype, EventEmitter, {
           replace('%PREFIX%', self.cssClasses.prefix).
           replace('%SUGGESTION%', self.cssClasses.suggestion);
         $el = DOM.element(suggestionHtml)
+          .attr('role', 'option')
           .append(that.templates.suggestion.apply(this, [suggestion].concat(args)));
 
         $el.data(datasetKey, that.name);

--- a/src/autocomplete/dataset.js
+++ b/src/autocomplete/dataset.js
@@ -130,8 +130,10 @@ _.mixin(Dataset.prototype, EventEmitter, {
       $suggestions = DOM
         .element(suggestionsHtml)
         .css(this.css.suggestions)
-        .attr('role', 'group')
-        .attr('aria-label', this.name);
+        .attr({
+          role: 'group',
+          'aria-label': this.name
+        });
 
       // jQuery#append doesn't support arrays as the first argument
       // until version 1.8, see http://bugs.jquery.com/ticket/11231
@@ -148,8 +150,8 @@ _.mixin(Dataset.prototype, EventEmitter, {
           replace('%SUGGESTION%', self.cssClasses.suggestion);
         $el = DOM.element(suggestionHtml)
           .attr({
-            'role': 'option',
-            'id': ['option', Math.floor(Math.random() * 100000000)].join('-')
+            role: 'option',
+            id: ['option', Math.floor(Math.random() * 100000000)].join('-')
           })
           .append(that.templates.suggestion.apply(this, [suggestion].concat(args)));
 

--- a/src/autocomplete/dataset.js
+++ b/src/autocomplete/dataset.js
@@ -140,11 +140,7 @@ _.mixin(Dataset.prototype, EventEmitter, {
         replace('%SUGGESTIONS%', this.cssClasses.suggestions);
       $suggestions = DOM
         .element(suggestionsHtml)
-        .css(this.css.suggestions)
-        .attr({
-          role: 'group',
-          'aria-label': this.name
-        });
+        .css(this.css.suggestions);
 
       // jQuery#append doesn't support arrays as the first argument
       // until version 1.8, see http://bugs.jquery.com/ticket/11231

--- a/src/autocomplete/dataset.js
+++ b/src/autocomplete/dataset.js
@@ -106,8 +106,19 @@ _.mixin(Dataset.prototype, EventEmitter, {
     }
 
     if (this.$menu) {
-      this.$menu.addClass(this.cssClasses.prefix + '-' + (hasSuggestions ? 'with' : 'without') + '-' + this.name)
-        .removeClass(this.cssClasses.prefix + '-' + (hasSuggestions ? 'without' : 'with') + '-' + this.name);
+      this.$menu.addClass(
+        [
+          this.cssClasses.prefix,
+          (hasSuggestions ? 'with' : 'without'),
+          this.name
+        ].join('-')
+      ).removeClass(
+        [
+          this.cssClasses.prefix,
+          (hasSuggestions ? 'without' : 'with'),
+          this.name
+        ].join('-')
+      );
     }
 
     this.trigger('rendered', query);

--- a/src/autocomplete/dropdown.js
+++ b/src/autocomplete/dropdown.js
@@ -199,12 +199,16 @@ _.mixin(Dropdown.prototype, EventEmitter, {
   },
 
   _setCursor: function setCursor($el, updateInput) {
-    $el.first().addClass(_.className(this.cssClasses.prefix, this.cssClasses.cursor, true));
+    $el.first()
+      .addClass(_.className(this.cssClasses.prefix, this.cssClasses.cursor, true))
+      .attr('aria-selected', 'true');
     this.trigger('cursorMoved', updateInput);
   },
 
   _removeCursor: function removeCursor() {
-    this._getCursor().removeClass(_.className(this.cssClasses.prefix, this.cssClasses.cursor, true));
+    this._getCursor()
+      .removeClass(_.className(this.cssClasses.prefix, this.cssClasses.cursor, true))
+      .removeAttr('aria-selected');
   },
 
   _moveCursor: function moveCursor(increment) {

--- a/src/autocomplete/dropdown.js
+++ b/src/autocomplete/dropdown.js
@@ -318,6 +318,10 @@ _.mixin(Dropdown.prototype, EventEmitter, {
     return datum;
   },
 
+  getCurrentCursor: function getCurrentCursor() {
+    return this._getCursor().first();
+  },
+
   getDatumForCursor: function getDatumForCursor() {
     return this.getDatumForSuggestion(this._getCursor().first());
   },

--- a/src/autocomplete/input.js
+++ b/src/autocomplete/input.js
@@ -92,6 +92,7 @@ _.mixin(Input.prototype, EventEmitter, {
 
   _onBlur: function onBlur() {
     this.resetInputValue();
+    this.$input.removeAttr('aria-activedescendant');
     this.trigger('blurred');
   },
 
@@ -210,6 +211,14 @@ _.mixin(Input.prototype, EventEmitter, {
     } else {
       this._checkInputValue();
     }
+  },
+
+  setActiveDescendant: function setActiveDescendant(activedescendantId) {
+    this.$input.attr('aria-activedescendant', activedescendantId);
+  },
+
+  removeActiveDescendant: function removeActiveDescendant() {
+    this.$input.removeAttr('aria-activedescendant');
   },
 
   resetInputValue: function resetInputValue() {

--- a/src/autocomplete/input.js
+++ b/src/autocomplete/input.js
@@ -213,6 +213,14 @@ _.mixin(Input.prototype, EventEmitter, {
     }
   },
 
+  expand: function expand() {
+    this.$input.attr('aria-expanded', 'true');
+  },
+
+  collapse: function collapse() {
+    this.$input.attr('aria-expanded', 'false');
+  },
+
   setActiveDescendant: function setActiveDescendant(activedescendantId) {
     this.$input.attr('aria-activedescendant', activedescendantId);
   },

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -546,9 +546,9 @@ function buildDom(options) {
       'aria-autocomplete': (options.datasets[0].displayKey ? 'both' : 'list'),
       // Indicates whether the dropdown it controls is currently expanded or collapsed
       'aria-expanded': 'false',
-      // Note that this field is labelled by itself, which in this case,
+      // If a placeholder is set, label this field with itself, which in this case,
       // is an explicit pointer to use the placeholder attribute value.
-      'aria-labelledby': $input.attr('id'),
+      'aria-labelledby': ($input.attr('placeholder') ? $input.attr('id') : null),
       // Explicitly point to the listbox,
       // which is a list of suggestions (aka options)
       'aria-owns': options.listboxId

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -544,6 +544,7 @@ function buildDom(options) {
       // Let the screen reader know the field has an autocomplete
       // feature to it.
       'aria-autocomplete': 'inline',
+      // Indicates whether the dropdown it controls is currently expanded or collapsed
       'aria-expanded': 'false',
       // Explicitly point to the listbox,
       // which is a list of suggestions (aka options)

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -546,6 +546,9 @@ function buildDom(options) {
       'aria-autocomplete': 'inline',
       // Indicates whether the dropdown it controls is currently expanded or collapsed
       'aria-expanded': 'false',
+      // Note that this field is labelled by itself, which in this case,
+      // is an explicit pointer to use the placeholder attribute value.
+      'aria-labelledby': $input.attr('id'),
       // Explicitly point to the listbox,
       // which is a list of suggestions (aka options)
       'aria-owns': options.listboxId

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -185,6 +185,7 @@ _.mixin(Typeahead.prototype, {
 
   _onOpened: function onOpened() {
     this._updateHint();
+    this.input.expand();
 
     this.eventBus.trigger('opened');
   },
@@ -220,6 +221,7 @@ _.mixin(Typeahead.prototype, {
   _onClosed: function onClosed() {
     this.input.clearHint();
     this.input.removeActiveDescendant();
+    this.input.collapse();
 
     this.eventBus.trigger('closed');
   },

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -514,8 +514,9 @@ function buildDom(options) {
   // store the original values of the attrs that get modified
   // so modifications can be reverted on destroy
   $input.data(attrsKey, {
+    'aria-autocomplete': $input.attr('aria-autocomplete'),
     'aria-expanded': $input.attr('aria-expanded'),
-    'aria-owns': $input.attr('aria-owns'),
+    'aria-controls': $input.attr('aria-controls'),
     autocomplete: $input.attr('autocomplete'),
     dir: $input.attr('dir'),
     role: $input.attr('role'),
@@ -533,8 +534,9 @@ function buildDom(options) {
       // Accessibility features
       type: 'search',
       role: 'combobox',
+      'aria-autocomplete': 'list',
       'aria-expanded': 'false',
-      'aria-owns': listBoxId
+      'aria-controls': listBoxId
     })
     .css(options.hint ? options.css.input : options.css.inputWithNoHint);
 

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -536,7 +536,6 @@ function buildDom(options) {
       spellcheck: false,
 
       // Accessibility features
-      type: 'search',
       role: 'combobox',
       'aria-autocomplete': 'list',
       'aria-expanded': 'false',

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -510,7 +510,12 @@ function buildDom(options) {
     .addClass(_.className(options.cssClasses.prefix, options.cssClasses.hint, true))
     .removeAttr('id name placeholder required')
     .prop('readonly', true)
-    .attr({autocomplete: 'off', spellcheck: 'false', tabindex: -1});
+    .attr({
+      'aria-hidden': 'true',
+      autocomplete: 'off',
+      spellcheck: 'false',
+      tabindex: -1
+    });
   if ($hint.removeData) {
     $hint.removeData();
   }

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -543,7 +543,7 @@ function buildDom(options) {
       role: 'combobox',
       // Let the screen reader know the field has an autocomplete
       // feature to it.
-      'aria-autocomplete': (options.datasets[0].displayKey ? 'both' : 'list'),
+      'aria-autocomplete': (options.datasets && options.datasets[0] && options.datasets[0].displayKey ? 'both' : 'list'),
       // Indicates whether the dropdown it controls is currently expanded or collapsed
       'aria-expanded': 'false',
       // If a placeholder is set, label this field with itself, which in this case,

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -536,6 +536,10 @@ function buildDom(options) {
       spellcheck: false,
 
       // Accessibility features
+      // Give the field a presentation of a "select".
+      // Combobox is the combined presentation of a single line textfield
+      // with a listbox popup.
+      // https://www.w3.org/WAI/PF/aria/roles#combobox
       role: 'combobox',
       'aria-autocomplete': 'list',
       'aria-expanded': 'false',

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -158,6 +158,8 @@ _.mixin(Typeahead.prototype, {
 
   _onCursorMoved: function onCursorMoved(event, updateInput) {
     var datum = this.dropdown.getDatumForCursor();
+    var currentCursorId = this.dropdown.getCurrentCursor().attr('id');
+    this.input.setActiveDescendant(currentCursorId);
 
     if (datum) {
       if (updateInput) {
@@ -216,6 +218,7 @@ _.mixin(Typeahead.prototype, {
 
   _onClosed: function onClosed() {
     this.input.clearHint();
+    this.input.removeActiveDescendant();
 
     this.eventBus.trigger('closed');
   },
@@ -473,13 +476,16 @@ function buildDom(options) {
   var $wrapper;
   var $dropdown;
   var $hint;
-  var listBoxId = [options.cssClasses.root, _.getUniqueId()].join('-');
+  var listBoxId = [options.cssClasses.root, 'listbox', _.getUniqueId()].join('-');
 
   $input = DOM.element(options.input);
   $wrapper = DOM
     .element(html.wrapper.replace('%ROOT%', options.cssClasses.root))
     .css(options.css.wrapper)
-    .attr('id', listBoxId);
+    .attr({
+      id: listBoxId,
+      role: 'listbox'
+    });
   // override the display property with the table-cell value
   // if the parent element is a table and the original input was a block
   //  -> https://github.com/algolia/autocomplete.js/issues/16

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -543,7 +543,7 @@ function buildDom(options) {
       role: 'combobox',
       // Let the screen reader know the field has an autocomplete
       // feature to it.
-      'aria-autocomplete': 'inline',
+      'aria-autocomplete': (options.datasets[0].displayKey ? 'both' : 'list'),
       // Indicates whether the dropdown it controls is currently expanded or collapsed
       'aria-expanded': 'false',
       // Note that this field is labelled by itself, which in this case,

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -541,7 +541,9 @@ function buildDom(options) {
       // with a listbox popup.
       // https://www.w3.org/WAI/PF/aria/roles#combobox
       role: 'combobox',
-      'aria-autocomplete': 'list',
+      // Let the screen reader know the field has an autocomplete
+      // feature to it.
+      'aria-autocomplete': 'inline',
       'aria-expanded': 'false',
       // Explicitly point to the listbox,
       // which is a list of suggestions (aka options)

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -39,6 +39,7 @@ function Typeahead(o) {
 
   this.css = o.css = _.mixin({}, css, o.appendTo ? css.appendTo : {});
   this.cssClasses = o.cssClasses = _.mixin({}, css.defaultClasses, o.cssClasses || {});
+  this.listboxId = o.listboxId = [this.cssClasses.root, 'listbox', _.getUniqueId()].join('-');
 
   var domElts = buildDom(o);
 
@@ -476,16 +477,12 @@ function buildDom(options) {
   var $wrapper;
   var $dropdown;
   var $hint;
-  var listBoxId = [options.cssClasses.root, 'listbox', _.getUniqueId()].join('-');
 
   $input = DOM.element(options.input);
   $wrapper = DOM
     .element(html.wrapper.replace('%ROOT%', options.cssClasses.root))
-    .css(options.css.wrapper)
-    .attr({
-      id: listBoxId,
-      role: 'listbox'
-    });
+    .css(options.css.wrapper);
+
   // override the display property with the table-cell value
   // if the parent element is a table and the original input was a block
   //  -> https://github.com/algolia/autocomplete.js/issues/16
@@ -495,7 +492,12 @@ function buildDom(options) {
   var dropdownHtml = html.dropdown.
     replace('%PREFIX%', options.cssClasses.prefix).
     replace('%DROPDOWN_MENU%', options.cssClasses.dropdownMenu);
-  $dropdown = DOM.element(dropdownHtml).css(options.css.dropdown);
+  $dropdown = DOM.element(dropdownHtml)
+    .css(options.css.dropdown)
+    .attr({
+      role: 'listbox',
+      id: options.listboxId
+    });
   if (options.templates && options.templates.dropdownMenu) {
     $dropdown.html(_.templatify(options.templates.dropdownMenu)());
   }

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -473,9 +473,13 @@ function buildDom(options) {
   var $wrapper;
   var $dropdown;
   var $hint;
+  var listBoxId = [options.cssClasses.root, _.getUniqueId()].join('-');
 
   $input = DOM.element(options.input);
-  $wrapper = DOM.element(html.wrapper.replace('%ROOT%', options.cssClasses.root)).css(options.css.wrapper);
+  $wrapper = DOM
+    .element(html.wrapper.replace('%ROOT%', options.cssClasses.root))
+    .css(options.css.wrapper)
+    .attr('id', listBoxId);
   // override the display property with the table-cell value
   // if the parent element is a table and the original input was a block
   //  -> https://github.com/algolia/autocomplete.js/issues/16
@@ -504,15 +508,28 @@ function buildDom(options) {
   // store the original values of the attrs that get modified
   // so modifications can be reverted on destroy
   $input.data(attrsKey, {
-    dir: $input.attr('dir'),
+    'aria-expanded': $input.attr('aria-expanded'),
+    'aria-owns': $input.attr('aria-owns'),
     autocomplete: $input.attr('autocomplete'),
+    dir: $input.attr('dir'),
+    role: $input.attr('role'),
     spellcheck: $input.attr('spellcheck'),
-    style: $input.attr('style')
+    style: $input.attr('style'),
+    type: $input.attr('type')
   });
 
   $input
     .addClass(_.className(options.cssClasses.prefix, options.cssClasses.input, true))
-    .attr({autocomplete: 'off', spellcheck: false})
+    .attr({
+      autocomplete: 'off',
+      spellcheck: false,
+
+      // Accessibility features
+      type: 'search',
+      role: 'combobox',
+      'aria-expanded': 'false',
+      'aria-owns': listBoxId
+    })
     .css(options.hint ? options.css.input : options.css.inputWithNoHint);
 
   // ie7 does not like it when dir is set to auto

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -520,7 +520,7 @@ function buildDom(options) {
   $input.data(attrsKey, {
     'aria-autocomplete': $input.attr('aria-autocomplete'),
     'aria-expanded': $input.attr('aria-expanded'),
-    'aria-controls': $input.attr('aria-controls'),
+    'aria-owns': $input.attr('aria-owns'),
     autocomplete: $input.attr('autocomplete'),
     dir: $input.attr('dir'),
     role: $input.attr('role'),
@@ -540,7 +540,9 @@ function buildDom(options) {
       role: 'combobox',
       'aria-autocomplete': 'list',
       'aria-expanded': 'false',
-      'aria-controls': listBoxId
+      // Explicitly point to the listbox,
+      // which is a list of suggestions (aka options)
+      'aria-owns': options.listboxId
     })
     .css(options.hint ? options.css.input : options.css.inputWithNoHint);
 

--- a/src/standalone/index.js
+++ b/src/standalone/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var zepto = require('../../zepto.js'); // this will inject Zepto in window, unfortunately no easy commonJS zepto build
+// this will inject Zepto in window, unfortunately no easy commonJS zepto build
+var zepto = require('../../zepto.js');
 
 // setup DOM element
 var DOM = require('../common/dom.js');

--- a/test/playground.html
+++ b/test/playground.html
@@ -13,7 +13,7 @@
               <h4>Simple auto-complete</h4>
               <div class="input-group">
                 <input id="contacts" name="contacts" class="form-control" type="text">
-                <input id="contacts" name="contacts1" class="form-control" type="text">
+                <input id="contacts1" name="contacts1" class="form-control" type="text">
                 <span class="input-group-addon">Go</span>
               </div>
             </div>

--- a/test/playground.html
+++ b/test/playground.html
@@ -20,7 +20,7 @@
             <div class="col-sm-4">
               <h4>Multi-sections auto-complete</h4>
               <div class="input-group">
-                <input id="contacts2" name="contacts2" class="form-control" type="text">
+                <input id="contacts2" name="contacts2" class="form-control" type="text" placeholder="Search actors in movie types">
                 <span class="input-group-addon">Go</span>
               </div>
             </div>

--- a/test/playground.html
+++ b/test/playground.html
@@ -81,8 +81,17 @@
         }
       }, [
         {
-          source: autocomplete.sources.popularIn(actors, {hitsPerPage: 3}, {index: movies, source: 'name', facets: 'genre', maxValuesPerFacet: 3}),
-          name: '',
+          source: autocomplete.sources.popularIn(
+            actors,
+            { hitsPerPage: 3 },
+            {
+              index: movies,
+              source: 'name',
+              facets: 'genre',
+              maxValuesPerFacet: 3
+            }
+          ),
+          name: 'Actors',
           templates: {
             header: '<span class="aa-category-title">Actors</span>',
             suggestion: function(suggestion) {

--- a/test/playground.html
+++ b/test/playground.html
@@ -50,7 +50,7 @@
       var actors = client.initIndex('actors');
       var movies = client.initIndex('movies');
 
-      autocomplete('#contacts, #contacts1', { hint: false, templates: { empty: 'empty' }, autoselect: true, appendTo: 'body' }, [
+      autocomplete('#contacts, #contacts1', { debug: true, hint: false, templates: { empty: 'empty' }, autoselect: true, appendTo: 'body' }, [
         {
           source: autocomplete.sources.hits(index, { hitsPerPage: 5 }),
           displayKey: 'name',

--- a/test/playground.html
+++ b/test/playground.html
@@ -91,7 +91,6 @@
               maxValuesPerFacet: 3
             }
           ),
-          name: 'Actors',
           templates: {
             header: '<span class="aa-category-title">Actors</span>',
             suggestion: function(suggestion) {

--- a/test/unit/input_spec.js
+++ b/test/unit/input_spec.js
@@ -302,6 +302,22 @@ describe('Input', function() {
     });
   });
 
+  describe('#setActiveDescendant', function() {
+    it('should set the aria-activedescendant attribute', function() {
+      this.view.setActiveDescendant('abc');
+      expect(this.$input.attr('aria-activedescendant')).toBe('abc');
+    });
+  });
+
+  describe('#removeActiveDescendant', function() {
+    it('should remove the aria-activedescendant attribute', function() {
+      this.view.setActiveDescendant('foo');
+      expect(this.$input.attr('aria-activedescendant')).toBe('foo');
+      this.view.removeActiveDescendant('bar');
+      expect(this.$input.attr('aria-activedescendant')).toBeUndefined();
+    });
+  });
+
   describe('#getHint/#setHint', function() {
     it('should act as getter/setter to value of hint', function() {
       this.view.setHint('mountain');

--- a/test/unit/typeahead_spec.js
+++ b/test/unit/typeahead_spec.js
@@ -248,6 +248,11 @@ describe('Typeahead', function() {
 
       expect(spy).toHaveBeenCalled();
     });
+
+    it('should set the input\'s aria-expanded to true', function() {
+      this.dropdown.trigger('opened');
+      expect(this.input.expand).toHaveBeenCalled();
+    });
   });
 
   describe('when dropdown triggers closed', function() {
@@ -265,6 +270,11 @@ describe('Typeahead', function() {
       this.dropdown.trigger('closed');
 
       expect(spy).toHaveBeenCalled();
+    });
+
+    it('should set the input\'s aria-expanded to false', function() {
+      this.dropdown.trigger('closed');
+      expect(this.input.collapse).toHaveBeenCalled();
     });
   });
 

--- a/test/unit/typeahead_spec.js
+++ b/test/unit/typeahead_spec.js
@@ -40,7 +40,6 @@ describe('Typeahead', function() {
     this.dropdown = this.view.dropdown;
   });
 
-
   describe('appendTo', function() {
     it('should throw if used with hint', function(done) {
       expect(function() {
@@ -121,6 +120,7 @@ describe('Typeahead', function() {
   describe('when dropdown triggers cursorMoved', function() {
     beforeEach(function() {
       this.dropdown.getDatumForCursor.and.returnValue(testDatum);
+      this.dropdown.getCurrentCursor.and.returnValue($('<div id="option-id"></div>'));
     });
 
     it('should update the input value', function() {
@@ -128,6 +128,13 @@ describe('Typeahead', function() {
 
       expect(this.input.setInputValue)
         .toHaveBeenCalledWith(testDatum.value, true);
+    });
+
+    it('should update the active descendant', function() {
+      this.dropdown.trigger('cursorMoved', false);
+
+      expect(this.input.setActiveDescendant)
+        .toHaveBeenCalledWith('option-id');
     });
 
     it('should not update the input', function() {


### PR DESCRIPTION
### Accessibility - fixes #78

- Tested with good results in both NVDA and JAWS.
- VoiceOver has mixed support for these complex controls:
    - The normal autocomplete works well,
    - The multi sections auto complete won't work (the one in DocSearch)

Demo: http://autocompletejs-a11y.surge.sh/test/playground.html

### Other

- Added a temporary fix for #144 (more tests necessary)
- Generated sourcemaps in the standalone build for easier debugging
- Fixed two linting warnings in cc4a403
- Fixed an input ID in the playground (9b3aac9)

### To discuss

- Where should we add tests for the correct behavior/a11y features? Integration tests seem to be the best place but I wasn't sure about it.
- Commit history: let me know if my PR should be broken into multiple ones