### PR TITLE
fix(mergeClassNames): prevent classes with the same name being merged

### DIFF
--- a/packages/autocomplete-js/src/utils/mergeClassNames.ts
+++ b/packages/autocomplete-js/src/utils/mergeClassNames.ts
@@ -8,7 +8,8 @@ export function mergeClassNames(
       const accValue = acc[key];
       const currentValue = current[key];
 
-      acc[key] = [accValue, currentValue].filter(Boolean).join(' ');
+      if (accValue !== currentValue)
+        acc[key] = [accValue, currentValue].filter(Boolean).join(' ');
     });
 
     return acc;

--- a/packages/autocomplete-js/src/utils/mergeClassNames.ts
+++ b/packages/autocomplete-js/src/utils/mergeClassNames.ts
@@ -8,8 +8,9 @@ export function mergeClassNames(
       const accValue = acc[key];
       const currentValue = current[key];
 
-      if (accValue !== currentValue)
+      if (accValue !== currentValue) {
         acc[key] = [accValue, currentValue].filter(Boolean).join(' ');
+      }
     });
 
     return acc;


### PR DESCRIPTION
**Summary**
When `onResize` effect was triggered, classes were merged even if they had the same name.

This should fix this issue