### PR TITLE
docs: rewrite "Accessing data with Context"

### DIFF
--- a/packages/website/docs/context.md
+++ b/packages/website/docs/context.md
@@ -3,23 +3,17 @@ id: context
 title: Accessing data with Context
 ---
 
-The autocomplete context allows to store data in the state to use in different lifecycle hooks.
+The Context lets you store data and access it in different lifecycle hooks.
 
-:::note Draft
+Sometimes you need to store arbitrary data so you can access it later in your autocomplete. For example, when retrieving hits from Algolia, you may want to reuse the total number of retrieved hits in a template.
 
-This page needs to cover:
+Autocomplete lets you store data using its Context API and access it anywhere from the [state](/docs/state).
 
-- You can use **context** to store and access data in the **state**. You can think of it as a global variable.
-- For example, you can use **context** to store data regarding the number of hits from an Algolia response, and then use this when creating **templates** in your sources. Without storing this value in the **context**, you wouldn’t have access to it in the templates.
-- Like all setters, **setContext** expects an object that it will merge with the previous context object.
-  - Code snippet (including setContext and using context.nbHits in a template)
-- **Plugins** can also store their API in **context**
+## Usage
 
-:::
+Context exposes a `setContext` function, which takes an object and merges it with the existing context. You can then access the context in `state.context`.
 
-You can use this API to access data in the templates that you would otherwise have access only in `getSources` for instance. The `setContext` setters expects an object that will be merged with the previous context. You can then read the context in `state.context`.
-
-The following example stores the number of hits from an Algolia response to display it in the templates.
+The following example stores the number of hits from an Algolia response, making it accessible everywhere in your autocomplete.
 
 ```js
 const autocomplete = createAutocomplete({
@@ -33,15 +27,13 @@ const autocomplete = createAutocomplete({
           query,
         },
       ],
-    }).then((results) => {
-      const productsResults = results[0];
-
+    }).then(([products]) => {
       setContext({
-        nbProducts: productsResults.nbHits,
+        nbProducts: products.nbHits,
       });
 
-      // You can now use `state.context.nbProducts` anywhere you have access to
-      // the state.
+      // You can now use `state.context.nbProducts`
+      // anywhere where you have access to `state`.
 
       return [
         // ...
@@ -50,3 +42,23 @@ const autocomplete = createAutocomplete({
   },
 });
 ```
+
+Context can be handy when developing Autocomplete plugins. It avoids polluting the global namespace while still being able to pass data around across different lifecycle hooks.
+
+## Reference
+
+The `setContext` function is accessible on your `autocomplete` instance. It's also provided in the `subscribe` function of Autocomplete plugins.
+
+The `context` object is available on the [`state`](/docs/state) object.
+
+### `setContext`
+
+> `<TState>(value: TState) => void`
+
+The function to pass data to to store it in the context.
+
+### `context`
+
+> `{ [key: string]: unknown }`
+
+The context to read data from.

--- a/packages/website/docs/context.md
+++ b/packages/website/docs/context.md
@@ -45,6 +45,21 @@ const autocomplete = createAutocomplete({
 
 Context can be handy when developing Autocomplete plugins. It avoids polluting the global namespace while still being able to pass data around across different lifecycle hooks.
 
+```js
+function createAutocompletePlugin() {
+  return {
+    // ...
+    subscribe({ setContext }) {
+      setContext({
+        autocompletePlugin: {
+          // ...
+        },
+      });
+    },
+  };
+}
+```
+
 ## Reference
 
 The `setContext` function is accessible on your `autocomplete` instance.

--- a/packages/website/docs/context.md
+++ b/packages/website/docs/context.md
@@ -47,7 +47,17 @@ Context can be handy when developing Autocomplete plugins. It avoids polluting t
 
 ## Reference
 
-The `setContext` function is accessible on your `autocomplete` instance. It's also provided in the `subscribe` function of [Autocomplete plugins](/docs/plugins).
+The `setContext` function is accessible on your `autocomplete` instance.
+
+It's also provided in:
+- [`getSources`](createAutocomplete#getsources)
+- [`onInput`](createAutocomplete#oninput)
+- [`onSubmit`](createAutocomplete#onsubmit)
+- [`onReset`](createAutocomplete#onreset)
+- [`source.onActive`](sources#onactive)
+- [`source.onSelect`](sources#onselect)
+- [`source.getItems`](sources#getitems)
+- `plugin.subscribe`
 
 The `context` object is available on the [`state`](/docs/state) object.
 

--- a/packages/website/docs/context.md
+++ b/packages/website/docs/context.md
@@ -43,7 +43,7 @@ const autocomplete = createAutocomplete({
 });
 ```
 
-Context can be handy when developing Autocomplete plugins. It avoids polluting the global namespace while still being able to pass data around across different lifecycle hooks.
+Context can be handy when developing [Autocomplete plugins](/docs/plugins). It avoids polluting the global namespace while still being able to pass data around across different lifecycle hooks.
 
 ```js
 function createAutocompletePlugin() {

--- a/packages/website/docs/context.md
+++ b/packages/website/docs/context.md
@@ -47,18 +47,18 @@ Context can be handy when developing Autocomplete plugins. It avoids polluting t
 
 ## Reference
 
-The `setContext` function is accessible on your `autocomplete` instance. It's also provided in the `subscribe` function of Autocomplete plugins.
+The `setContext` function is accessible on your `autocomplete` instance. It's also provided in the `subscribe` function of [Autocomplete plugins](/docs/plugins).
 
 The `context` object is available on the [`state`](/docs/state) object.
 
 ### `setContext`
 
-> `<TState>(value: TState) => void`
+> `(value: Record<string, unknown>) => void`
 
 The function to pass data to to store it in the context.
 
 ### `context`
 
-> `{ [key: string]: unknown }`
+> `Record<string, unknown>`
 
 The context to read data from.


### PR DESCRIPTION
This PR rewrites the **Accessing data with Context** core concept.

It adds an introduction, and clarifies the concept.

I've added a **Reference** section to document the shape of both `context` and `setContext`. I've described the expanded types and dropped generics so it's still useful for users looking for parameter shape or return types (while `StateUpdater<TState>` would force them to look it up in the code, or for us to document it). Let me know if you'd like to go with a different approach.

Regarding `setContext`, we should document where it's provided (which functions expose it) so users know where they can leverage it. Could you list them all @francoischalifour?

I'd also like to show a simple example of using it in a plugin (just to illustrate the last point). It doesn't have to be crazy and we'll redirect to the **Plugins** section to show more in-depth use cases, but it would be useful for someone interested in this usage specifically.