### PR TITLE
feat(core): remove `statusContext` API

### DIFF
--- a/packages/autocomplete-core/src/getDefaultProps.ts
+++ b/packages/autocomplete-core/src/getDefaultProps.ts
@@ -38,7 +38,6 @@ export function getDefaultProps<TItem>(
       collections: [],
       isOpen: false,
       status: 'idle',
-      statusContext: {},
       context: {},
       ...props.initialState,
     },

--- a/packages/autocomplete-core/src/stateReducer.ts
+++ b/packages/autocomplete-core/src/stateReducer.ts
@@ -84,7 +84,6 @@ export const stateReducer: Reducer = (state, action) => {
         ...state,
         query: '',
         status: 'idle',
-        statusContext: {},
         collections: [],
       };
     }
@@ -95,7 +94,6 @@ export const stateReducer: Reducer = (state, action) => {
         selectedItemId: null,
         isOpen: false,
         status: 'idle',
-        statusContext: {},
       };
     }
 
@@ -113,7 +111,6 @@ export const stateReducer: Reducer = (state, action) => {
             : null,
         isOpen: action.props.openOnFocus, // @TODO: Check with UX team if we want to close the menu on reset.
         status: 'idle',
-        statusContext: {},
         query: '',
       };
     }

--- a/packages/autocomplete-core/src/types/state.ts
+++ b/packages/autocomplete-core/src/types/state.ts
@@ -7,8 +7,5 @@ export interface AutocompleteState<TItem> {
   collections: Array<AutocompleteCollection<TItem>>;
   isOpen: boolean;
   status: 'idle' | 'loading' | 'stalled' | 'error';
-  statusContext: {
-    error?: Error;
-  };
   context: { [key: string]: unknown };
 }


### PR DESCRIPTION
This removes the undocumented `statusContext` API.

This state property was originally added to my POC to track which error happened last in the lifecycle. Since we don't leverage this for now, let's remove it. If users express the need for such a feature, we can add the feature back.