### PR TITLE
test(core): add tests for `default source implementation` and `concat getSources from plugins`

### DIFF
--- a/packages/autocomplete-core/src/__tests__/getSources.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getSources.test.ts
@@ -1,6 +1,11 @@
+import { fireEvent } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 
-import { createSource, createPlayground } from '../../../../test/utils';
+import {
+  createSource,
+  createPlayground,
+  runAllMicroTasks,
+} from '../../../../test/utils';
 import { createAutocomplete } from '../createAutocomplete';
 
 describe('getSources', () => {
@@ -37,7 +42,42 @@ describe('getSources', () => {
     });
   });
 
-  test.todo('provides default source implementations');
+  test('provides a default source implementations', async () => {
+    const onStateChange = jest.fn();
+    const getSources = () => {
+      return [
+        {
+          getItems() {
+            return [];
+          },
+          templates: {
+            item() {},
+          },
+        },
+      ];
+    };
+    const { inputElement } = createPlayground(createAutocomplete, {
+      getSources,
+      onStateChange,
+      openOnFocus: true,
+    });
+
+    fireEvent.input(inputElement, { target: { value: 'a' } });
+
+    await runAllMicroTasks();
+
+    onStateChange.mock.calls.forEach((x) =>
+      x[0].state.collections.forEach((collection: any) => {
+        expect(collection.source.getItemInputValue).not.toBe(undefined);
+        expect(collection.source.getItemUrl).not.toBe(undefined);
+        expect(collection.source.getItems).not.toBe(undefined);
+        expect(collection.source.onActive).not.toBe(undefined);
+        expect(collection.source.onSelect).not.toBe(undefined);
+        expect(collection.source.templates).not.toBe(undefined);
+        expect(collection.source.templates.item).not.toBe(undefined);
+      })
+    );
+  });
 
   test.todo('concat getSources from plugins');
 });

--- a/packages/autocomplete-core/src/__tests__/getSources.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getSources.test.ts
@@ -43,20 +43,19 @@ describe('getSources', () => {
 
   test('provides a default source implementations', async () => {
     const onStateChange = jest.fn();
-    const getSources = () => {
-      return [
-        {
-          getItems() {
-            return [];
-          },
-          templates: {
-            item() {},
-          },
-        },
-      ];
-    };
     const { inputElement } = createPlayground(createAutocomplete, {
-      getSources,
+      getSources: () => {
+        return [
+          {
+            getItems() {
+              return [];
+            },
+            templates: {
+              item() {},
+            },
+          },
+        ];
+      },
       onStateChange,
     });
 
@@ -88,18 +87,6 @@ describe('getSources', () => {
 
   test('concat getSources from plugins', async () => {
     const onStateChange = jest.fn();
-    const getSources = () => {
-      return [
-        {
-          getItems() {
-            return [];
-          },
-          templates: {
-            item() {},
-          },
-        },
-      ];
-    };
     const plugin = {
       getSources: () => {
         return [
@@ -116,7 +103,18 @@ describe('getSources', () => {
     };
     const { inputElement } = createPlayground(createAutocomplete, {
       onStateChange,
-      getSources,
+      getSources: () => {
+        return [
+          {
+            getItems() {
+              return [];
+            },
+            templates: {
+              item() {},
+            },
+          },
+        ];
+      },
       plugins: [plugin],
     });
 
@@ -125,9 +123,6 @@ describe('getSources', () => {
 
     await runAllMicroTasks();
 
-    expect(onStateChange.mock.calls.pop()[0].state.collections).toEqual([
-      expect.any(Object),
-      expect.any(Object),
-    ]);
+    expect(onStateChange.mock.calls.pop()[0].state.collections).toHaveLength(2);
   });
 });

--- a/packages/autocomplete-core/src/__tests__/getSources.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getSources.test.ts
@@ -69,7 +69,7 @@ describe('getSources', () => {
       state: expect.objectContaining({
         collections: expect.arrayContaining([
           expect.objectContaining({
-            source: expect.objectContaining({
+            source: {
               getItemInputValue: expect.any(Function),
               getItemUrl: expect.any(Function),
               getItems: expect.any(Function),
@@ -78,7 +78,7 @@ describe('getSources', () => {
               templates: expect.objectContaining({
                 item: expect.any(Function),
               }),
-            }),
+            },
           }),
         ]),
       }),

--- a/packages/autocomplete-core/src/__tests__/getSources.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getSources.test.ts
@@ -43,11 +43,12 @@ describe('getSources', () => {
 
   test('provides a default source implementations', async () => {
     const onStateChange = jest.fn();
-    const sources = createSource();
     const getSources = () => {
       return [
         {
-          ...sources,
+          getItems() {
+            return [];
+          },
           templates: {
             item() {},
           },
@@ -70,9 +71,9 @@ describe('getSources', () => {
         collections: expect.arrayContaining([
           expect.objectContaining({
             source: expect.objectContaining({
-              getItemInputValue: sources.getItemInputValue,
-              getItemUrl: sources.getItemUrl,
-              getItems: sources.getItems,
+              getItemInputValue: expect.any(Function),
+              getItemUrl: expect.any(Function),
+              getItems: expect.any(Function),
               onActive: expect.any(Function),
               onSelect: expect.any(Function),
               templates: expect.objectContaining({
@@ -86,11 +87,13 @@ describe('getSources', () => {
   });
 
   test('concat getSources from plugins', async () => {
-    const sources = createSource();
+    const onStateChange = jest.fn();
     const getSources = () => {
       return [
         {
-          ...sources,
+          getItems() {
+            return [];
+          },
           templates: {
             item() {},
           },
@@ -98,12 +101,19 @@ describe('getSources', () => {
       ];
     };
     const plugin = {
-      getSources: jest.fn((..._args: any[]) => {
-        return [sources];
-      }),
+      getSources: () => {
+        return [
+          {
+            getItems() {
+              return [];
+            },
+            templates: {
+              item() {},
+            },
+          },
+        ];
+      },
     };
-
-    const onStateChange = jest.fn();
     const { inputElement } = createPlayground(createAutocomplete, {
       onStateChange,
       getSources,
@@ -115,24 +125,9 @@ describe('getSources', () => {
 
     await runAllMicroTasks();
 
-    expect(onStateChange).toHaveBeenCalledWith({
-      prevState: expect.anything(),
-      state: expect.objectContaining({
-        collections: expect.arrayContaining([
-          expect.objectContaining({
-            source: expect.objectContaining({
-              getItemInputValue: sources.getItemInputValue,
-              getItemUrl: sources.getItemUrl,
-              getItems: sources.getItems,
-              onActive: expect.any(Function),
-              onSelect: expect.any(Function),
-              templates: expect.objectContaining({
-                item: expect.any(Function),
-              }),
-            }),
-          }),
-        ]),
-      }),
-    });
+    expect(onStateChange.mock.calls.pop()[0].state.collections).toEqual([
+      expect.any(Object),
+      expect.any(Object),
+    ]);
   });
 });


### PR DESCRIPTION
Add tests for `default source implementation` and `concat getSources from plugins`.

_I'm not sure if this is the expected the behavior, any tips appreciated!_