### PR TITLE
test(js): use local version in assertion

### DIFF
--- a/packages/autocomplete-preset-algolia/src/search/__tests__/search.test.ts
+++ b/packages/autocomplete-preset-algolia/src/search/__tests__/search.test.ts
@@ -1,4 +1,4 @@
-import { version } from '@algolia/autocomplete-core';
+import { version } from '../../version';
 import {
   MultipleQueriesResponse,
   SearchResponse,

--- a/packages/autocomplete-preset-algolia/src/search/__tests__/search.test.ts
+++ b/packages/autocomplete-preset-algolia/src/search/__tests__/search.test.ts
@@ -1,9 +1,9 @@
-import { version } from '../../version';
 import {
   MultipleQueriesResponse,
   SearchResponse,
 } from '@algolia/client-search';
 
+import { version } from '../../version';
 import { getAlgoliaHits } from '../getAlgoliaHits';
 import { getAlgoliaResults } from '../getAlgoliaResults';
 


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

I think I needed this before lerna ran, but in either case, I think it makes more sense to assert the lcoal version is used than the one from @algolia/autocomplete-core

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

no dependencies are used within the test of autocomplete.js