### PR TITLE
fix(getSuggestions): allow nested arrays to be returned

### DIFF
--- a/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
@@ -2,8 +2,8 @@ import { createAutocomplete, AutocompleteSuggestion } from '..';
 import { InternalAutocompleteSource } from '../types';
 
 function createSuggestion<TItem extends { label: string }>(
-  items: TItem[] = []
-): AutocompleteSuggestion<TItem> {
+  items: TItem[] | TItem[][] = []
+): AutocompleteSuggestion<TItem | TItem[]> | AutocompleteSuggestion<TItem[]> {
   return {
     source: {
       getInputValue: ({ suggestion }) => suggestion.label,
@@ -117,7 +117,7 @@ describe('createAutocomplete', () => {
         onStateChange,
       });
 
-      setSuggestions([createMultiSuggestion([[{ label: 'hi' }]])]);
+      setSuggestions([createSuggestion([[{ label: 'hi' }]])]);
 
       expect(onStateChange).toHaveBeenCalledWith({
         prevState: expect.any(Object),

--- a/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
@@ -16,26 +16,6 @@ function createSuggestion<TItem extends { label: string }>(
   };
 }
 
-interface AutocompleteMultiSuggestion<TItem> {
-  source: InternalAutocompleteSource<TItem>;
-  items: TItem[][];
-}
-
-function createMultiSuggestion<TItem extends { label: string }>(
-  items: TItem[][] = []
-): AutocompleteMultiSuggestion<TItem> {
-  return {
-    source: {
-      getInputValue: ({ suggestion }) => suggestion.label,
-      getSuggestionUrl: () => undefined,
-      onHighlight: () => {},
-      onSelect: () => {},
-      getSuggestions: () => items,
-    },
-    items,
-  };
-}
-
 describe('createAutocomplete', () => {
   test('setHighlightedIndex', () => {
     const onStateChange = jest.fn();

--- a/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
@@ -1,5 +1,4 @@
-import { createAutocomplete } from '..';
-import { AutocompleteSuggestion } from '../../dist/esm';
+import { createAutocomplete, AutocompleteSuggestion } from '..';
 
 function createSuggestion<TItem extends { label: string }>(
   items: TItem[] = []
@@ -98,7 +97,7 @@ describe('createAutocomplete', () => {
 
       // @ts-expect-error AutocompleteSuggestion has an array of items
       // while it also accepts a nested array.
-      // There's only one type for both input and output however, 
+      // There's only one type for both input and output however,
       setSuggestions([createSuggestion([[{ label: 'hi' }]])]);
 
       expect(onStateChange).toHaveBeenCalledWith({

--- a/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
@@ -2,7 +2,7 @@ import { createAutocomplete } from '..';
 import { AutocompleteSuggestion } from '../../dist/esm';
 
 function createSuggestion<TItem extends { label: string }>(
-  items: TItem[] | TItem[][] = []
+  items: TItem[] = []
 ): AutocompleteSuggestion<TItem> {
   return {
     source: {
@@ -96,6 +96,9 @@ describe('createAutocomplete', () => {
         onStateChange,
       });
 
+      // @ts-expect-error AutocompleteSuggestion has an array of items
+      // while it also accepts a nested array.
+      // There's only one type for both input and output however, 
       setSuggestions([createSuggestion([[{ label: 'hi' }]])]);
 
       expect(onStateChange).toHaveBeenCalledWith({

--- a/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
@@ -116,8 +116,6 @@ describe('createAutocomplete', () => {
         onStateChange,
       });
 
-      // while it also accepts a nested array.
-      // There's only one type for both input and output however,
       setSuggestions([createMultiSuggestion([[{ label: 'hi' }]])]);
 
       expect(onStateChange).toHaveBeenCalledWith({

--- a/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
@@ -1,5 +1,4 @@
 import { createAutocomplete, AutocompleteSuggestion } from '..';
-import { InternalAutocompleteSource } from '../types';
 
 function createSuggestion<TItem extends { label: string }>(
   items: TItem[] | TItem[][] = []

--- a/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
@@ -92,6 +92,7 @@ describe('createAutocomplete', () => {
 
       expect(onStateChange).toHaveBeenCalledTimes(1);
       expect(onStateChange).toHaveBeenCalledWith({
+        prevState: expect.any(Object),
         state: expect.objectContaining({
           suggestions: [
             {
@@ -119,6 +120,7 @@ describe('createAutocomplete', () => {
       setSuggestions([createMultiSuggestion([[{ label: 'hi' }]])]);
 
       expect(onStateChange).toHaveBeenCalledWith({
+        prevState: expect.any(Object),
         state: expect.objectContaining({
           suggestions: [
             expect.objectContaining({

--- a/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
@@ -1,6 +1,9 @@
 import { createAutocomplete } from '..';
+import { AutocompleteSuggestion } from '../../dist/esm';
 
-function createSuggestion(items = []) {
+function createSuggestion<TItem extends { label: string }>(
+  items: TItem[] | TItem[][] = []
+): AutocompleteSuggestion<TItem> {
   return {
     source: {
       getInputValue: ({ suggestion }) => suggestion.label,
@@ -64,9 +67,8 @@ describe('createAutocomplete', () => {
         getSources: () => [],
         onStateChange,
       });
-      const suggestions = [createSuggestion([{ item: 'hi' }])];
 
-      setSuggestions(suggestions);
+      setSuggestions([createSuggestion([{ label: 'hi' }])]);
 
       expect(onStateChange).toHaveBeenCalledTimes(1);
       expect(onStateChange).toHaveBeenCalledWith({
@@ -75,7 +77,7 @@ describe('createAutocomplete', () => {
             {
               items: [
                 {
-                  item: 'hi',
+                  label: 'hi',
                   __autocomplete_id: 0,
                 },
               ],
@@ -86,27 +88,21 @@ describe('createAutocomplete', () => {
       });
     });
 
-    test('flattens suggestions', async () => {
+    test('flattens suggestions', () => {
       const onStateChange = jest.fn();
-      const { refresh } = createAutocomplete({
+      const { setSuggestions } = createAutocomplete({
         openOnFocus: true,
-        getSources: () => [
-          {
-            getSuggestions() {
-              return [[{ suggestion: 1 }]];
-            },
-          },
-        ],
+        getSources: () => [],
         onStateChange,
       });
 
-      await refresh();
+      setSuggestions([createSuggestion([[{ label: 'hi' }]])]);
 
       expect(onStateChange).toHaveBeenCalledWith({
         state: expect.objectContaining({
           suggestions: [
             expect.objectContaining({
-              items: [expect.objectContaining({ suggestion: 1 })],
+              items: [{ label: 'hi', __autocomplete_id: 0 }],
             }),
           ],
         }),

--- a/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
@@ -71,15 +71,17 @@ describe('createAutocomplete', () => {
       expect(onStateChange).toHaveBeenCalledTimes(1);
       expect(onStateChange).toHaveBeenCalledWith({
         state: expect.objectContaining({
-          suggestions: expect.arrayContaining(
-            suggestions.map((suggestion) => ({
-              ...suggestion,
-              items: suggestion.items.map((item) => ({
-                ...item,
-                __autocomplete_id: expect.any(Number),
-              })),
-            }))
-          ),
+          suggestions: [
+            {
+              items: [
+                {
+                  item: 'hi',
+                  __autocomplete_id: 0,
+                },
+              ],
+              source: expect.any(Object),
+            },
+          ],
         }),
       });
     });

--- a/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getAutocompleteSetters.test.ts
@@ -1,8 +1,29 @@
 import { createAutocomplete, AutocompleteSuggestion } from '..';
+import { InternalAutocompleteSource } from '../types';
 
 function createSuggestion<TItem extends { label: string }>(
   items: TItem[] = []
 ): AutocompleteSuggestion<TItem> {
+  return {
+    source: {
+      getInputValue: ({ suggestion }) => suggestion.label,
+      getSuggestionUrl: () => undefined,
+      onHighlight: () => {},
+      onSelect: () => {},
+      getSuggestions: () => items,
+    },
+    items,
+  };
+}
+
+interface AutocompleteMultiSuggestion<TItem> {
+  source: InternalAutocompleteSource<TItem>;
+  items: TItem[][];
+}
+
+function createMultiSuggestion<TItem extends { label: string }>(
+  items: TItem[][] = []
+): AutocompleteMultiSuggestion<TItem> {
   return {
     source: {
       getInputValue: ({ suggestion }) => suggestion.label,
@@ -95,10 +116,9 @@ describe('createAutocomplete', () => {
         onStateChange,
       });
 
-      // @ts-expect-error AutocompleteSuggestion has an array of items
       // while it also accepts a nested array.
       // There's only one type for both input and output however,
-      setSuggestions([createSuggestion([[{ label: 'hi' }]])]);
+      setSuggestions([createMultiSuggestion([[{ label: 'hi' }]])]);
 
       expect(onStateChange).toHaveBeenCalledWith({
         state: expect.objectContaining({

--- a/packages/autocomplete-core/src/__tests__/utils.test.ts
+++ b/packages/autocomplete-core/src/__tests__/utils.test.ts
@@ -1,15 +1,15 @@
 import { flatten } from '../utils';
 
 describe('flatten', () => {
-  it('flattens only values', () => {
+  it('does not split strings', () => {
     expect(flatten(['value', 'value'])).toEqual(['value', 'value']);
   });
 
-  it('flattens arrays mixed with nested arrays', () => {
+  it('spreads arrays', () => {
     expect(flatten(['value', ['value']])).toEqual(['value', 'value']);
   });
 
-  it('ignores empty nested arrays', () => {
+  it('ignores empty arrays', () => {
     expect(flatten([[], 'value', 'value'])).toEqual(['value', 'value']);
   });
 });

--- a/packages/autocomplete-core/src/__tests__/utils.test.ts
+++ b/packages/autocomplete-core/src/__tests__/utils.test.ts
@@ -1,0 +1,15 @@
+import { flatten } from '../utils';
+
+describe('flatten', () => {
+  it('flattens only values', () => {
+    expect(flatten(['value', 'value'])).toEqual(['value', 'value']);
+  });
+
+  it('flattens arrays mixed with nested arrays', () => {
+    expect(flatten(['value', ['value']])).toEqual(['value', 'value']);
+  });
+
+  it('ignores empty nested arrays', () => {
+    expect(flatten([[], 'value', 'value'])).toEqual(['value', 'value']);
+  });
+});

--- a/packages/autocomplete-core/src/getAutocompleteSetters.ts
+++ b/packages/autocomplete-core/src/getAutocompleteSetters.ts
@@ -1,4 +1,5 @@
 import { AutocompleteApi, AutocompleteStore } from './types';
+import { flatten } from './utils';
 
 interface GetAutocompleteSettersOptions<TItem> {
   store: AutocompleteStore<TItem>;
@@ -23,7 +24,7 @@ export function getAutocompleteSetters<TItem>({
     let baseItemId = 0;
     const value = rawValue.map((suggestion) => ({
       ...suggestion,
-      items: suggestion.items.map((item) => ({
+      items: flatten(suggestion.items).map((item) => ({
         ...item,
         __autocomplete_id: baseItemId++,
       })),

--- a/packages/autocomplete-core/src/getAutocompleteSetters.ts
+++ b/packages/autocomplete-core/src/getAutocompleteSetters.ts
@@ -24,6 +24,8 @@ export function getAutocompleteSetters<TItem>({
     let baseItemId = 0;
     const value = rawValue.map((suggestion) => ({
       ...suggestion,
+      // We flatten the stored items to support calling `getAlgoliaHits`
+      // from the source itself.
       items: flatten(suggestion.items).map((item) => ({
         ...item,
         __autocomplete_id: baseItemId++,

--- a/packages/autocomplete-core/src/getDefaultProps.ts
+++ b/packages/autocomplete-core/src/getDefaultProps.ts
@@ -4,6 +4,7 @@ import {
   getItemsCount,
   noop,
   getNormalizedSources,
+  flatten,
 } from './utils';
 
 export function getDefaultProps<TItem>(
@@ -62,11 +63,7 @@ export function getDefaultProps<TItem>(
         )
       )
         .then((nested) =>
-          // same as `nested.flat()`
-          nested.reduce((acc, array) => {
-            acc = acc.concat(array);
-            return acc;
-          }, [])
+          flatten(nested)
         )
         .then((sources) =>
           sources.map((source) => ({

--- a/packages/autocomplete-core/src/types/api.ts
+++ b/packages/autocomplete-core/src/types/api.ts
@@ -93,7 +93,9 @@ export interface AutocompleteSource<TItem> {
   /**
    * Function called when the input changes. You can use this function to filter/search the items based on the query.
    */
-  getSuggestions(params: GetSourcesParams<TItem>): MaybePromise<TItem[]>;
+  getSuggestions(
+    params: GetSourcesParams<TItem>
+  ): MaybePromise<TItem[] | TItem[][]>;
   /**
    * Function called when an item is selected.
    */

--- a/packages/autocomplete-core/src/types/api.ts
+++ b/packages/autocomplete-core/src/types/api.ts
@@ -25,7 +25,7 @@ export type AutocompleteRefresh = () => Promise<void>;
 
 export interface AutocompleteSuggestion<TItem> {
   source: InternalAutocompleteSource<TItem>;
-  items: TItem[] | TItem[][];
+  items: TItem[];
 }
 
 export interface GetSourcesParams<TItem> extends AutocompleteSetters<TItem> {

--- a/packages/autocomplete-core/src/types/api.ts
+++ b/packages/autocomplete-core/src/types/api.ts
@@ -25,7 +25,7 @@ export type AutocompleteRefresh = () => Promise<void>;
 
 export interface AutocompleteSuggestion<TItem> {
   source: InternalAutocompleteSource<TItem>;
-  items: TItem[];
+  items: TItem[] | TItem[][];
 }
 
 export interface GetSourcesParams<TItem> extends AutocompleteSetters<TItem> {

--- a/packages/autocomplete-core/src/utils.ts
+++ b/packages/autocomplete-core/src/utils.ts
@@ -187,3 +187,9 @@ export function getHighlightedItem<TItem>({
 export function isOrContainsNode(parent: Node, child: Node) {
   return parent === child || (parent.contains && parent.contains(child));
 }
+
+export function flatten<TType>(values: Array<TType | TType[]>): TType[] {
+  return values.reduce<TType[]>((a, b) => {
+    return a.concat(b);
+  }, []);
+}


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

It flattens the result of getSuggestions. this is useful, since it allows getAlgoliaHits to be used top-level, but also within a single source, without having to take the first element of the array manually

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

you can use getAlgoliaHits top-level in getSources, but also in getSuggestions (like in the docs: https://algolia-autocomplete.netlify.app/docs/autocomplete-js)
