### PR TITLE
fix(js): calculate panel position before opening

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   extends: ['algolia', 'algolia/jest', 'algolia/react', 'algolia/typescript'],
   globals: {
     __DEV__: false,
+    __TEST__: false,
   },
   settings: {
     react: {

--- a/babel.config.js
+++ b/babel.config.js
@@ -31,6 +31,10 @@ module.exports = (api) => {
             type: 'node',
             replacement: "process.env.NODE_ENV !== 'production'",
           },
+          __TEST__: {
+            type: 'node',
+            replacement: "process.env.NODE_ENV === 'test'",
+          },
         },
       ],
     ]),

--- a/examples/js/env.ts
+++ b/examples/js/env.ts
@@ -3,3 +3,4 @@
 // We therefore need to manually override it in the example app.
 // See https://twitter.com/devongovett/status/1134231234605830144
 (global as any).__DEV__ = process.env.NODE_ENV !== 'production';
+(global as any).__TEST__ = false;

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,5 +11,6 @@ module.exports = {
   ],
   globals: {
     __DEV__: true,
+    __TEST__: true,
   },
 };

--- a/packages/autocomplete-js/global.d.ts
+++ b/packages/autocomplete-js/global.d.ts
@@ -1,2 +1,1 @@
-declare const __DEV__: boolean;
 declare const __TEST__: boolean;

--- a/packages/autocomplete-js/src/__tests__/fixtures/query-suggestions.json
+++ b/packages/autocomplete-js/src/__tests__/fixtures/query-suggestions.json
@@ -1,0 +1,387 @@
+[
+  {
+    "instant_search": {
+      "exact_nb_hits": 260,
+      "facets": {
+        "exact_matches": {
+          "categories": [
+            {
+              "value": "Appliances",
+              "count": 252
+            },
+            {
+              "value": "Ranges, Cooktops & Ovens",
+              "count": 229
+            }
+          ],
+          "hierarchicalCategories.lvl0": [
+            {
+              "value": "Appliances",
+              "count": 252
+            }
+          ],
+          "hierarchicalCategories.lvl1": [
+            {
+              "value": "Appliances > Ranges, Cooktops & Ovens",
+              "count": 229
+            }
+          ],
+          "hierarchicalCategories.lvl2": [
+            {
+              "value": "Appliances > Ranges, Cooktops & Ovens > Cooktops",
+              "count": 137
+            }
+          ]
+        },
+        "analytics": {
+          "categories": [],
+          "hierarchicalCategories.lvl0": [],
+          "hierarchicalCategories.lvl1": [
+            {
+              "attribute": "hierarchicalCategories.lvl1",
+              "operator": ":",
+              "value": "Appliances > Ranges, Cooktops & Ovens",
+              "count": 1756
+            }
+          ],
+          "hierarchicalCategories.lvl2": []
+        }
+      }
+    },
+    "nb_words": 1,
+    "popularity": 1230,
+    "query": "cooktop",
+    "objectID": "cooktop",
+    "_highlightResult": {
+      "query": {
+        "value": "cooktop",
+        "matchLevel": "none",
+        "matchedWords": []
+      }
+    }
+  },
+  {
+    "instant_search": {
+      "exact_nb_hits": 151,
+      "facets": {
+        "exact_matches": {
+          "categories": [
+            {
+              "value": "Computers & Tablets",
+              "count": 142
+            },
+            {
+              "value": "Laptop Accessories",
+              "count": 106
+            }
+          ],
+          "hierarchicalCategories.lvl0": [
+            {
+              "value": "Computers & Tablets",
+              "count": 142
+            }
+          ],
+          "hierarchicalCategories.lvl1": [
+            {
+              "value": "Computers & Tablets > Laptop Accessories",
+              "count": 106
+            }
+          ],
+          "hierarchicalCategories.lvl2": [
+            {
+              "value": "Computers & Tablets > Laptop Accessories > Laptop Bags & Cases",
+              "count": 88
+            }
+          ]
+        },
+        "analytics": {
+          "categories": [],
+          "hierarchicalCategories.lvl0": [],
+          "hierarchicalCategories.lvl1": [],
+          "hierarchicalCategories.lvl2": []
+        }
+      }
+    },
+    "nb_words": 1,
+    "popularity": 700,
+    "query": "macbook",
+    "objectID": "macbook",
+    "_highlightResult": {
+      "query": {
+        "value": "macbook",
+        "matchLevel": "none",
+        "matchedWords": []
+      }
+    }
+  },
+  {
+    "instant_search": {
+      "exact_nb_hits": 1179,
+      "facets": {
+        "exact_matches": {
+          "categories": [
+            {
+              "value": "Cell Phones",
+              "count": 385
+            },
+            {
+              "value": "Cell Phone Accessories",
+              "count": 237
+            }
+          ],
+          "hierarchicalCategories.lvl0": [
+            {
+              "value": "Cell Phones",
+              "count": 385
+            }
+          ],
+          "hierarchicalCategories.lvl1": [
+            {
+              "value": "Cell Phones > Cell Phone Accessories",
+              "count": 237
+            }
+          ],
+          "hierarchicalCategories.lvl2": [
+            {
+              "value": "Cameras & Camcorders > Digital Camera Accessories > Camera Batteries & Power",
+              "count": 111
+            }
+          ]
+        },
+        "analytics": {
+          "categories": [],
+          "hierarchicalCategories.lvl0": [],
+          "hierarchicalCategories.lvl1": [],
+          "hierarchicalCategories.lvl2": []
+        }
+      }
+    },
+    "nb_words": 1,
+    "popularity": 536,
+    "query": "battery",
+    "objectID": "battery",
+    "_highlightResult": {
+      "query": {
+        "value": "battery",
+        "matchLevel": "none",
+        "matchedWords": []
+      }
+    }
+  },
+  {
+    "instant_search": {
+      "exact_nb_hits": 79,
+      "facets": {
+        "exact_matches": {
+          "categories": [
+            {
+              "value": "Computers & Tablets",
+              "count": 52
+            },
+            {
+              "value": "Tablets",
+              "count": 23
+            }
+          ],
+          "hierarchicalCategories.lvl0": [
+            {
+              "value": "Computers & Tablets",
+              "count": 52
+            }
+          ],
+          "hierarchicalCategories.lvl1": [
+            {
+              "value": "Computers & Tablets > Tablets",
+              "count": 23
+            }
+          ],
+          "hierarchicalCategories.lvl2": [
+            {
+              "value": "Computers & Tablets > Tablets > All Tablets",
+              "count": 22
+            }
+          ]
+        },
+        "analytics": {
+          "categories": [],
+          "hierarchicalCategories.lvl0": [],
+          "hierarchicalCategories.lvl1": [],
+          "hierarchicalCategories.lvl2": []
+        }
+      }
+    },
+    "nb_words": 1,
+    "popularity": 407,
+    "query": "amazon",
+    "objectID": "amazon",
+    "_highlightResult": {
+      "query": {
+        "value": "amazon",
+        "matchLevel": "none",
+        "matchedWords": []
+      }
+    }
+  },
+  {
+    "instant_search": {
+      "exact_nb_hits": 116,
+      "facets": {
+        "exact_matches": {
+          "categories": [
+            {
+              "value": "Cell Phones",
+              "count": 54
+            },
+            {
+              "value": "Cell Phone Accessories",
+              "count": 41
+            }
+          ],
+          "hierarchicalCategories.lvl0": [
+            {
+              "value": "Cell Phones",
+              "count": 54
+            }
+          ],
+          "hierarchicalCategories.lvl1": [
+            {
+              "value": "Cell Phones > Cell Phone Accessories",
+              "count": 41
+            }
+          ],
+          "hierarchicalCategories.lvl2": [
+            {
+              "value": "Cell Phones > Cell Phone Accessories > Cell Phone Cases & Clips",
+              "count": 29
+            }
+          ]
+        },
+        "analytics": {
+          "categories": [],
+          "hierarchicalCategories.lvl0": [],
+          "hierarchicalCategories.lvl1": [],
+          "hierarchicalCategories.lvl2": []
+        }
+      }
+    },
+    "nb_words": 1,
+    "popularity": 149,
+    "query": "google",
+    "objectID": "google",
+    "_highlightResult": {
+      "query": {
+        "value": "google",
+        "matchLevel": "none",
+        "matchedWords": []
+      }
+    }
+  },
+  {
+    "instant_search": {
+      "exact_nb_hits": 1205,
+      "facets": {
+        "exact_matches": {
+          "categories": [
+            {
+              "value": "Cell Phones",
+              "count": 639
+            },
+            {
+              "value": "Cell Phone Accessories",
+              "count": 554
+            }
+          ],
+          "hierarchicalCategories.lvl0": [
+            {
+              "value": "Cell Phones",
+              "count": 639
+            }
+          ],
+          "hierarchicalCategories.lvl1": [
+            {
+              "value": "Cell Phones > Cell Phone Accessories",
+              "count": 554
+            }
+          ],
+          "hierarchicalCategories.lvl2": [
+            {
+              "value": "Cell Phones > Cell Phone Accessories > Cell Phone Cases & Clips",
+              "count": 450
+            }
+          ]
+        },
+        "analytics": {
+          "categories": [],
+          "hierarchicalCategories.lvl0": [],
+          "hierarchicalCategories.lvl1": [],
+          "hierarchicalCategories.lvl2": []
+        }
+      }
+    },
+    "nb_words": 1,
+    "popularity": 125,
+    "query": "samsung",
+    "objectID": "samsung",
+    "_highlightResult": {
+      "query": {
+        "value": "samsung",
+        "matchLevel": "none",
+        "matchedWords": []
+      }
+    }
+  },
+  {
+    "instant_search": {
+      "exact_nb_hits": 1659,
+      "facets": {
+        "exact_matches": {
+          "categories": [
+            {
+              "value": "Cell Phones",
+              "count": 1509
+            },
+            {
+              "value": "Cell Phone Accessories",
+              "count": 1370
+            }
+          ],
+          "hierarchicalCategories.lvl0": [
+            {
+              "value": "Cell Phones",
+              "count": 1509
+            }
+          ],
+          "hierarchicalCategories.lvl1": [
+            {
+              "value": "Cell Phones > Cell Phone Accessories",
+              "count": 1370
+            }
+          ],
+          "hierarchicalCategories.lvl2": [
+            {
+              "value": "Cell Phones > Cell Phone Accessories > Cell Phone Cases & Clips",
+              "count": 607
+            }
+          ]
+        },
+        "analytics": {
+          "categories": [],
+          "hierarchicalCategories.lvl0": [],
+          "hierarchicalCategories.lvl1": [],
+          "hierarchicalCategories.lvl2": []
+        }
+      }
+    },
+    "nb_words": 1,
+    "popularity": 124,
+    "query": "iphone",
+    "objectID": "iphone",
+    "_highlightResult": {
+      "query": {
+        "value": "iphone",
+        "matchLevel": "none",
+        "matchedWords": []
+      }
+    }
+  }
+]

--- a/packages/autocomplete-js/src/__tests__/positioning.test.ts
+++ b/packages/autocomplete-js/src/__tests__/positioning.test.ts
@@ -1,0 +1,163 @@
+import { AutocompletePlugin } from '@algolia/autocomplete-core';
+import { waitFor, getByTestId } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
+
+import { autocomplete } from '../';
+
+import querySuggestions from './fixtures/query-suggestions.json';
+
+type QuerySuggestionFacetMatch = {
+  value: string;
+  count: number;
+};
+type QuerySuggestionsHit = {
+  instant_search: {
+    exact_nb_hits: number;
+    facets: {
+      exact_matches: {
+        categories: QuerySuggestionFacetMatch[];
+        'hierarchicalCategories.lvl0': QuerySuggestionFacetMatch[];
+        'hierarchicalCategories.lvl1': QuerySuggestionFacetMatch[];
+        'hierarchicalCategories.lvl2': QuerySuggestionFacetMatch[];
+      };
+    };
+  };
+  nb_words: number;
+  popularity: number;
+  query: string;
+  objectID: string;
+};
+
+const querySuggestionsFixturePlugin: AutocompletePlugin<
+  QuerySuggestionsHit,
+  undefined
+> = {
+  getSources() {
+    return [
+      {
+        getItems() {
+          return querySuggestions;
+        },
+        templates: {
+          item({ item }) {
+            return item.query;
+          },
+        },
+      },
+    ];
+  },
+};
+
+describe('Panel positioning', () => {
+  const rootPosition = {
+    bottom: 0,
+    height: 40,
+    left: 300,
+    right: 990,
+    top: 20,
+    width: 600,
+    x: 300,
+    y: 40,
+  };
+  const formPosition = {
+    bottom: 0,
+    height: 40,
+    left: 300,
+    right: 990,
+    top: 20,
+    width: 600,
+    x: 300,
+    y: 40,
+  };
+
+  beforeAll(() => {
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      writable: true,
+      configurable: true,
+      value: 1920,
+    });
+    Object.defineProperty(document.documentElement, 'clientHeight', {
+      writable: true,
+      configurable: true,
+      value: 1080,
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('positions the panel below the root element', async () => {
+    const container = document.createElement('div');
+    const panelContainer = document.body;
+    document.body.appendChild(container);
+
+    autocomplete({
+      id: 'autocomplete-0',
+      container,
+      panelContainer,
+      plugins: [querySuggestionsFixturePlugin],
+    });
+
+    const root = document.querySelector<HTMLDivElement>('.aa-Autocomplete');
+    root.getBoundingClientRect = jest.fn().mockReturnValue(rootPosition);
+    const form = document.querySelector<HTMLFormElement>('.aa-Form');
+    form.getBoundingClientRect = jest.fn().mockReturnValue(formPosition);
+
+    const input = document.querySelector<HTMLInputElement>('.aa-Input');
+    userEvent.type(input, 'a');
+
+    await waitFor(() => getByTestId(panelContainer, 'panel'));
+
+    expect(getByTestId(panelContainer, 'panel')).toHaveStyle({
+      top: '60px',
+      left: '300px',
+      right: '1020px',
+    });
+  });
+
+  test('repositions the panel below the root element after a UI change', async () => {
+    const container = document.createElement('div');
+    const panelContainer = document.body;
+    document.body.appendChild(container);
+
+    autocomplete({
+      id: 'autocomplete-0',
+      container,
+      panelContainer,
+      plugins: [querySuggestionsFixturePlugin],
+    });
+
+    const root = document.querySelector<HTMLDivElement>('.aa-Autocomplete');
+    root.getBoundingClientRect = jest.fn().mockReturnValue(rootPosition);
+    const form = document.querySelector<HTMLFormElement>('.aa-Form');
+    form.getBoundingClientRect = jest.fn().mockReturnValue(formPosition);
+
+    const input = document.querySelector<HTMLInputElement>('.aa-Input');
+    userEvent.type(input, 'a');
+
+    await waitFor(() => getByTestId(panelContainer, 'panel'));
+
+    expect(getByTestId(panelContainer, 'panel')).toHaveStyle({
+      top: '60px',
+      left: '300px',
+      right: '1020px',
+    });
+
+    input.blur();
+
+    // Move the root vertically
+    root.getBoundingClientRect = jest.fn().mockReturnValue({
+      ...rootPosition,
+      top: 40,
+    });
+
+    input.focus();
+
+    expect(getByTestId(panelContainer, 'panel')).toHaveStyle({
+      top: '80px',
+      left: '300px',
+      right: '1020px',
+    });
+  });
+});

--- a/packages/autocomplete-js/src/components/Panel.ts
+++ b/packages/autocomplete-js/src/components/Panel.ts
@@ -17,5 +17,11 @@ export const Panel: Component<PanelProps, HTMLDivElement> = ({
     class: concatClassNames(['aa-Panel', classNames.panel]),
   });
 
+  if (__TEST__) {
+    setProperties(element, {
+      'data-testid': 'panel',
+    });
+  }
+
   return element;
 };

--- a/packages/autocomplete-js/src/getPanelPositionStyle.ts
+++ b/packages/autocomplete-js/src/getPanelPositionStyle.ts
@@ -1,14 +1,19 @@
 import { AutocompleteOptions } from './types';
 
+type GetPanelPositionStyleParams = Pick<
+  AutocompleteOptions<any>,
+  'panelPlacement' | 'environment'
+> & {
+  container: HTMLElement;
+  form: HTMLElement;
+};
+
 export function getPanelPositionStyle({
   panelPlacement,
   container,
-  inputWrapper,
+  form,
   environment = window,
-}: Partial<AutocompleteOptions<any>> & {
-  container: HTMLElement;
-  inputWrapper: HTMLElement;
-}) {
+}: GetPanelPositionStyleParams) {
   const containerRect = container.getBoundingClientRect();
   const top = containerRect.top + containerRect.height;
 
@@ -42,14 +47,14 @@ export function getPanelPositionStyle({
     }
 
     case 'input-wrapper-width': {
-      const inputWrapperRect = inputWrapper.getBoundingClientRect();
+      const formRect = form.getBoundingClientRect();
 
       return {
         top,
-        left: inputWrapperRect.left,
+        left: formRect.left,
         right:
           environment.document.documentElement.clientWidth -
-          (inputWrapperRect.left + inputWrapperRect.width),
+          (formRect.left + formRect.width),
         // @TODO [IE support] IE doesn't support `"unset"`
         // See https://caniuse.com/#feat=css-unset-value
         width: 'unset',


### PR DESCRIPTION
This PR makes sure that the panel position always remains below the root element, even after a UI change.

We used to calculate the position of the panel only when the library was instantiated. We now recalculate its position when it needs to be opened.