### PR TITLE
fix(algolia): fix `getAlgoliaResults` typings

### DIFF
--- a/packages/autocomplete-preset-algolia/src/search/getAlgoliaHits.ts
+++ b/packages/autocomplete-preset-algolia/src/search/getAlgoliaHits.ts
@@ -2,11 +2,11 @@ import { Hit } from '@algolia/client-search';
 
 import { search, SearchParams } from './search';
 
-export function getAlgoliaHits<THit>({
+export function getAlgoliaHits<TRecord>({
   searchClient,
   queries,
-}: SearchParams): Promise<Array<Array<Hit<THit>>>> {
-  return search<THit>({ searchClient, queries }).then((response) => {
+}: SearchParams): Promise<Array<Array<Hit<TRecord>>>> {
+  return search<TRecord>({ searchClient, queries }).then((response) => {
     const results = response.results;
 
     return results.map((result) => result.hits);

--- a/packages/autocomplete-preset-algolia/src/search/getAlgoliaResults.ts
+++ b/packages/autocomplete-preset-algolia/src/search/getAlgoliaResults.ts
@@ -1,12 +1,12 @@
-import { MultipleQueriesResponse } from '@algolia/client-search';
+import { SearchResponse } from '@algolia/client-search';
 
 import { search, SearchParams } from './search';
 
-export function getAlgoliaResults<THit>({
+export function getAlgoliaResults<TRecord>({
   searchClient,
   queries,
-}: SearchParams): Promise<MultipleQueriesResponse<THit>['results']> {
-  return search<THit>({ searchClient, queries }).then((response) => {
+}: SearchParams): Promise<Array<SearchResponse<TRecord>>> {
+  return search<TRecord>({ searchClient, queries }).then((response) => {
     return response.results;
   });
 }

--- a/packages/autocomplete-preset-algolia/src/search/search.ts
+++ b/packages/autocomplete-preset-algolia/src/search/search.ts
@@ -9,12 +9,12 @@ export interface SearchParams {
   queries: MultipleQueriesQuery[];
 }
 
-export function search<THit>({ searchClient, queries }: SearchParams) {
+export function search<TRecord>({ searchClient, queries }: SearchParams) {
   if (typeof searchClient.addAlgoliaAgent === 'function') {
     searchClient.addAlgoliaAgent('autocomplete-core', version);
   }
 
-  return searchClient.search<THit>(
+  return searchClient.search<TRecord>(
     queries.map((searchParameters) => {
       const { indexName, query, params } = searchParameters;
 


### PR DESCRIPTION
This fixes some wrong types in the `getAlgoliaResults` function. We now make sure to receive records as inputs and to return hits (being their returned value with highlighting and snippetting).