### PR TITLE
Installation doc fix for standalone version

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This JavaScript library adds a fast and fully-featured auto-completion menu to y
 
 ## Installation
 
-The `autocomplete.js` library must be included **after** jQuery or Angular.js (with jQuery). Else, it will use the embedded Zepto.
+The `autocomplete.js` library must be included **after** jQuery, Zepto or Angular.js (with jQuery). Else, it will use the embedded Zepto.
 
 ### jsDelivr
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This JavaScript library adds a fast and fully-featured auto-completion menu to y
 
 ## Installation
 
-The `autocomplete.js` library must be included **after** jQuery, Zepto or Angular.js (with jQuery).
+The `autocomplete.js` library must be included **after** jQuery or Angular.js (with jQuery). Else, it will use the embedded Zepto.
 
 ### jsDelivr
 


### PR DESCRIPTION
**Summary**

The README currently says that "The autocomplete.js library must be included after […] Zepto […]".

So I thought I had to load `Zepto` first, and then `autocomplete.js`.

But it looks like `Zepto` is [already embedded into `dist/autocomplete.js`](https://github.com/algolia/autocomplete.js/blob/master/dist/autocomplete.js#L169).

I checked it works when I load `autocomplete.js` without loading `Zepto` before.

**Result**

Updated doc.