### PR TITLE
docs: rename the assigned variable

### DIFF
--- a/packages/website/docs/autocomplete-js.md
+++ b/packages/website/docs/autocomplete-js.md
@@ -24,7 +24,7 @@ const searchClient = algoliasearch(
   '6be0576ff61c053d5f9a3225e2a90f76'
 );
 
-const autocomplete = autocomplete({
+const autocompleteSearch = autocomplete({
   container: '#autocomplete',
   getSources() {
     return [

--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -304,7 +304,7 @@ const searchClient = algoliasearch(
   '6be0576ff61c053d5f9a3225e2a90f76'
 );
 
-const autocomplete = autocomplete({
+const autocompleteSearch = autocomplete({
   container: '#autocomplete',
   getSources() {
     return [


### PR DESCRIPTION
This PR fixes `autocomplete = autocomplete(` error.