### PR TITLE
Added check to set _isEmpty if the suggestions length is 0

### DIFF
--- a/src/autocomplete/dataset.js
+++ b/src/autocomplete/dataset.js
@@ -93,7 +93,7 @@ _.mixin(Dataset.prototype, EventEmitter, {
     var renderArgs = [].slice.call(arguments, 2);
     this.$el.empty();
 
-    hasSuggestions = suggestions && suggestions.length;
+    hasSuggestions = suggestions && suggestions.length > 0;
     this._isEmpty = !hasSuggestions;
 
     if (!hasSuggestions && this.templates.empty) {


### PR DESCRIPTION
**Summary**

When handling suggestions from multiple sources, if a source has an empty result and that is passed directly to the handleSuggestion callback, handleSuggestion doesn't consider that "empty" and will attempt to render the template for each suggestion (of which there are 0).

This PR adds a check for an empty array when setting the `_isEmpty` flag, resulting in the empty template being rendered (and more importantly for #178 , seems to result in the cacheSuggestions not being overwritten with an empty array).

#178 happened to me and there didn't seem to be any progress on a solution, so I thought I'd dig in a little bit.

**Result**

Using multiple sources where the last source has an empty set of hits (ie. the example from #178) seems fixed.


