### PR TITLE
fix(zepto): apply patch to handle read-only event

### DIFF
--- a/zepto.js
+++ b/zepto.js
@@ -2,7 +2,7 @@
 /* Zepto v1.2.0 - zepto event assets data - zeptojs.com/license */
 (function(global, factory) {
   module.exports = factory(global);
-}(/* this ##### UPDATED: here we want to use window/global instead of this which is the current file context ##### */ window, function(window) {  
+}(/* this ##### UPDATED: here we want to use window/global instead of this which is the current file context ##### */ window, function(window) {
   var Zepto = (function() {
   var undefined, key, $, classList, emptyArray = [], concat = emptyArray.concat, filter = emptyArray.filter, slice = emptyArray.slice,
     document = window.document,
@@ -999,7 +999,11 @@
       handler.proxy = function(e){
         e = compatible(e)
         if (e.isImmediatePropagationStopped()) return
-        e.data = data
+        try {
+          var dataPropDescriptor = Object.getOwnPropertyDescriptor(e, 'data')
+          if (!dataPropDescriptor || dataPropDescriptor.writable)
+            e.data = data
+        } catch (e) {} // when using strict mode dataPropDescriptor will be undefined when e is InputEvent (even though data property exists). So we surround with try/catch
         var result = callback.apply(element, e._args == undefined ? [e] : [e].concat(e._args))
         if (result === false) e.preventDefault(), e.stopPropagation()
         return result


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

This PR applies [this patch](https://github.com/madrobby/zepto/pull/1319) from @ymoran00.
Some events are read only and zepto can not update `data` property.

I can't reproduce it at the moment because I am on smartphone, but this problem was really painful.

Also it seems that it doesn't break anything, this patch worked fine on our project at work (it uses place.js). 

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

![autocomplete](https://user-images.githubusercontent.com/2103975/47775004-ccbbff80-dcee-11e8-8f49-9857038908e9.gif)

---

~By the way, should I remove build files from this pull request?
I wanted to ship them but they were desynchronized with actual source files.
The build is done before publishing on npm right?~

Thanks.
