### PR TITLE
feat(recent-searches): add search highlighting

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "packages/autocomplete-plugin-recent-searches/dist/umd/index.production.js",
-      "maxSize": "2.5 kB"
+      "maxSize": "3 kB"
     },
     {
       "path": "packages/autocomplete-plugin-query-suggestions/dist/umd/index.production.js",

--- a/packages/autocomplete-plugin-recent-searches/src/createLocalStorageRecentSearchesPlugin.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/createLocalStorageRecentSearchesPlugin.ts
@@ -5,7 +5,7 @@ import {
   CreateRecentSearchesPluginParams,
   RecentSearchesPluginData,
 } from './createRecentSearchesPlugin';
-import { RecentSearchesItem } from './types';
+import { Highlighted, RecentSearchesItem } from './types';
 import {
   LOCAL_STORAGE_KEY,
   createLocalStorage,
@@ -33,7 +33,7 @@ export type CreateRecentSearchesLocalStorageOptions<
   /**
    * Function to search in the recent items.
    */
-  search?(params: SearchParams<TItem>): TItem[];
+  search?(params: SearchParams<TItem>): Array<Highlighted<TItem>>;
 };
 
 type LocalStorageRecentSearchesPluginOptions<

--- a/packages/autocomplete-plugin-recent-searches/src/createStore.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/createStore.ts
@@ -1,6 +1,6 @@
 import { MaybePromise } from '@algolia/autocomplete-shared';
 
-import { RecentSearchesItem } from './types/RecentSearchesItem';
+import { Highlighted, RecentSearchesItem } from './types';
 
 export type RecentSearchesStore<TItem extends RecentSearchesItem> = {
   add(item: TItem): void;
@@ -11,7 +11,7 @@ export type RecentSearchesStore<TItem extends RecentSearchesItem> = {
 export type RecentSearchesStorage<TItem extends RecentSearchesItem> = {
   onAdd(item: TItem): void;
   onRemove(id: string): void;
-  getAll(query?: string): MaybePromise<TItem[]>;
+  getAll(query?: string): MaybePromise<Array<Highlighted<TItem>>>;
 };
 
 export function createStore<TItem extends RecentSearchesItem>(

--- a/packages/autocomplete-plugin-recent-searches/src/getTemplates.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/getTemplates.ts
@@ -1,4 +1,4 @@
-import { SourceTemplates } from '@algolia/autocomplete-js';
+import { SourceTemplates, reverseHighlightHit } from '@algolia/autocomplete-js';
 
 import { recentIcon, resetIcon } from './icons';
 import { RecentSearchesItem } from './types';
@@ -19,7 +19,10 @@ export function getTemplates<TItem extends RecentSearchesItem>({
       icon.innerHTML = recentIcon;
       const title = document.createElement('div');
       title.className = 'aa-ItemTitle';
-      title.innerText = item.query;
+      title.innerHTML = reverseHighlightHit({
+        hit: item as any,
+        attribute: 'query',
+      });
       content.appendChild(icon);
       content.appendChild(title);
 

--- a/packages/autocomplete-plugin-recent-searches/src/types/Highlighted.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/types/Highlighted.ts
@@ -1,0 +1,7 @@
+export type Highlighted<TItem> = TItem & {
+  _highlightResult: {
+    query: {
+      value: string;
+    };
+  };
+};

--- a/packages/autocomplete-plugin-recent-searches/src/types/RecentSearchesHit.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/types/RecentSearchesHit.ts
@@ -1,0 +1,9 @@
+import { RecentSearchesItem } from './RecentSearchesItem';
+
+export type RecentSearchesHit = RecentSearchesItem & {
+  _highlightResult: {
+    query: {
+      value: string;
+    };
+  };
+};

--- a/packages/autocomplete-plugin-recent-searches/src/types/RecentSearchesHit.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/types/RecentSearchesHit.ts
@@ -1,9 +1,0 @@
-import { RecentSearchesItem } from './RecentSearchesItem';
-
-export type RecentSearchesHit = RecentSearchesItem & {
-  _highlightResult: {
-    query: {
-      value: string;
-    };
-  };
-};

--- a/packages/autocomplete-plugin-recent-searches/src/types/index.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/types/index.ts
@@ -1,1 +1,2 @@
+export * from './RecentSearchesHit';
 export * from './RecentSearchesItem';

--- a/packages/autocomplete-plugin-recent-searches/src/types/index.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/types/index.ts
@@ -1,2 +1,2 @@
-export * from './RecentSearchesHit';
+export * from './Highlighted';
 export * from './RecentSearchesItem';

--- a/packages/autocomplete-plugin-recent-searches/src/usecases/localStorage/search.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/usecases/localStorage/search.ts
@@ -36,11 +36,11 @@ export function search<TItem extends RecentSearchesItem>({
   limit,
 }: SearchParams<TItem>): Array<Highlighted<TItem>> {
   if (!query) {
-    return items.map((item) => highlight({ item, query })).slice(0, limit);
+    return items.slice(0, limit).map((item) => highlight({ item, query }));
   }
 
   return items
     .filter((item) => item.query.toLowerCase().includes(query.toLowerCase()))
-    .map((item) => highlight({ item, query }))
-    .slice(0, limit);
+    .slice(0, limit)
+    .map((item) => highlight({ item, query }));
 }

--- a/packages/autocomplete-plugin-recent-searches/src/usecases/localStorage/search.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/usecases/localStorage/search.ts
@@ -1,4 +1,4 @@
-import { RecentSearchesHit, RecentSearchesItem } from '../../types';
+import { Highlighted, RecentSearchesItem } from '../../types';
 
 type HighlightParams<TItem> = {
   item: TItem;
@@ -8,7 +8,7 @@ type HighlightParams<TItem> = {
 function highlight<TItem extends RecentSearchesItem>({
   item,
   query,
-}: HighlightParams<TItem>) {
+}: HighlightParams<TItem>): Highlighted<TItem> {
   return {
     ...item,
     _highlightResult: {
@@ -34,7 +34,7 @@ export function search<TItem extends RecentSearchesItem>({
   query,
   items,
   limit,
-}: SearchParams<TItem>): RecentSearchesHit[] {
+}: SearchParams<TItem>): Array<Highlighted<TItem>> {
   if (!query) {
     return items.map((item) => highlight({ item, query })).slice(0, limit);
   }

--- a/packages/autocomplete-plugin-recent-searches/src/usecases/localStorage/search.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/usecases/localStorage/search.ts
@@ -1,4 +1,28 @@
-import { RecentSearchesItem } from '../../types';
+import { RecentSearchesHit, RecentSearchesItem } from '../../types';
+
+type HighlightParams<TItem> = {
+  item: TItem;
+  query: string;
+};
+
+function highlight<TItem extends RecentSearchesItem>({
+  item,
+  query,
+}: HighlightParams<TItem>) {
+  return {
+    ...item,
+    _highlightResult: {
+      query: {
+        value: query
+          ? item.query.replace(
+              new RegExp(query, 'g'),
+              `__aa-highlight__${query}__/aa-highlight__`
+            )
+          : item.query,
+      },
+    },
+  };
+}
 
 export type SearchParams<TItem> = {
   query: string;
@@ -10,12 +34,13 @@ export function search<TItem extends RecentSearchesItem>({
   query,
   items,
   limit,
-}: SearchParams<TItem>) {
+}: SearchParams<TItem>): RecentSearchesHit[] {
   if (!query) {
-    return items.slice(0, limit);
+    return items.map((item) => highlight({ item, query })).slice(0, limit);
   }
 
   return items
-    .filter((item) => item.query.toLowerCase().startsWith(query.toLowerCase()))
+    .filter((item) => item.query.toLowerCase().includes(query.toLowerCase()))
+    .map((item) => highlight({ item, query }))
     .slice(0, limit);
 }


### PR DESCRIPTION
This adds support for search highlighting in the Recent Searches.

## Preview

![image](https://user-images.githubusercontent.com/6137112/98940259-041f3280-24eb-11eb-8ec2-a2c216b7a249.png)

![image](https://user-images.githubusercontent.com/6137112/98940266-071a2300-24eb-11eb-9a6c-909174d05f6a.png)
