### PR TITLE
Handle an odd case with the user agent

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -20,8 +20,11 @@ module.exports = {
 
   isMsie: function() {
     // from https://github.com/ded/bowser/blob/master/bowser.js
-    return (/(msie|trident)/i).test(navigator.userAgent) ?
-      navigator.userAgent.match(/(msie |rv:)(\d+(.\d+)?)/i)[2] : false;
+    if ((/(msie|trident)/i).test(navigator.userAgent)) {
+      var match = navigator.userAgent.match(/(msie |rv:)(\d+(.\d+)?)/i);
+      if (match) { return match[2]; }
+    }
+    return false;
   },
 
   // http://stackoverflow.com/a/6969486

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -18,10 +18,11 @@ module.exports = {
   map: null,
   mixin: null,
 
-  isMsie: function() {
+  isMsie: function(agentString) {
+    if (agentString === undefined) { agentString = navigator.userAgent; }
     // from https://github.com/ded/bowser/blob/master/bowser.js
-    if ((/(msie|trident)/i).test(navigator.userAgent)) {
-      var match = navigator.userAgent.match(/(msie |rv:)(\d+(.\d+)?)/i);
+    if ((/(msie|trident)/i).test(agentString)) {
+      var match = agentString.match(/(msie |rv:)(\d+(.\d+)?)/i);
       if (match) { return match[2]; }
     }
     return false;

--- a/test/unit/utils_spec.js
+++ b/test/unit/utils_spec.js
@@ -18,4 +18,9 @@ describe('escapeHTML', function() {
     var actual = _.escapeHighlightedString(test, '<span class="highlighted">', '</span>');
     expect(actual).toEqual('<span class="highlighted">&lt;img src=VALUE1 onerror=alert(1) /&gt;</span>OTHER CONTENT<span class="highlighted">VALUE2</span>OTHER CONTENT$');
   });
+
+  it('should report the isMsie state correctly', function() {
+    var actual = _.isMsie();
+    expect(actual).toEqual(false);
+  });
 });

--- a/test/unit/utils_spec.js
+++ b/test/unit/utils_spec.js
@@ -23,4 +23,22 @@ describe('escapeHTML', function() {
     var actual = _.isMsie();
     expect(actual).toEqual(false);
   });
+
+  it('should report the isMsie state correctly under a non-IE browser', function() {
+    var ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36';
+    var actual = _.isMsie(ua);
+    expect(actual).toEqual(false);
+  });
+
+  it('should report the isMsie state correctly under an IE browser', function() {
+    var ua = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko';
+    var actual = _.isMsie(ua);
+    expect(actual).toEqual('11.0');
+  });
+
+  it('should report the isMsie state correctly under a browser that includes Trident but is not IE', function() {
+    var ua = 'Mozilla/5.0 (iPad; CPU OS 11_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15G77 KurogoVersion/2.7.7 (Kurogo iOS Tablet) KurogoOSVersion/11.4.1 KurogoAppVersion/2.0.1 (com.telerik.TridentUniversity)';
+    var actual = _.isMsie(ua);
+    expect(actual).toEqual(false);
+  });
 });


### PR DESCRIPTION
Fixes #243 

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

I'm getting a JS crash due to an odd useragent from the client. The agent I'm getting is:

```Mozilla/5.0 (iPad; CPU OS 11_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15G77 KurogoVersion/2.7.7 (Kurogo iOS Tablet) KurogoOSVersion/11.4.1 KurogoAppVersion/2.0.1 (com.telerik.TridentUniversity)```

This Kurogo browser is used by universities, and it includes the name of the university in the useragent string. In this case, the university is called Trident. In the `isMsie` code in utils.js, the first line tests for the presence of msie or trident, and the positive side of the unary operator assumes this means it will be checking a standard IE useragent string to get the revision. In my case, that is not the case, so `navigator.userAgent.match(/(msie |rv:)(\d+(.\d+)?)/i)` return null and trying to index into null as an array makes a crash.

What I've done is split out the unary to get the result of the match and make sure it exists before indexing into it. This fixes the crash.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

This is an attempt at solving the crash described above. It fixes issue #243.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

Unfortunately, I was unable to figure out how to spoof the useragent in a test after a bunch of searching. To validate this, I copied the useragent string i'm getting directly into the code, made a test that `isMsie` was working as expected, and then deleted that hack. It worked as expected both with my hack in place and with the user agent provided by phantomjs.