### PR TITLE
fix(algolia): parse user agents with new search clients

### DIFF
--- a/src/common/parseAlgoliaClientVersion.js
+++ b/src/common/parseAlgoliaClientVersion.js
@@ -1,6 +1,15 @@
 'use strict';
+
 module.exports = function parseAlgoliaClientVersion(agent) {
-  var parsed = agent.match(/Algolia for vanilla JavaScript (\d+\.)(\d+\.)(\d+)/);
-  if (parsed) return [parsed[1], parsed[2], parsed[3]];
+  var parsed =
+    // User agent for algoliasearch >= 3.33.0
+    agent.match(/Algolia for JavaScript \((\d+\.)(\d+\.)(\d+)\)/) ||
+    // User agent for algoliasearch < 3.33.0
+    agent.match(/Algolia for vanilla JavaScript (\d+\.)(\d+\.)(\d+)/);
+
+  if (parsed) {
+    return [parsed[1], parsed[2], parsed[3]];
+  }
+
   return undefined;
 };

--- a/test/unit/parseAlgoliaClientVersion_spec.js
+++ b/test/unit/parseAlgoliaClientVersion_spec.js
@@ -1,0 +1,27 @@
+'use strict';
+
+/* eslint-env mocha, jasmine */
+
+describe('parseAlgoliaClientVersion', function() {
+  var parseAlgoliaClientVersion = require('../../src/common/parseAlgoliaClientVersion.js');
+
+  it('should return undefined for unknown user agents', function() {
+    expect(parseAlgoliaClientVersion('random user agent 1.2.3')).toEqual(
+      undefined
+    );
+  });
+
+  it('should parse user agents with algoliasearch < 3.33.0 format', function() {
+    expect(
+      parseAlgoliaClientVersion('Algolia for vanilla JavaScript 3.1.0')
+    ).toEqual(['3.', '1.', '0']);
+  });
+
+  it('should parse user agents with algoliasearch >= 3.33.0 format', function() {
+    expect(parseAlgoliaClientVersion('Algolia for JavaScript (3.5.0)')).toEqual([
+      '3.',
+      '5.',
+      '0'
+    ]);
+  });
+});


### PR DESCRIPTION
This fixes #301 by supporting user agents for `algoliasearch` >= 3.33.0.