### PR TITLE
feat(js): introduce `dropdownPlacement` API

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "packages/autocomplete-js/dist/umd/index.js",
-      "maxSize": "6.5 kB"
-    },
+      "maxSize": "7 kB"
+    }
   ]
 }

--- a/examples/js/app.js
+++ b/examples/js/app.js
@@ -13,7 +13,7 @@ const searchClient = algoliasearch(
 autocomplete({
   container: '#autocomplete',
   debug: true,
-  // dropdownPlacement: 'end',
+  // dropdownPlacement: 'start',
   getSources() {
     return [
       {

--- a/examples/js/app.js
+++ b/examples/js/app.js
@@ -13,6 +13,7 @@ const searchClient = algoliasearch(
 autocomplete({
   container: '#autocomplete',
   debug: true,
+  // dropdownPlacement: 'end',
   getSources() {
     return [
       {

--- a/examples/js/autocomplete.css
+++ b/examples/js/autocomplete.css
@@ -80,10 +80,6 @@
   z-index: 3;
 }
 
-.aa-Autocomplete {
-  width: 100%;
-}
-
 .aa-Dropdown {
   background-color: #fff;
   border: 1px solid rgba(150, 150, 150, 0.16);
@@ -91,6 +87,8 @@
   box-shadow: 0 0 0 1px rgba(35, 38, 59, 0.05),
     0 8px 16px -4px rgba(35, 38, 59, 0.25);
   margin-top: 5px;
+  max-width: 480px;
+  position: absolute;
   width: 100%;
 }
 

--- a/examples/js/style.css
+++ b/examples/js/style.css
@@ -1,9 +1,10 @@
-body {
-  margin: 0;
-  padding: 0;
+* {
+  box-sizing: border-box;
 }
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
     Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  margin: 0;
+  padding: 0;
 }

--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -169,7 +169,7 @@ export function autocomplete<TItem>({
       if (!dropdown.hasAttribute('hidden')) {
         setDropdownPosition();
       }
-    }, 100)();
+    }, 100);
   }
 
   function setDropdownPosition() {

--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -109,6 +109,8 @@ export function getDropdownPositionStyle({
         top,
         left: 0,
         right: 0,
+        // @TODO [IE support] IE doesn't support `"unset"`
+        // See https://caniuse.com/#feat=css-unset-value
         width: 'unset',
         maxWidth: 'unset',
       };
@@ -123,6 +125,8 @@ export function getDropdownPositionStyle({
         right:
           environment.document.documentElement.clientWidth -
           (inputWrapperRect.left + inputWrapperRect.width),
+        // @TODO [IE support] IE doesn't support `"unset"`
+        // See https://caniuse.com/#feat=css-unset-value
         width: 'unset',
         maxWidth: 'unset',
       };

--- a/packages/autocomplete-js/src/debounce.ts
+++ b/packages/autocomplete-js/src/debounce.ts
@@ -1,8 +1,11 @@
 export function debounce(fn: Function, time: number) {
-  let timerId: number | undefined = undefined;
+  let timerId: ReturnType<typeof setTimeout> | undefined = undefined;
 
   return function () {
-    clearTimeout(timerId);
-    timerId = (setTimeout(fn, time) as unknown) as number;
+    if (timerId) {
+      clearTimeout(timerId);
+    }
+
+    timerId = setTimeout(fn(), time);
   };
 }

--- a/packages/autocomplete-js/src/debounce.ts
+++ b/packages/autocomplete-js/src/debounce.ts
@@ -1,0 +1,8 @@
+export function debounce(fn: Function, time: number) {
+  let timerId: number | undefined = undefined;
+
+  return function () {
+    clearTimeout(timerId);
+    timerId = (setTimeout(fn, time) as unknown) as number;
+  };
+}

--- a/packages/website/docs/autocomplete-js.md
+++ b/packages/website/docs/autocomplete-js.md
@@ -62,7 +62,7 @@ import CreateAutocompleteProps from './partials/createAutocomplete-props.md'
 
 ### `dropdownPlacement`
 
-> `"start" | "end"` | defaults to `"start"`
+> `"start" | "end" | "full-width" | "input-wrapper-width" | defaults to `"input-wrapper-width"`
 
 The dropdown horizontal position.
 

--- a/packages/website/docs/autocomplete-js.md
+++ b/packages/website/docs/autocomplete-js.md
@@ -13,10 +13,7 @@ This function creates a JavaScript autocomplete experience.
 
 ```js title="JavaScript"
 import algoliasearch from 'algoliasearch/lite';
-import {
-  autocomplete,
-  getAlgoliaHits,
-} from '@algolia/autocomplete-js';
+import { autocomplete, getAlgoliaHits } from '@algolia/autocomplete-js';
 
 const searchClient = algoliasearch(
   'latency',
@@ -62,6 +59,12 @@ The container for the autocomplete search box. You can either pass a [CSS select
 import CreateAutocompleteProps from './partials/createAutocomplete-props.md'
 
 <CreateAutocompleteProps />
+
+### `dropdownPlacement`
+
+> `"start" | "end"` | defaults to `"start"`
+
+The dropdown horizontal position.
 
 ### `render`
 


### PR DESCRIPTION
This introduces a new API for Autocomplete JavaScript called `dropdownPlacement`.

## Description

I went for the terminology "placement" because [Popper.js](https://popper.js.org/docs/v2/constructors/#placement) uses this term, and `"start" | "end"` like [`align-content`](https://css-tricks.com/almanac/properties/a/align-content/) from the Flexible Box Layout module.

## Preview

### `"input-wrapper-width"` (default)

![input-wrapper-width preview](https://user-images.githubusercontent.com/6137112/92227731-fb84fd00-eea6-11ea-8e5d-daa125d6ea62.png)

### `"full-width"`

![full-width preview](https://user-images.githubusercontent.com/6137112/92227770-0b9cdc80-eea7-11ea-8463-46e39f385938.png)


### `"start"`

![start preview](https://user-images.githubusercontent.com/6137112/92144318-d21c9080-ee16-11ea-9a51-c80f9b91253b.png)

### `"end"`

![end preview](https://user-images.githubusercontent.com/6137112/92144357-e1034300-ee16-11ea-940b-c015f77f30eb.png)

## Next steps

Fall back to `"full-width"` on mobile.

## How to test

- Open the PR sandbox
- Uncomment the `dropdownPlacement` of `autocomplete`