### PR TITLE
chore(ts): add MaybePromise wrapper to make APIs shorter to read

### DIFF
--- a/packages/autocomplete-core/src/types/api.ts
+++ b/packages/autocomplete-core/src/types/api.ts
@@ -1,6 +1,7 @@
 import { AutocompleteAccessibilityGetters } from './getters';
 import { AutocompleteSetters } from './setters';
 import { AutocompleteState } from './state';
+import { MaybePromise } from './wrappers';
 
 export interface AutocompleteApi<
   TItem,
@@ -92,7 +93,7 @@ export interface AutocompleteSource<TItem> {
   /**
    * Function called when the input changes. You can use this function to filter/search the items based on the query.
    */
-  getSuggestions(params: GetSourcesParams<TItem>): TItem[] | Promise<TItem[]>;
+  getSuggestions(params: GetSourcesParams<TItem>): MaybePromise<TItem[]>;
   /**
    * Function called when an item is selected.
    */
@@ -163,9 +164,7 @@ export type AutocompletePlugin<TItem, TData> = {
    */
   getSources?(
     params: GetSourcesParams<TItem>
-  ):
-    | Array<AutocompleteSource<TItem>>
-    | Promise<Array<AutocompleteSource<TItem>>>;
+  ): MaybePromise<Array<AutocompleteSource<TItem>>>;
   /**
    * The function called when the autocomplete form is submitted.
    */
@@ -244,9 +243,7 @@ export interface AutocompleteOptions<TItem> {
    */
   getSources(
     params: GetSourcesParams<TItem>
-  ):
-    | Array<AutocompleteSource<TItem>>
-    | Promise<Array<AutocompleteSource<TItem>>>;
+  ): MaybePromise<Array<AutocompleteSource<TItem>>>;
   /**
    * The environment from where your JavaScript is running.
    * Useful if you're using autocomplete in a different context than

--- a/packages/autocomplete-core/src/types/wrappers.ts
+++ b/packages/autocomplete-core/src/types/wrappers.ts
@@ -1,0 +1,1 @@
+export type MaybePromise<TResolution> = Promise<TResolution> | TResolution;

--- a/packages/autocomplete-js/src/types/index.ts
+++ b/packages/autocomplete-js/src/types/index.ts
@@ -52,10 +52,7 @@ export type InternalAutocompleteSource<TItem> = InternalAutocompleteCoreSource<
 type GetSources<TItem> = (
   params: GetSourcesParams<TItem>
 ) =>
-  // TODO: decide whether:
-  // 1. find out whether GetSources in core is also Promise / nonPromise and reuse it
-  // 2. export MaybePromise from -core (but it's public API then)
-  // 3. rewrite MaybePromise here
+  // TODO: reuse MaybePromise from autocomplete-core when we find a way to share the type
   | Array<AutocompleteCoreSource<TItem>>
   | Promise<Array<AutocompleteCoreSource<TItem>>>;
 

--- a/packages/autocomplete-js/src/types/index.ts
+++ b/packages/autocomplete-js/src/types/index.ts
@@ -52,6 +52,10 @@ export type InternalAutocompleteSource<TItem> = InternalAutocompleteCoreSource<
 type GetSources<TItem> = (
   params: GetSourcesParams<TItem>
 ) =>
+  // TODO: decide whether:
+  // 1. find out whether GetSources in core is also Promise / nonPromise and reuse it
+  // 2. export MaybePromise from -core (but it's public API then)
+  // 3. rewrite MaybePromise here
   | Array<AutocompleteCoreSource<TItem>>
   | Promise<Array<AutocompleteCoreSource<TItem>>>;
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

it's complex to type when an item is either a promise or not (and after #331 maybe arrays or not) from the typings, so refactoring this into a shared type makes sense

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

add the complexity for types which are allowed to be promises or not into a single helper object