### PR TITLE
fix(recent-searches): escape highlighted query regex

### DIFF
--- a/packages/autocomplete-plugin-recent-searches/src/usecases/localStorage/search.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/usecases/localStorage/search.ts
@@ -14,8 +14,8 @@ function highlight<TItem extends RecentSearchesItem>({
     _highlightResult: {
       query: {
         value: query
-          ? item.query.replace(
-              new RegExp(query, 'g'),
+          ? item.query.replaceAll(
+              query,
               `__aa-highlight__${query}__/aa-highlight__`
             )
           : item.query,

--- a/packages/autocomplete-plugin-recent-searches/src/usecases/localStorage/search.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/usecases/localStorage/search.ts
@@ -14,8 +14,8 @@ function highlight<TItem extends RecentSearchesItem>({
     _highlightResult: {
       query: {
         value: query
-          ? item.query.replaceAll(
-              query,
+          ? item.query.replace(
+              new RegExp(query.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&'), 'g'),
               `__aa-highlight__${query}__/aa-highlight__`
             )
           : item.query,


### PR DESCRIPTION
**Summary**
The previous RegEx was not escaping parentheses or question marks in recent searches.

**Actual behavior**
- Parentheses: Throw an error when a parenthesis is typed `invalid regex`
- Question marks: Duplicates the question mark when it's typed (e.g. with query `Amazon?` result is `Amazon??`)
and then throwing error while trying to replace the `item.query