### PR TITLE
Fix playground html dist path

### DIFF
--- a/test/playground.html
+++ b/test/playground.html
@@ -29,7 +29,7 @@
       </form>
     </div>
 
-    <script src="../../dist/autocomplete.js"></script>
+    <script src="../dist/autocomplete.js"></script>
     <script src="https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js"></script>
     <script type="text/template" id="my-custom-menu-template">
       <div class="my-custom-menu">


### PR DESCRIPTION
### Problem

When i'm trying to run an interface test i stopped with an exception in console saying that `autocomplete is not defined` so i see that the distribution autocomplete path are wrong.

### What i've done

- Point to correct distribution path.



