### PR TITLE
fix(refresh): remain current value of isOpen

### DIFF
--- a/packages/autocomplete-core/src/createAutocomplete.ts
+++ b/packages/autocomplete-core/src/createAutocomplete.ts
@@ -58,6 +58,9 @@ export function createAutocomplete<
       setIsOpen,
       setStatus,
       setContext,
+      nextState: {
+        isOpen: store.getState().isOpen,
+      },
       refresh,
     });
   }


### PR DESCRIPTION
## Summary

For now, `autocompleteInstance.refresh()` always open the dropdown no matter if it was already closed or not.
This PR fixes the bug so that it can remain closed if it was.