### PR TITLE
docs(example): provide `__DEV__` replacement

### DIFF
--- a/examples/js/index.html
+++ b/examples/js/index.html
@@ -13,6 +13,7 @@
       <div id="autocomplete"></div>
     </div>
 
+    <script src="index.ts"></script>
     <script src="app.ts"></script>
   </body>
 </html>

--- a/examples/js/index.ts
+++ b/examples/js/index.ts
@@ -1,0 +1,5 @@
+// Parcel picks the `source` field of the monorepo packages and thus doesn't
+// apply the Babel config to replace our `__DEV__` global expression.
+// We therefore need to manually override it in the example app.
+// See https://twitter.com/devongovett/status/1134231234605830144
+(global as any).__DEV__ = process.env.NODE_ENV !== 'production';


### PR DESCRIPTION
Parcel picks the `source` field of the monorepo packages and thus doesn't apply the Babel config to replace our `__DEV__` global expression. We therefore need to manually override it in the example app.

See https://twitter.com/devongovett/status/1134231234605830144