### PR TITLE
fix: cursor stays where it's supposed to be

### DIFF
--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -59,8 +59,8 @@ export function onInput<TItem>({
     clearTimeout(lastStalledId);
   }
 
-  setHighlightedIndex(props.defaultHighlightedIndex);
   setQuery(query);
+  setHighlightedIndex(props.defaultHighlightedIndex);
 
   if (query.length === 0 && props.openOnFocus === false) {
     setStatus('idle');


### PR DESCRIPTION
## Summary

When the query is `abcdef`, and move the cursor in the middle of `input` element and type `Z`, then it will become `abcZdef`. Here the cursor is supposed to be right after `Z`, but it was wrongly moved to the end of the query.

The problem comes from the order of 

```
  setHighlightedIndex(props.defaultHighlightedIndex);
  setQuery(query);
```

When `setHighlightedIndex()` is called, the `input.value` is already `abcZdef`, but `store.getState().query` is still `abcdef` because the query hasn't been updated to the store yet.

So `input.value` becomes `abcdef`. Shortly after because of `setQuery`, `input.value` becomes `abcZdef` again.

In this PR, the order is been reversed, which now correctly sets the query first, and then proceed with the rest. It doesn't move cursor anymore.