### PR TITLE
getWrapper public method

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,6 +668,7 @@ search.autocomplete.close();
 search.autocomplete.getVal();
 search.autocomplete.setVal('Hey Jude');
 search.autocomplete.destroy();
+search.autocomplete.getWrapper();
 ```
 
 You can also pass a custom Typeahead instance in Autocomplete.js constructor:

--- a/README.md
+++ b/README.md
@@ -668,7 +668,7 @@ search.autocomplete.close();
 search.autocomplete.getVal();
 search.autocomplete.setVal('Hey Jude');
 search.autocomplete.destroy();
-search.autocomplete.getWrapper();
+search.autocomplete.getWrapper(); // since autocomplete.js wraps your input into another div, you can access that div
 ```
 
 You can also pass a custom Typeahead instance in Autocomplete.js constructor:

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -477,7 +477,11 @@ _.mixin(Typeahead.prototype, {
     destroyDomStructure(this.$node, this.cssClasses);
 
     this.$node = null;
-  }
+  },
+
+  getWrapper: function getWrapper() {
+		return this.dropdown.$container[0];
+	}
 });
 
 function buildDom(options) {

--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -480,8 +480,8 @@ _.mixin(Typeahead.prototype, {
   },
 
   getWrapper: function getWrapper() {
-		return this.dropdown.$container[0];
-	}
+    return this.dropdown.$container[0];
+  }
 });
 
 function buildDom(options) {

--- a/src/standalone/index.js
+++ b/src/standalone/index.js
@@ -56,7 +56,7 @@ function autocomplete(selector, options, datasets, typeaheadObject) {
 
   // expose all methods in the `autocomplete` attribute
   inputs.autocomplete = {};
-  _.each(['open', 'close', 'getVal', 'setVal', 'destroy'], function(method) {
+  _.each(['open', 'close', 'getVal', 'setVal', 'destroy', 'getWrapper'], function(method) {
     inputs.autocomplete[method] = function() {
       var methodArguments = arguments;
       var result;

--- a/test/unit/standalone_spec.js
+++ b/test/unit/standalone_spec.js
@@ -38,7 +38,7 @@ describe('Typeahead', function() {
   describe('when accessing autocomplete function', function() {
 
     it('should have an open, close, getVal, setVal and destroy methods', function() {
-      var methodsToAssert = ['open', 'close', 'getVal', 'setVal', 'destroy'];
+      var methodsToAssert = ['open', 'close', 'getVal', 'setVal', 'destroy', 'getWrapper'];
 
       for (var i = 0; i < methodsToAssert.length; i++) {
         expect(this.ac.autocomplete[methodsToAssert[i]]).toBeDefined();
@@ -58,7 +58,8 @@ describe('Typeahead', function() {
           close: sinon.stub().returns('hello'),
           getVal: sinon.stub().returns('hello'),
           setVal: sinon.stub().returns('hello'),
-          destroy: sinon.stub().returns('hello')
+          destroy: sinon.stub().returns('hello'),
+          getWrapper: sinon.stub().returns('hello')
         };
 
         this.ac = autocomplete('input', {}, {
@@ -85,6 +86,8 @@ describe('Typeahead', function() {
         expect(this.typeaheadSpy.setVal.withArgs('Hey').calledOnce).toBe(true);
         expect(this.ac.autocomplete.destroy()).toEqual('hello');
         expect(this.typeaheadSpy.destroy.calledOnce).toBe(true);
+        expect(this.ac.autocomplete.getWrapper()).toEqual('hello');
+        expect(this.typeaheadSpy.getWrapper.calledOnce).toBe(true);
       });
 
     });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
In my case i need to take the specific `ca-autocomplete` container to verify a custom element and as is possible to have many autocomplete in the same page i don't see other way for get the reference of container through the autocomplete instance. 


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
My playground page:

<img width="477" alt="captura de tela 2017-03-15 as 20 27 49" src="https://cloud.githubusercontent.com/assets/5859119/23975156/e7a7d45a-09bd-11e7-9ada-fe5d9f144a6c.png">

As you see has more than one autocomplete and the `advanced` has a header template. And in my autocomplete wrapper i made a:
```
this._$autocomplete = this._instance.autocomplete.getWrapper();
``` 
through this new option to get the container and after: 
```
this._$dropdownHeader = this._$autocomplete.querySelector('.autocomplete-dropdown-header');
```

Works perfectly for me.