### PR TITLE
Add dataset suggestion filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,19 @@ Datasets can be configured using the following options.
   `value`.
   Example function usage: `displayKey: function(suggestion) { return suggestion.nickname || suggestion.firstName }`
 
+* `filter` - For a list of suggestions from the source,
+  determines the list of suggestions to be rendered. It is expected that the
+  function will return suggestion objects of the same type.
+  Example function usage:
+  
+    ```
+    filter: function(suggestions) {
+      return suggestions.filter(function(suggestion) {
+        return !suggestion.hideMe;
+      });
+    }
+    ```
+
 * `templates` – A hash of templates to be used when rendering the dataset. Note
   a precompiled template is a function that takes a JavaScript object as its
   first argument and returns a HTML string.

--- a/src/autocomplete/dataset.js
+++ b/src/autocomplete/dataset.js
@@ -34,6 +34,7 @@ function Dataset(o) {
 
   this.source = o.source;
   this.displayFn = getDisplayFn(o.display || o.displayKey);
+  this.filterFn = getFilterFn(o.filter);
 
   this.debounce = o.debounce;
 
@@ -181,6 +182,10 @@ _.mixin(Dataset.prototype, EventEmitter, {
     }
   },
 
+  _applyFilters: function(suggestions) {
+    return this.filterFn(suggestions);
+  },
+
   // ### public
 
   getRoot: function getRoot() {
@@ -192,11 +197,12 @@ _.mixin(Dataset.prototype, EventEmitter, {
       // if the update has been canceled or if the query has changed
       // do not render the suggestions as they've become outdated
       if (!this.canceled && query === this.query) {
+        var filteredSuggestions = this._applyFilters(suggestions);
         // concat all the other arguments that could have been passed
         // to the render function, and forward them to _render
         var extraArgs = [].slice.call(arguments, 1);
-        this.cacheSuggestions(query, suggestions, extraArgs);
-        this._render.apply(this, [query, suggestions].concat(extraArgs));
+        this.cacheSuggestions(query, filteredSuggestions, extraArgs);
+        this._render.apply(this, [query, filteredSuggestions].concat(extraArgs));
       }
     }
 
@@ -274,6 +280,14 @@ function getDisplayFn(display) {
 
   function displayFn(obj) {
     return obj[display];
+  }
+}
+
+function getFilterFn(filter) {
+  return _.isFunction(filter) ? filter : filterFn;
+
+  function filterFn(suggestions) {
+    return suggestions;
   }
 }
 

--- a/test/unit/dataset_spec.js
+++ b/test/unit/dataset_spec.js
@@ -66,6 +66,27 @@ describe('Dataset', function() {
       expect(this.dataset.getRoot()).toContainText('6');
     });
 
+    it('should allow custom filter functions', function() {
+      this.dataset = new Dataset({
+        name: 'test',
+        filter: function(suggestions) {
+          return suggestions.filter(function(suggestion) {
+            var value = suggestion.value;
+            return value === '1' || value === '3';
+          });
+        },
+        source: this.source = jasmine.createSpy('source')
+      });
+
+      this.source.and.callFake(fakeGetForFilterFn);
+      this.dataset.update('woah');
+
+      expect(this.dataset.getRoot()).toContainText('1');
+      expect(this.dataset.getRoot()).not.toContainText('2');
+      expect(this.dataset.getRoot()).toContainText('3');
+      expect(this.dataset.getRoot()).not.toContainText('4');
+    });
+
     it('should render empty when no suggestions are available', function() {
       this.dataset = new Dataset({
         source: this.source,
@@ -475,6 +496,18 @@ describe('Dataset', function() {
 
   function fakeGetForDisplayFn(query, cb) {
     cb([{display: '4'}, {display: '5'}, {display: '6'}]);
+  }
+
+  function fakeGetForFilterFn(query, cb) {
+    cb([{
+        value: '1',
+      }, {
+        value: '2', 
+      },{
+        value: '3', 
+      },{
+        value: '4', 
+      }]);
   }
 
   function fakeGetWithSyncEmptyResults(query, cb) {


### PR DESCRIPTION
**Summary**

Adds the ability to filter suggestions from a dataset source before
rendering.

Use case:
* Dropdown selections are used to "select" items. Once the item has been selected,
it should not be displayed as an autocomplete suggestion again.
* The dataset source is unaware of the selected items thus it cannot do the filtering.

Related issues:
* #251
