### PR TITLE
docs: rewrite "Populating autocomplete with Sources"

### DIFF
--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -65,15 +65,17 @@ autocomplete({
 });
 ```
 
+Before moving on to more complex sources, let's take a closer look at the code.
+
+Notice that the [`getSources`](#getsources) function returns an array of sources. Each source implements a [`getItems`](#getitems) function to return the items to display. These items can be a simple static array, but you can also use a function to refine items based on the query. **The [`getItems`](#getitems) function is called whenever the input changes.**
+
+By default, autocomplete items are meant to be hyperlinks. To determine what URL to navigate to, you can implement a [`getItemURL`](#getitemurl) function. It enables the [keyboard accessibility](https://autocomplete.algolia.com/docs/keyboard-navigation) feature, allowing users to open items in the current tab, a new tab, or a new window from their keyboard.
+
 ### Customizing items with templates
 
 In addition to defining data sources for items, a source also lets you customize how to display items using [`templates`](#templates).
 
-Templates can return a string:
-
 ```js
-import { autocomplete } from '@algolia/autocomplete-js';
-
 autocomplete({
   // ...
   getSources({ query }) {
@@ -91,80 +93,9 @@ autocomplete({
 });
 ```
 
-Or a [Preact](https://preactjs.com/) component:
+You can also display header and a footer elements around the list of items.
 
 ```js
-/** @jsx jsx */
-import { h } from 'preact';
-import { autocomplete } from '@algolia/autocomplete-js';
-
-autocomplete({
-  // ...
-  getSources({ query }) {
-    return [
-      {
-        // ...
-        templates: {
-          item({ item }) {
-            return <div>{item.name}</div>;
-          },
-        },
-      },
-    ];
-  },
-});
-```
-
-Or HTML/JSX-like syntax (here using [htm](https://github.com/developit/htm)):
-
-```js
-import { html } from 'htm/preact';
-import { autocomplete } from '@algolia/autocomplete-js';
-
-autocomplete({
-  // ...
-  getSources({ query }) {
-    return [
-      {
-        // ...
-        templates: {
-          item({ item }) {
-            return html`<div>${item.name}</div>`
-          },
-        },
-      },
-    ];
-  },
-});
-```
-
-Or a custom component using `createElement` and `Fragment`:
-
-```js
-import { autocomplete } from '@algolia/autocomplete-js';
-
-autocomplete({
-  // ...
-  getSources({ query }) {
-    return [
-      {
-        // ...
-        templates: {
-          item({ item, createElement, Fragment }) {
-            return createElement(Fragment, {}, item.name);
-          },
-        },
-      },
-    ];
-  },
-});
-```
-
-You can also define `header` and `footer` templates to display before and after the items list.
-
-```js
-import { autocomplete } from '@algolia/autocomplete-js';
-
 autocomplete({
   // ...
   getSources({ query }) {
@@ -175,7 +106,9 @@ autocomplete({
           header() {
             return 'Suggestions';
           },
-          // ...
+          item({ item }) {
+            return `Result: ${item.name}`;
+          },
           footer() {
             return 'Footer';
           },
@@ -186,11 +119,7 @@ autocomplete({
 });
 ```
 
-Before moving on to more complex sources, let's take a closer look at the code.
-
-Notice that the [`getSources`](#getsources) function returns an array of sources. Each source implements a [`getItems`](#getitems) function to return the items to display. These items can be a simple static array, but you can also use a function to refine items based on the query. **The [`getItems`](#getitems) function is called whenever the input changes.**
-
-By default, autocomplete items are meant to be hyperlinks. To determine what URL to navigate to, you can implement a [`getItemURL`](#getitemurl) function. It enables the [keyboard accessibility](https://autocomplete.algolia.com/docs/keyboard-navigation) feature, allowing users to open items in the current tab, a new tab, or a new window from their keyboard.
+Templates don't have to be strings. You can provide anything as long as they're a valid Virtual DOM element (see more in [**Templates**](templates)).
 
 ### Using dynamic sources
 

--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -428,8 +428,6 @@ const source = {
 
 Called to get the value of the item. The value is used to fill the search box.
 
-If you don't want to update the input value when an item is selected, you can return `state.query`.
-
 ```js
 const items = [{ value: 'Apple' }, { value: 'Banana' }];
 

--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -93,7 +93,7 @@ autocomplete({
 });
 ```
 
-You can also display header and a footer elements around the list of items.
+You can also display header and footer elements around the list of items.
 
 ```js
 autocomplete({
@@ -407,8 +407,8 @@ You can trigger different behaviors if the item is active depending on the trigg
 
 ### `templates`
 
-> `AutocompleteTemplate`
+> `AutocompleteTemplates`
 
 A set of templates to customize how items are displayed.
 
-You can also provide templates for header and a footer elements around the list of items.
+You can also provide templates for header and footer elements around the list of items.

--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -119,7 +119,7 @@ autocomplete({
 });
 ```
 
-**Templates aren't limited to strings.** You can provide anything as long as they're a valid Virtual DOM element (see more in [**Templates**](templates)).
+**Templates aren't limited to strings.** You can provide anything as long as they're a valid virtual DOM element (see more in [**Templates**](templates)).
 
 ### Using dynamic sources
 

--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -169,7 +169,7 @@ const autocomplete = createAutocomplete({
 
 The [`getSources`](#getsources) function provides access to the current `query`, which you can use to return sources conditionally. You can use this pattern to display recent searches when the query is empty and search results when the user types.
 
-Note that you have access to the [complete autocomplete state](state), not only the query. It lets you compute sources based on many different aspects.
+Note that you have access to the [full autocomplete state](state), not only the query. It lets you compute sources based on [various aspects](state#state), such as the query, but also the autocomplete status, whether the autocomplete is open or not, the context, etc.
 
 ### Using asynchronous sources
 

--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -3,7 +3,7 @@ id: sources
 title: Populating autocomplete with Sources
 ---
 
-Sources define from where to retrieve items and their behavior.
+Sources define where to retrieve items from and their behavior.
 
 **The most important aspect of an autocomplete experience is the items you display.** Most of the time they're search results to a query, but you could imagine many different usages.
 
@@ -30,6 +30,7 @@ autocomplete({
         getItemUrl({ item }) {
           return item.url;
         },
+        // ...
       },
     ];
   },
@@ -56,6 +57,130 @@ autocomplete({
         },
         getItemUrl({ item }) {
           return item.url;
+        },
+        // ...
+      },
+    ];
+  },
+});
+```
+
+### Customizing items with templates
+
+In addition to defining data sources for items, a source also lets you customize how to display items using [`templates`](#templates).
+
+Templates can return a string:
+
+```js
+import { autocomplete } from '@algolia/autocomplete-js';
+
+autocomplete({
+  // ...
+  getSources({ query }) {
+    return [
+      {
+        // ...
+        templates: {
+          item({ item }) {
+            return `Result: ${item.name}`;
+          },
+        },
+      },
+    ];
+  },
+});
+```
+
+Or a [Preact](https://preactjs.com/) component:
+
+```js
+import { autocomplete } from '@algolia/autocomplete-js';
+import { h } from 'preact';
+
+autocomplete({
+  // ...
+  getSources({ query }) {
+    return [
+      {
+        // ...
+        templates: {
+          item({ item }) {
+            return h('div', null, item.name);
+          },
+        },
+      },
+    ];
+  },
+});
+
+```
+
+Or HTML/JSX-like syntax (here using [htm](https://github.com/developit/htm)):
+
+```js
+import { autocomplete, highlightHit } from '@algolia/autocomplete-js';
+import { html } from 'htm/preact';
+
+autocomplete({
+  // ...
+  getSources({ query }) {
+    return [
+      {
+        // ...
+        templates: {
+          item({ item }) {
+            return html`<div>
+              ${html([highlightHit({ hit: item, attribute: 'name' })])}
+            </div>`
+          },
+        },
+      },
+    ];
+  },
+});
+```
+
+Or a custom component using `createElement` and `Fragment`:
+
+```js
+import { autocomplete } from '@algolia/autocomplete-js';
+
+autocomplete({
+  // ...
+  getSources({ query }) {
+    return [
+      {
+        // ...
+        templates: {
+          item({ item, createElement, Fragment }) {
+            return createElement(Fragment, {}, item.name);
+          },
+        },
+      },
+    ];
+  },
+});
+```
+
+You can also define `header` and `footer` templates to display before and after the items list.
+
+```js
+import { autocomplete } from '@algolia/autocomplete-js';
+
+autocomplete({
+  // ...
+  getSources({ query }) {
+    return [
+      {
+        // ...
+        templates: {
+          header() {
+            return 'Suggestions';
+          },
+          // ...
+          footer() {
+            return 'Footer';
+          },
         },
       },
     ];
@@ -104,6 +229,7 @@ autocomplete({
         getItemUrl({ item }) {
           return item.url;
         },
+        // ...
       },
     ];
   },
@@ -269,129 +395,6 @@ autocomplete({
 You can use the official [`autocomplete-plugin-query-suggestions`](createQuerySuggestionsPlugin) plugin to retrieve Query Suggestions from Algolia.
 
 :::
-
-### Customizing items with templates
-
-In addition to defining data sources for items, a source also lets you customize how to display items using [`templates`](#templates).
-
-Templates can return a string:
-
-```js
-import { autocomplete } from '@algolia/autocomplete-js';
-
-autocomplete({
-  // ...
-  getSources({ query }) {
-    return [
-      {
-        // ...
-        templates: {
-          item({ item }) {
-            return `Result: ${item.name}`;
-          },
-        },
-      },
-    ];
-  },
-});
-```
-
-Or a [Preact](https://preactjs.com/) component:
-
-```js
-import { autocomplete } from '@algolia/autocomplete-js';
-import { h } from 'preact';
-
-autocomplete({
-  // ...
-  getSources({ query }) {
-    return [
-      {
-        // ...
-        templates: {
-          item({ item }) {
-            return h('div', null, item.name);
-          },
-        },
-      },
-    ];
-  },
-});
-
-```
-
-Or HTML/JSX-like syntax (here using [htm](https://github.com/developit/htm)):
-
-```js
-import { autocomplete, highlightHit } from '@algolia/autocomplete-js';
-import { html } from 'htm/preact';
-
-autocomplete({
-  // ...
-  getSources({ query }) {
-    return [
-      {
-        // ...
-        templates: {
-          item({ item }) {
-            return html`<div>
-              ${html([highlightHit({ hit: item, attribute: 'name' })])}
-            </div>`
-          },
-        },
-      },
-    ];
-  },
-});
-```
-
-Or a custom component using `createElement` and `Fragment`:
-
-```js
-import { autocomplete } from '@algolia/autocomplete-js';
-
-autocomplete({
-  // ...
-  getSources({ query }) {
-    return [
-      {
-        // ...
-        templates: {
-          item({ item, createElement, Fragment }) {
-            return createElement(Fragment, {}, item.name);
-          },
-        },
-      },
-    ];
-  },
-});
-```
-
-You can also define `header` and `footer` templates to display before and after the items list.
-
-```js
-import { autocomplete } from '@algolia/autocomplete-js';
-
-autocomplete({
-  // ...
-  getSources({ query }) {
-    return [
-      {
-        // ...
-        templates: {
-          header() {
-            return 'Suggestions';
-          },
-          // ...
-          footer() {
-            return 'Footer';
-          },
-        },
-      },
-    ];
-  },
-});
-```
 
 ## Reference
 

--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -16,7 +16,8 @@ Autocomplete gives you total freedom to return rich suggestions via the Sources 
 The most straightforward way to provide items is to return static sources. Each source returns a collection of items.
 
 ```js
-const autocomplete = createAutocomplete({
+autocomplete({
+  // ...
   getSources() {
     return [
       {
@@ -42,7 +43,8 @@ Here, whatever the autocomplete state is, it always returns these two items.
 You can access the autocomplete state in your sources, meaning you can search within static sources to update them as the user types.
 
 ```js
-const autocomplete = createAutocomplete({
+autocomplete({
+  // ...
   getSources() {
     return [
       {
@@ -75,7 +77,7 @@ In this case, you could search into one or more Algolia indices using the built-
 
 ```js
 import algoliasearch from 'algoliasearch/lite';
-import { createAutocomplete } from '@algolia/autocomplete-core';
+import { autocomplete } from '@algolia/autocomplete-js';
 import { getAlgoliaHits } from '@algolia/autocomplete-preset-algolia';
 
 const searchClient = algoliasearch(
@@ -83,7 +85,8 @@ const searchClient = algoliasearch(
   '6be0576ff61c053d5f9a3225e2a90f76'
 );
 
-const autocomplete = createAutocomplete({
+autocomplete({
+  // ...
   getSources() {
     return [
       {
@@ -119,7 +122,7 @@ You don't have to show an empty screen until the user types a query. A typical p
 
 ```js
 import algoliasearch from 'algoliasearch/lite';
-import { createAutocomplete } from '@algolia/autocomplete-core';
+import { autocomplete } from '@algolia/autocomplete-js';
 import { getAlgoliaHits } from '@algolia/autocomplete-preset-algolia';
 
 const searchClient = algoliasearch(
@@ -127,7 +130,8 @@ const searchClient = algoliasearch(
   '6be0576ff61c053d5f9a3225e2a90f76'
 );
 
-const autocomplete = createAutocomplete({
+autocomplete({
+  // ...
   getSources({ query }) {
     if (!query) {
       return [
@@ -178,9 +182,8 @@ The [`getSources`](#getsources) function supports promises so that you can fetch
 For example, you could use the [Query Autocomplete](https://developers.google.com/places/web-service/query) service of the Google Places API to search for places and retrieve popular queries that map to actual points of interest.
 
 ```js
-import { createAutocomplete } from '@algolia/autocomplete-core';
-
-const autocomplete = createAutocomplete({
+autocomplete({
+  // ...
   getSources({ query }) {
     return fetch(
       `https://maps.googleapis.com/maps/api/place/queryautocomplete/json?input=${query}&key=YOUR_GOOGLE_PLACES_API_KEY`
@@ -212,7 +215,7 @@ For example, you may want to display Algolia search results and Query Suggestion
 
 ```js
 import algoliasearch from 'algoliasearch/lite';
-import { createAutocomplete } from '@algolia/autocomplete-core';
+import { autocomplete } from '@algolia/autocomplete-js';
 import { getAlgoliaHits } from '@algolia/autocomplete-preset-algolia';
 
 const searchClient = algoliasearch(
@@ -220,9 +223,10 @@ const searchClient = algoliasearch(
   '6be0576ff61c053d5f9a3225e2a90f76'
 );
 
-const autocomplete = createAutocomplete({
+autocomplete({
+  // ...
   getSources({ query }) {
-    return getAlgoliaResults({
+    return getAlgoliaHits({
       searchClient,
       queries: [
         {

--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -94,8 +94,9 @@ autocomplete({
 Or a [Preact](https://preactjs.com/) component:
 
 ```js
-import { autocomplete } from '@algolia/autocomplete-js';
+/** @jsx jsx */
 import { h } from 'preact';
+import { autocomplete } from '@algolia/autocomplete-js';
 
 autocomplete({
   // ...
@@ -105,21 +106,20 @@ autocomplete({
         // ...
         templates: {
           item({ item }) {
-            return h('div', null, item.name);
+            return <div>{item.name}</div>;
           },
         },
       },
     ];
   },
 });
-
 ```
 
 Or HTML/JSX-like syntax (here using [htm](https://github.com/developit/htm)):
 
 ```js
-import { autocomplete, highlightHit } from '@algolia/autocomplete-js';
 import { html } from 'htm/preact';
+import { autocomplete } from '@algolia/autocomplete-js';
 
 autocomplete({
   // ...
@@ -129,9 +129,7 @@ autocomplete({
         // ...
         templates: {
           item({ item }) {
-            return html`<div>
-              ${html([highlightHit({ hit: item, attribute: 'name' })])}
-            </div>`
+            return html`<div>${item.name}</div>`
           },
         },
       },

--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -119,7 +119,7 @@ autocomplete({
 });
 ```
 
-**Templates aren't limited to strings.** You can provide anything as long as they're a valid virtual DOM element (see more in [**Templates**](templates)).
+**Templates aren't limited to strings.** You can provide anything as long as they're a valid virtual DOM element (see more in **Templates**).
 
 ### Using dynamic sources
 

--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -394,7 +394,7 @@ You can use the official [`autocomplete-plugin-query-suggestions`](createQuerySu
 
 :::
 
-## Reference
+## Sources
 
 ### `getSources`
 
@@ -402,7 +402,11 @@ You can use the official [`autocomplete-plugin-query-suggestions`](createQuerySu
 
 The function to fetch sources and their behaviors.
 
-A source implements the following interface:
+See [source](#source) to see what to return.
+
+## Source
+
+Each source implements the following interface:
 
 ### `getItems`
 

--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -130,7 +130,7 @@ const searchClient = algoliasearch(
 const autocomplete = createAutocomplete({
   getSources({ query }) {
     if (!query) {
-      [
+      return [
         {
           getItems() {
             return [

--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -331,7 +331,7 @@ You can use the official [`autocomplete-plugin-query-suggestions`](createQuerySu
 
 The function to fetch sources and their behaviors.
 
-See [source](#source) to see what to return.
+See [source](#source) for what to return.
 
 ## Source
 

--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -268,13 +268,7 @@ You can use the official [`autocomplete-plugin-query-suggestions`](createQuerySu
 
 ### Customizing items with templates
 
-In addition to defining data sources for items, a source also lets you customize how to display items using [`templates`](#templates-specific-to-algoliaautocomplete-js).
-
-:::info
-
-Templates are only supported in [autocomplete-js](autocomplete-js).
-
-:::
+In addition to defining data sources for items, a source also lets you customize how to display items using [`templates`](#templates).
 
 Templates can return a string:
 
@@ -473,10 +467,10 @@ Called whenever an item is active.
 
 You can trigger different behaviors if the item is active depending on the triggering event using the `event` parameter.
 
-### `templates` (specific to `@algolia/autocomplete-js`)
+### `templates`
 
 > `SourceTemplate`
 
-The `@algolia/autocomplete-js` supports source templates.
+A set of templates to customize how items are displayed.
 
-A template can either return a string or perform DOM mutations without returning a string.
+You can also provide templates for header and a footer elements around the list of items.

--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -119,7 +119,7 @@ autocomplete({
 });
 ```
 
-Templates don't have to be strings. You can provide anything as long as they're a valid Virtual DOM element (see more in [**Templates**](templates)).
+**Templates aren't limited to strings.** You can provide anything as long as they're a valid Virtual DOM element (see more in [**Templates**](templates)).
 
 ### Using dynamic sources
 

--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -69,7 +69,7 @@ Before moving on to more complex sources, let's take a closer look at the code.
 
 Notice that the [`getSources`](#getsources) function returns an array of sources. Each source implements a [`getItems`](#getitems) function to return the items to display. These items can be a simple static array, but you can also use a function to refine items based on the query. **The [`getItems`](#getitems) function is called whenever the input changes.**
 
-By default, autocomplete items are meant to be hyperlinks. To determine what URL to navigate to, you can implement a [`getItemURL`](#getitemurl) function. It enables the [keyboard accessibility](https://autocomplete.algolia.com/docs/keyboard-navigation) feature, allowing users to open items in the current tab, a new tab, or a new window from their keyboard.
+By default, autocomplete items are meant to be hyperlinks. To determine what URL to navigate to, you can implement a [`getItemURL`](#getitemurl) function. It enables the [keyboard accessibility](/docs/keyboard-navigation) feature, allowing users to open items in the current tab, a new tab, or a new window from their keyboard.
 
 ### Customizing items with templates
 
@@ -407,7 +407,7 @@ You can trigger different behaviors if the item is active depending on the trigg
 
 ### `templates`
 
-> `SourceTemplate`
+> `AutocompleteTemplate`
 
 A set of templates to customize how items are displayed.
 


### PR DESCRIPTION
This rewrites and clarifies "Populating autocomplete with Sources", and add missing parts.

I have some uncertainties regarding some parts of the docs, which I detailed directly in the diff.