### PR TITLE
docs: rewrite "Integrating keyboard navigation"

### DIFF
--- a/packages/website/docs/keyboard-navigation.md
+++ b/packages/website/docs/keyboard-navigation.md
@@ -3,20 +3,21 @@ id: keyboard-navigation
 title: Integrating keyboard navigation
 ---
 
-The Navigator API is used to redirect users when a suggestion link is opened programmatically using keyboard navigation.
+The Navigator API redirects users when opening a suggestion using their keyboard.
 
-This API defines how a URL should be opened with different key modifiers:
+**Keyboard navigation is essential to a satisfying autocomplete experience.** This is one of the most important aspects of web accessibility: users should be able to interact with an autocomplete without using their mouse or trackpad.
 
-- **In the current tab** triggered on <kbd>Enter</kbd>
-- **In a new tab** triggered on <kbd>⌘ Cmd</kbd>+<kbd>Enter</kbd> or <kbd>Ctrl</kbd>+<kbd>Enter</kbd>.
-- **In a new window** triggered on <kbd>⇧ Shift</kbd>+<kbd>Enter</kbd>
+Autocomplete provides keyboard accessibility out of the box and lets you define how to navigate to results without leaving the keyboard using the Navigator API.
 
-<!-- prettier-ignore -->
-:::important
-To activate keyboard navigation, use [`getItemUrl`](createAutocomplete#getitemurl) in your source to provide the value to process as a URL. This indicates the navigator API which links to open on <kbd>Enter</kbd>.
-:::
+The API defines three navigation schemes based on key combinations:
 
-## Example
+- **In the current tab** when hitting <kbd>Enter</kbd>
+- **In a new tab** when hitting <kbd>⌘ Cmd</kbd>+<kbd>Enter</kbd> or <kbd>Ctrl</kbd>+<kbd>Enter</kbd>
+- **In a new window** when hitting <kbd>⇧ Shift</kbd>+<kbd>Enter</kbd>
+
+## Usage
+
+To activate keyboard navigation, you need to implement a [`getItemUrl`](createAutocomplete#getitemurl) function in each of your [sources](/docs/sources) to provide the URL to navigate to. It tells the Navigator API which link to open on <kbd>Enter</kbd>.
 
 ```js {6-8}
 const autocomplete = createAutocomplete({
@@ -33,7 +34,7 @@ const autocomplete = createAutocomplete({
       },
     ];
   },
-  // Default navigator values
+  // Default Navigator API implementation
   navigator: {
     navigate({ itemUrl }) {
       window.location.assign(itemUrl);
@@ -52,7 +53,9 @@ const autocomplete = createAutocomplete({
 });
 ```
 
-If you use autocomplete in a [Gatsby](https://www.gatsbyjs.org/) website, you can leverage their [`navigate`](https://www.gatsbyjs.org/docs/gatsby-link/) API to avoid hard refreshes.
+By default, the Navigator API uses the [`Location`](https://developer.mozilla.org/en-US/docs/Web/API/Location) API (see default implementation above). If you're relying on native document-based routing, this should work out of the box. If you're using custom client-side routing, you can use the Navigator API to connect your autocomplete with it.
+
+For example, if you're using Autocomplete in a [Gatsby](https://www.gatsbyjs.org/) website, you can leverage their [`navigate`](https://www.gatsbyjs.org/docs/gatsby-link/) helper to navigate to internal pages without refreshing the page.
 
 ```js
 import { navigate } from 'gatsby';
@@ -66,15 +69,15 @@ const autocomplete = createAutocomplete({
 });
 ```
 
-## Params
+## Parameters
 
-The provided params get merged with the default configuration so that you don't have to rewrite all methods.
+Autocomplete merges the provided parameters with the default configuration, so you can only rewrite what you need.
 
 ### `navigate`
 
 > `(params: { itemUrl: string, item: TItem, state: AutocompleteState<TItem> }) => void`
 
-Function called when a URL should be open in the current page.
+The function called when a URL should open in the current page.
 
 This is triggered on <kbd>Enter</kbd>.
 
@@ -82,7 +85,7 @@ This is triggered on <kbd>Enter</kbd>.
 
 > `(params: { itemUrl: string, item: TItem, state: AutocompleteState<TItem> }) => void`
 
-Function called when a URL should be open in a new tab.
+The function called when a URL should open in a new tab.
 
 This is triggered on <kbd>⌘ Cmd</kbd>+<kbd>Enter</kbd> or <kbd>Ctrl</kbd>+<kbd>Enter</kbd>.
 
@@ -90,6 +93,6 @@ This is triggered on <kbd>⌘ Cmd</kbd>+<kbd>Enter</kbd> or <kbd>Ctrl</kbd>+<kbd
 
 > `(params: { itemUrl: string, item: TItem, state: AutocompleteState<TItem> }) => void`
 
-Function called when a URL should be open in a new window.
+The function called when a URL should open in a new window.
 
 This is triggered on <kbd>⇧ Shift</kbd>+<kbd>Enter</kbd>.

--- a/packages/website/docs/keyboard-navigation.md
+++ b/packages/website/docs/keyboard-navigation.md
@@ -5,9 +5,9 @@ title: Integrating keyboard navigation
 
 The Navigator API redirects users when opening a suggestion using their keyboard.
 
-**Keyboard navigation is essential to a satisfying autocomplete experience.** This is one of the most important aspects of web accessibility: users should be able to interact with an autocomplete without using their mouse or trackpad.
+**Keyboard navigation is essential to a satisfying autocomplete experience.** This is one of the most important aspects of web accessibility: users should be able to interact with an autocomplete without using a mouse or trackpad.
 
-Autocomplete provides keyboard accessibility out of the box and lets you define how to navigate to results without leaving the keyboard using the Navigator API.
+Autocomplete provides keyboard accessibility out of the box and lets you define how to navigate to results without leaving the keyboard.
 
 The API defines three navigation schemes based on key combinations:
 

--- a/packages/website/docs/keyboard-navigation.md
+++ b/packages/website/docs/keyboard-navigation.md
@@ -69,7 +69,7 @@ const autocomplete = createAutocomplete({
 });
 ```
 
-## Parameters
+## Reference
 
 Autocomplete merges the provided parameters with the default configuration, so you can only rewrite what you need.
 

--- a/packages/website/docs/keyboard-navigation.md
+++ b/packages/website/docs/keyboard-navigation.md
@@ -9,7 +9,7 @@ The Navigator API redirects users when opening a suggestion using their keyboard
 
 Autocomplete provides keyboard accessibility out of the box and lets you define how to navigate to results without leaving the keyboard.
 
-The API defines three navigation schemes based on key combinations:
+The Navigator API defines three navigation schemes based on key combinations:
 
 - **In the current tab** when hitting <kbd>Enter</kbd>
 - **In a new tab** when hitting <kbd>⌘ Cmd</kbd>+<kbd>Enter</kbd> or <kbd>Ctrl</kbd>+<kbd>Enter</kbd>


### PR DESCRIPTION
This PR rewrites the **Integrating keyboard navigation** guide.

It adds an introduction, and clarifies the concept.

I've tried to clarify what is meant by keyboard _navigation_ in this context (the navigation to a URL via the keyboard), as users may think this page is about keyboard accessibility (which Autocomplete provides by default).

I've also tried to explain why you would need to implement the API, and when to leave the default implementation alone.