### PR TITLE
chore: include recent searches plugin in the next release

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -7,6 +7,7 @@ const packages = [
   'packages/autocomplete-core',
   'packages/autocomplete-preset-algolia',
   'packages/autocomplete-js',
+  'packages/autocomplete-plugin-recent-searches',
 ];
 
 module.exports = {


### PR DESCRIPTION
## Summary

This PR includes `@algolia/autocomplete-plugin-recent-searches` in the shipjs config.