### PR TITLE
fix(standalone): use aria label from input

### DIFF
--- a/src/standalone/index.js
+++ b/src/standalone/index.js
@@ -51,7 +51,8 @@ function autocomplete(selector, options, datasets, typeaheadObject) {
       datasets: datasets,
       keyboardShortcuts: options.keyboardShortcuts,
       appendTo: options.appendTo,
-      autoWidth: options.autoWidth
+      autoWidth: options.autoWidth,
+      ariaLabel: options.ariaLabel || input.getAttribute('aria-label')
     });
     $input.data(typeaheadKey, typeahead);
   });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Use `aria-label` property from given input element on the new input element.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
When using standalone version (with places.js for instance) the aria-label on the target input element will be forwarded to the input element created by autocomplete.js.