### PR TITLE
chore(ci): use branch sandbox on deployments

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -2,5 +2,5 @@
   "packages": ["packages/autocomplete-*"],
   "buildCommand": false,
   "^": "buildCommand is false because `yarn prepare` is going to build packages anyway.",
-  "sandboxes": ["github/algolia/autocomplete.js/tree/next/examples/js"]
+  "sandboxes": ["/examples/js"]
 }


### PR DESCRIPTION
This will use the playground from the local code rather than from the next branch in our PRs.