### PR TITLE
Throw err on update if suggestions are invalid type

### DIFF
--- a/src/autocomplete/dataset.js
+++ b/src/autocomplete/dataset.js
@@ -109,7 +109,7 @@ _.mixin(Dataset.prototype, EventEmitter, {
         .prepend(that.templates.header ? getHeaderHtml.apply(this, renderArgs) : null)
         .append(that.templates.footer ? getFooterHtml.apply(this, renderArgs) : null);
     } else if (suggestions && !Array.isArray(suggestions)) {
-      throw new Error('suggestions must be an array');
+      throw new TypeError('suggestions must be an array');
     }
 
     if (this.$menu) {

--- a/src/autocomplete/dataset.js
+++ b/src/autocomplete/dataset.js
@@ -108,6 +108,8 @@ _.mixin(Dataset.prototype, EventEmitter, {
         .html(getSuggestionsHtml.apply(this, renderArgs))
         .prepend(that.templates.header ? getHeaderHtml.apply(this, renderArgs) : null)
         .append(that.templates.footer ? getFooterHtml.apply(this, renderArgs) : null);
+    } else if (suggestions && !Array.isArray(suggestions)) {
+      throw new Error('suggestions must be an array');
     }
 
     if (this.$menu) {

--- a/test/unit/dataset_spec.js
+++ b/test/unit/dataset_spec.js
@@ -81,7 +81,9 @@ describe('Dataset', function() {
     });
 
     it('should throw an error if suggestions is not an array', function() {
-      expect(this.source.and.callFake(fakeGetNonArrayResults)).toThrow();
+      this.source.and.callFake(fakeGetWithSyncNonArrayResults);
+      expect(this.dataset.update.bind(this.dataset, 'woah'))
+        .toThrowError(TypeError, 'suggestions must be an array');
     });
 
     it('should set the aa-without class when no suggestions are available', function() {
@@ -481,7 +483,7 @@ describe('Dataset', function() {
     cb([{display: '4'}, {display: '5'}, {display: '6'}]);
   }
 
-  function fakeGetNonArrayResults(query, cb) {
+  function fakeGetWithSyncNonArrayResults(query, cb) {
     cb({});
   }
 

--- a/test/unit/dataset_spec.js
+++ b/test/unit/dataset_spec.js
@@ -80,6 +80,10 @@ describe('Dataset', function() {
       expect(this.dataset.getRoot()).toContainText('empty');
     });
 
+    it('should throw an error if suggestions is not an array', function() {
+      expect(this.source.and.callFake(fakeGetNonArrayResults)).toThrow();
+    });
+
     it('should set the aa-without class when no suggestions are available', function() {
       var $menu = $('<div />');
       this.dataset = new Dataset({
@@ -475,6 +479,10 @@ describe('Dataset', function() {
 
   function fakeGetForDisplayFn(query, cb) {
     cb([{display: '4'}, {display: '5'}, {display: '6'}]);
+  }
+
+  function fakeGetNonArrayResults(query, cb) {
+    cb({});
   }
 
   function fakeGetWithSyncEmptyResults(query, cb) {


### PR DESCRIPTION
Resolves #131

**Summary**

Throws an error if `suggestions` provided by a dataset are not valid type (`Array`). This helps the developer/user understand why results aren't displayed rather than silently failing.