### PR TITLE
feat(js): ESLint error fixes

### DIFF
--- a/packages/website/docs/creating-a-renderer.md
+++ b/packages/website/docs/creating-a-renderer.md
@@ -99,20 +99,18 @@ function Autocomplete() {
               <section key={`source-${index}`} className="aa-Source">
                 {items.length > 0 && (
                   <ul className="aa-List" {...autocomplete.getListProps()}>
-                    {items.map((item, index) => {
-                      return (
-                        <li
-                          key={item.objectID}
-                          className="aa-Item"
-                          {...autocomplete.getItemProps({
-                            item,
-                            source,
-                          })}
-                        >
-                          {item.query}
-                        </li>
-                      );
-                    })}
+                    {items.map((item) => (
+                      <li
+                        key={item.objectID}
+                        className="aa-Item"
+                        {...autocomplete.getItemProps({
+                          item,
+                          source,
+                        })}
+                      >
+                        {item.query}
+                      </li>
+                    ))}
                   </ul>
                 )}
               </section>


### PR DESCRIPTION
Line 102 - removed the block wrapper to fix an "Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`" error.
Line 102 - removed reference to index to fix the "'index' is already declared in the upper scope" and "'index' is defined but never used" errors.