### PR TITLE
Fix redrawn position

### DIFF
--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -198,14 +198,14 @@ _.mixin(Typeahead.prototype, {
   },
 
   _onRedrawn: function onRedrawn() {
+    this.$node.css('top', 0 + 'px');
+    this.$node.css('left', 0 + 'px');
+
     var inputRect = this.$input[0].getBoundingClientRect();
 
     if (this.autoWidth) {
       this.$node.css('width', inputRect.width + 'px');
     }
-
-    this.$node.css('top', 0 + 'px');
-    this.$node.css('left', 0 + 'px');
 
     var wrapperRect = this.$node[0].getBoundingClientRect();
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
My case:

<img width="975" alt="captura de tela 2017-03-13 as 17 50 52" src="https://cloud.githubusercontent.com/assets/5859119/23874784/a4797cdc-0815-11e7-8cd7-f3f79be6cd7a.png">

And i have a `Show more button`:

<img width="963" alt="captura de tela 2017-03-13 as 17 51 39" src="https://cloud.githubusercontent.com/assets/5859119/23874804/bbc1cfac-0815-11e7-993d-cc30073638ab.png">

The problem:

1º Click in `show more` button
2º More data appended to autocomplete-dataset
3º `_onRedrawn` is called
4º The problem: **var inputRect = `this.$input[0].getBoundingClientRect()`**

As already has a scroll in the page the `bottom` position returned by `inputRect` are much greater than when has no scroll in the page and when are set position of `autocomplete` to `top: 0` and `left: 0` the scroll disappear causing a wrong `top` position:

<img width="1009" alt="captura de tela 2017-03-13 as 18 03 54" src="https://cloud.githubusercontent.com/assets/5859119/23875233/782539b2-0817-11e7-9759-b7500e649e9e.png">

**What i've done**

Guarantee the autocomplete `top and left` position are reset before calculating the `getBoundingClientRect()` 
