### PR TITLE
Fixes prop names causing menu height to be NaN

### DIFF
--- a/src/autocomplete/dropdown.js
+++ b/src/autocomplete/dropdown.js
@@ -272,8 +272,8 @@ _.mixin(Dropdown.prototype, EventEmitter, {
       parseInt($el.css('margin-bottom'), 10);
     menuScrollTop = this.$menu.scrollTop();
     menuHeight = this.$menu.height() +
-      parseInt(this.$menu.css('paddingTop'), 10) +
-      parseInt(this.$menu.css('paddingBottom'), 10);
+      parseInt(this.$menu.css('padding-top'), 10) +
+      parseInt(this.$menu.css('padding-bottom'), 10);
 
     if (elTop < 0) {
       this.$menu.scrollTop(menuScrollTop + elTop);


### PR DESCRIPTION
Keeping the selected suggestion in view when using `max-height` and `overflow: scroll` was not working. The css property names being used to calculate the menu height were mistakenly camelCased causing `menuHeight` to be NaN and never triggering the conditional.