### PR TITLE
Fix NPE when clear is called after destroy

### DIFF
--- a/src/autocomplete/dataset.js
+++ b/src/autocomplete/dataset.js
@@ -256,9 +256,11 @@ _.mixin(Dataset.prototype, EventEmitter, {
   },
 
   clear: function clear() {
-    this.cancel();
-    this.$el.empty();
-    this.trigger('rendered', '');
+    if (this.$el) {
+      this.cancel();
+      this.$el.empty();
+      this.trigger('rendered', '');
+    }
   },
 
   isEmpty: function isEmpty() {

--- a/test/unit/dataset_spec.js
+++ b/test/unit/dataset_spec.js
@@ -462,6 +462,14 @@ describe('Dataset', function() {
       this.dataset.clear();
       expect(spy).toHaveBeenCalled();
     });
+
+    it('should do nothing if this.$el is not defined', function() {
+      this.source.and.callFake(fakeGetWithSyncResults);
+      this.dataset.update('woah');
+      this.dataset.destroy();
+      this.dataset.clear();
+      expect(this.dataset.getRoot()).toBeNull();
+    });
   });
 
   describe('#isEmpty', function() {

--- a/test/unit/dataset_spec.js
+++ b/test/unit/dataset_spec.js
@@ -463,7 +463,7 @@ describe('Dataset', function() {
       expect(spy).toHaveBeenCalled();
     });
 
-    it('should do nothing if this.$el is not defined', function() {
+    it('should not throw if called right after destroy()', function() {
       this.source.and.callFake(fakeGetWithSyncResults);
       this.dataset.update('woah');
       this.dataset.destroy();


### PR DESCRIPTION
Fixes: https://github.com/busbud/public-website/issues/8331

**Summary**

It is possible to have Null Pointer Exception, when 'clear' is called immediately after 'destroy' (due to async code somewhere in jquery and user spamming some controls). 
Adding a simple check prevents this error.

Original error:
![Screen Shot 2019-08-27 at 12 49 39 PM](https://user-images.githubusercontent.com/8777372/63791274-2702fe00-c8c9-11e9-83a5-bde94e3e9bb2.png)

Some debugging:
![Screen Shot 2019-08-27 at 12 54 26 PM](https://user-images.githubusercontent.com/8777372/63791612-dc35b600-c8c9-11e9-82f9-7cbaf3eeac10.png)
![Screen Shot 2019-08-27 at 1 00 03 PM](https://user-images.githubusercontent.com/8777372/63791969-99c0a900-c8ca-11e9-9aaa-6f96b5ff5276.png)

![Screen Shot 2019-08-27 at 12 54 34 PM](https://user-images.githubusercontent.com/8777372/63791610-dc35b600-c8c9-11e9-945a-2720c1d9b79e.png)


**Result**

No more NPE