### PR TITLE
Catch exceptions while assigning event.timeStamp

### DIFF
--- a/zepto.js
+++ b/zepto.js
@@ -1077,7 +1077,9 @@
         event[predicate] = returnFalse
       })
 
-      event.timeStamp || (event.timeStamp = Date.now())
+      try {
+        event.timeStamp || (event.timeStamp = Date.now())
+      } catch (ignored) { }
 
       if (source.defaultPrevented !== undefined ? source.defaultPrevented :
           'returnValue' in source ? source.returnValue === false :


### PR DESCRIPTION
**Summary**

On some old browsers such as Safari mobile 9, Firefox 52 or Chrome mobile 58, trying to set a read-only property raises an exception `TypeError: setting a property that has only a getter`.

This has been fixed on the Zepto repository, in this [PR](https://github.com/madrobby/zepto/pull/1218). But since no release has been done, it's not available via Semver.

This PR applies the above patch to the versioned Zepto file.