### PR TITLE
feat(core): provide previous state to `onStateChange`

### DIFF
--- a/packages/autocomplete-core/src/createStore.ts
+++ b/packages/autocomplete-core/src/createStore.ts
@@ -16,12 +16,13 @@ export function createStore<TItem>(
       return this.state;
     },
     send(action, payload) {
+      const prevState = { ...this.state };
       this.state = withCompletion(
         reducer({ type: action, value: payload }, this.state, props),
         props
       );
 
-      props.onStateChange({ state: this.state });
+      props.onStateChange({ state: this.state, prevState });
     },
   };
 }

--- a/packages/autocomplete-core/src/types/api.ts
+++ b/packages/autocomplete-core/src/types/api.ts
@@ -199,7 +199,10 @@ export interface AutocompleteOptions<TItem> {
   /**
    * Function called when the internal state changes.
    */
-  onStateChange?<TItem>(props: { state: AutocompleteState<TItem> }): void;
+  onStateChange?<TItem>(props: {
+    state: AutocompleteState<TItem>;
+    prevState: AutocompleteState<TItem>;
+  }): void;
   /**
    * The text that appears in the search box input when there is no query.
    */
@@ -285,7 +288,10 @@ export interface InternalAutocompleteOptions<TItem>
   extends AutocompleteOptions<TItem> {
   debug: boolean;
   id: string;
-  onStateChange<TItem>(props: { state: AutocompleteState<TItem> }): void;
+  onStateChange<TItem>(props: {
+    state: AutocompleteState<TItem>;
+    prevState: AutocompleteState<TItem>;
+  }): void;
   placeholder: string;
   autoFocus: boolean;
   defaultHighlightedIndex: number | null;


### PR DESCRIPTION
## Summary

This PR adds a new prop `prevState` to `onStateChange`.
With this addition, users don't have to keep track of the previous state for comparison.

For example,

```js
      onStateChange({ state }) {
        if (state.query !== queryRef.current) {
          queryRef.current = state.query;
          props.refine(state.query);
        }
      },
```

becomes

```js
      onStateChange({ state, prevState }) {
        if (state.query !== prevState.query) {
          props.refine(state.query);
        }
      },
```