### PR TITLE
docs: write "help and discussion" page

### DIFF
--- a/packages/website/docs/help.md
+++ b/packages/website/docs/help.md
@@ -3,12 +3,11 @@ id: help
 title: Help and Discussion
 ---
 
-<!-- prettier-ignore -->
-:::note Draft
-This page needs to cover:
+Autocomplete is an open source library that welcomes questions, feature requests, bug reports, and contributions on [GitHub](https://github.com/algolia/autocomplete.js/tree/next).
 
-- Ask questions and discuss with other community members on [GitHub](https://github.com/algolia/autocomplete.js/discussions/new)
-- Request a feature to add to Autocomplete on [GitHub](https://github.com/algolia/autocomplete.js/discussions/new)
-- Report a bug on [GitHub](https://github.com/algolia/autocomplete.js/issues/new?template=Bug_report.md)
+The best way to get in touch with the maintainers and other community members of the Autocomplete library is through the [Github repository](https://github.com/algolia/autocomplete.js/tree/next):
+- Ask questions, discuss with other community members, or request features on [GitHub Discussions](https://github.com/algolia/autocomplete.js/discussions/new).
+- Report bugs using [issues](https://github.com/algolia/autocomplete.js/issues/new?template=Bug_report.md).
+- Contribute directly by [submitting a pull request](https://github.com/algolia/autocomplete.js/compare). Please read the [contribution guidelines](https://github.com/algolia/autocomplete.js/blob/master/CONTRIBUTING.md) first.
 
-:::
+You're also welcome to engage with community members in our [forum](https://discourse.algolia.com/tag/autocomplete).

--- a/packages/website/docs/help.md
+++ b/packages/website/docs/help.md
@@ -5,9 +5,9 @@ title: Help and Discussion
 
 Autocomplete is an open source library that welcomes questions, feature requests, bug reports, and contributions on [GitHub](https://github.com/algolia/autocomplete.js/tree/next).
 
-The best way to get in touch with the maintainers and other community members of the Autocomplete library is through the [Github repository](https://github.com/algolia/autocomplete.js/tree/next):
+The best way to get in touch with the maintainers and other community members of the Autocomplete library is through the [GitHub repository](https://github.com/algolia/autocomplete.js/tree/next):
 - Ask questions, discuss with other community members, or request features on [GitHub Discussions](https://github.com/algolia/autocomplete.js/discussions/new).
 - Report bugs using [issues](https://github.com/algolia/autocomplete.js/issues/new?template=Bug_report.md).
-- Contribute directly by [submitting a pull request](https://github.com/algolia/autocomplete.js/compare). Please read the [contribution guidelines](https://github.com/algolia/autocomplete.js/blob/master/CONTRIBUTING.md) first.
+- Contribute directly by [submitting a pull request](https://github.com/algolia/autocomplete.js/compare). Please read the [contribution guidelines](https://github.com/algolia/autocomplete.js/blob/next/CONTRIBUTING.md) first.
 
 You're also welcome to engage with community members in our [forum](https://discourse.algolia.com/tag/autocomplete).


### PR DESCRIPTION
This PR writes the last introduction page, "Help and discussion".

I was wondering if we should also link the [Discord](https://discord.gg/tXdr5mP). 

I think it's a good idea if it's actively monitored. My only fear would be that it could get **too** busy, but I guess we can cross that bridge if/when we get to it. 😅