### PR TITLE
fix(core): turn public `navigator` type to partial

### DIFF
--- a/packages/autocomplete-core/src/types/api.ts
+++ b/packages/autocomplete-core/src/types/api.ts
@@ -258,7 +258,7 @@ export interface AutocompleteOptions<TItem> {
   /**
    * Navigator API to redirect the user when a link should be opened.
    */
-  navigator?: Navigator<TItem>;
+  navigator?: Partial<Navigator<TItem>>;
   /**
    * The function called to determine whether the dropdown should open.
    */


### PR DESCRIPTION
We assign [default values](https://github.com/algolia/autocomplete.js/blob/637d23ecb82f88b6de686b76657fe53a8acf119d/packages/autocomplete-core/src/getDefaultProps.ts#L85-L104) for each navigator property so we expect `Partial<Navigator>`, not `Navigator` from users.
