### PR TITLE
feat(highlighting): support array syntax for nested attributes

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -6,11 +6,11 @@
     },
     {
       "path": "packages/autocomplete-js/dist/umd/index.production.js",
-      "maxSize": "13.5 kB"
+      "maxSize": "13.65 kB"
     },
     {
       "path": "packages/autocomplete-preset-algolia/dist/umd/index.production.js",
-      "maxSize": "1.5 kB"
+      "maxSize": "1.75 kB"
     },
     {
       "path": "packages/autocomplete-plugin-algolia-insights/dist/umd/index.production.js",
@@ -22,7 +22,7 @@
     },
     {
       "path": "packages/autocomplete-plugin-query-suggestions/dist/umd/index.production.js",
-      "maxSize": "2.5 kB"
+      "maxSize": "2.8 kB"
     }
   ]
 }

--- a/packages/autocomplete-js/src/highlight.ts
+++ b/packages/autocomplete-js/src/highlight.ts
@@ -11,7 +11,7 @@ import { AutocompleteRenderer } from './types';
 
 type HighlightItemParams<TItem> = {
   hit: TItem;
-  attribute: keyof TItem;
+  attribute: keyof TItem | string[];
   tagName?: string;
   createElement?: AutocompleteRenderer['createElement'];
 };

--- a/packages/autocomplete-preset-algolia/src/highlight/ParseAlgoliaHitParams.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/ParseAlgoliaHitParams.ts
@@ -1,4 +1,4 @@
 export type ParseAlgoliaHitParams<TItem> = {
   hit: TItem;
-  attribute: keyof TItem;
+  attribute: keyof TItem | string[];
 };

--- a/packages/autocomplete-preset-algolia/src/highlight/__tests__/parseAlgoliaHitHighlight.test.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/__tests__/parseAlgoliaHitHighlight.test.ts
@@ -25,26 +25,104 @@ describe('parseAlgoliaHitHighlight', () => {
           },
         },
       })
-    ).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "isHighlighted": true,
-          "value": "He",
+    ).toEqual([
+      {
+        isHighlighted: true,
+        value: 'He',
+      },
+      {
+        isHighlighted: false,
+        value: 'llo t',
+      },
+      {
+        isHighlighted: true,
+        value: 'he',
+      },
+      {
+        isHighlighted: false,
+        value: 're',
+      },
+    ]);
+  });
+
+  test('returns the highlighted parts of the hit with an array attribute', () => {
+    expect(
+      parseAlgoliaHitHighlight({
+        attribute: ['title'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          _highlightResult: {
+            title: {
+              value:
+                '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+              matchLevel: 'partial',
+              matchedWords: [],
+              fullyHighlighted: false,
+            },
+          },
         },
-        Object {
-          "isHighlighted": false,
-          "value": "llo t",
+      })
+    ).toEqual([
+      {
+        isHighlighted: true,
+        value: 'He',
+      },
+      {
+        isHighlighted: false,
+        value: 'llo t',
+      },
+      {
+        isHighlighted: true,
+        value: 'he',
+      },
+      {
+        isHighlighted: false,
+        value: 're',
+      },
+    ]);
+  });
+
+  test('returns the highlighted parts of the hit with a nested array attribute', () => {
+    expect(
+      parseAlgoliaHitHighlight({
+        attribute: ['hierarchy', 'lvl0'],
+        hit: {
+          objectID: '1',
+          hierarchy: {
+            lvl0: 'Hello there',
+          },
+          _highlightResult: {
+            hierarchy: {
+              lvl0: {
+                value:
+                  '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+                matchLevel: 'partial',
+                matchedWords: [],
+                fullyHighlighted: false,
+              },
+            },
+          },
         },
-        Object {
-          "isHighlighted": true,
-          "value": "he",
-        },
-        Object {
-          "isHighlighted": false,
-          "value": "re",
-        },
-      ]
-    `);
+      })
+    ).toEqual([
+      {
+        isHighlighted: true,
+        value: 'He',
+      },
+      {
+        isHighlighted: false,
+        value: 'llo t',
+      },
+      {
+        isHighlighted: true,
+        value: 'he',
+      },
+      {
+        isHighlighted: false,
+        value: 're',
+      },
+    ]);
   });
 
   test('returns the attribute value if the attribute cannot be highlighted', () => {
@@ -113,7 +191,95 @@ describe('parseAlgoliaHitHighlight', () => {
         },
       });
     }).toWarnDev(
-      '[Autocomplete] The attribute "_highlightResult.description.value" does not exist on the hit. Did you set it in `attributesToHighlight`?' +
+      '[Autocomplete] The attribute path ["description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
+        '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/'
+    );
+  });
+
+  test('returns empty parts if the array attribute does not exist', () => {
+    expect(
+      parseAlgoliaHitHighlight({
+        attribute: ['description'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          _snippetResult: {
+            title: {
+              value:
+                '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+            },
+          },
+        },
+      })
+    ).toEqual([]);
+  });
+
+  test('warns if the array attribute cannot be highlighted', () => {
+    expect(() => {
+      parseAlgoliaHitHighlight({
+        attribute: ['description'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          description: 'Welcome all',
+          _highlightResult: {
+            title: {
+              value:
+                '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+              matchLevel: 'partial',
+              matchedWords: [],
+              fullyHighlighted: false,
+            },
+          },
+        },
+      });
+    }).toWarnDev(
+      '[Autocomplete] The attribute path ["description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
+        '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/'
+    );
+  });
+
+  test('returns empty parts if the nested array attribute does not exist', () => {
+    expect(
+      parseAlgoliaHitHighlight({
+        attribute: ['title', 'description'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          _snippetResult: {
+            title: {
+              value:
+                '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+            },
+          },
+        },
+      })
+    ).toEqual([]);
+  });
+
+  test('warns if the nested array attribute cannot be highlighted', () => {
+    expect(() => {
+      parseAlgoliaHitHighlight({
+        attribute: ['title', 'description'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          description: 'Welcome all',
+          _highlightResult: {
+            title: {
+              noDescription: {
+                value:
+                  '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+                matchLevel: 'partial',
+                matchedWords: [],
+                fullyHighlighted: false,
+              },
+            },
+          },
+        },
+      });
+    }).toWarnDev(
+      '[Autocomplete] The attribute path ["title","description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/'
     );
   });

--- a/packages/autocomplete-preset-algolia/src/highlight/__tests__/parseAlgoliaHitHighlight.test.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/__tests__/parseAlgoliaHitHighlight.test.ts
@@ -125,6 +125,48 @@ describe('parseAlgoliaHitHighlight', () => {
     ]);
   });
 
+  test('returns the highlighted parts of the hit with a nested array attribute containing a dot', () => {
+    expect(
+      parseAlgoliaHitHighlight({
+        attribute: ['hierarchy', 'lvl0.inside'],
+        hit: {
+          objectID: '1',
+          hierarchy: {
+            'lvl0.inside': 'Hello there',
+          },
+          _highlightResult: {
+            hierarchy: {
+              'lvl0.inside': {
+                value:
+                  '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+                matchLevel: 'partial',
+                matchedWords: [],
+                fullyHighlighted: false,
+              },
+            },
+          },
+        },
+      })
+    ).toEqual([
+      {
+        isHighlighted: true,
+        value: 'He',
+      },
+      {
+        isHighlighted: false,
+        value: 'llo t',
+      },
+      {
+        isHighlighted: true,
+        value: 'he',
+      },
+      {
+        isHighlighted: false,
+        value: 're',
+      },
+    ]);
+  });
+
   test('returns the attribute value if the attribute cannot be highlighted', () => {
     expect(
       parseAlgoliaHitHighlight({
@@ -191,7 +233,7 @@ describe('parseAlgoliaHitHighlight', () => {
         },
       });
     }).toWarnDev(
-      '[Autocomplete] The attribute path ["description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
+      '[Autocomplete] The attribute "description" described by the path ["description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/'
     );
   });
@@ -234,7 +276,7 @@ describe('parseAlgoliaHitHighlight', () => {
         },
       });
     }).toWarnDev(
-      '[Autocomplete] The attribute path ["description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
+      '[Autocomplete] The attribute "description" described by the path ["description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/'
     );
   });
@@ -279,7 +321,35 @@ describe('parseAlgoliaHitHighlight', () => {
         },
       });
     }).toWarnDev(
-      '[Autocomplete] The attribute path ["title","description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
+      '[Autocomplete] The attribute "title.description" described by the path ["title","description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
+        '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/'
+    );
+  });
+
+  test('warns if the nested array attribute containing a dot does not exist', () => {
+    expect(() => {
+      parseAlgoliaHitHighlight({
+        attribute: ['hierarchy', 'lvl1.inside'],
+        hit: {
+          objectID: '1',
+          hierarchy: {
+            'lvl0.inside': 'Hello there',
+          },
+          _highlightResult: {
+            hierarchy: {
+              'lvl0.inside': {
+                value:
+                  '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+                matchLevel: 'partial',
+                matchedWords: [],
+                fullyHighlighted: false,
+              },
+            },
+          },
+        },
+      });
+    }).toWarnDev(
+      '[Autocomplete] The attribute "hierarchy.lvl1.inside" described by the path ["hierarchy","lvl1.inside"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/'
     );
   });

--- a/packages/autocomplete-preset-algolia/src/highlight/__tests__/parseAlgoliaHitReverseHighlight.test.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/__tests__/parseAlgoliaHitReverseHighlight.test.ts
@@ -122,6 +122,48 @@ describe('parseAlgoliaHitReverseHighlight', () => {
     ]);
   });
 
+  test('returns the highlighted parts of the hit with a nested array attribute containing a dot', () => {
+    expect(
+      parseAlgoliaHitReverseHighlight({
+        attribute: ['hierarchy', 'lvl0.inside'],
+        hit: {
+          objectID: '1',
+          hierarchy: {
+            'lvl0.inside': 'Hello there',
+          },
+          _highlightResult: {
+            hierarchy: {
+              'lvl0.inside': {
+                value:
+                  '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+                matchLevel: 'partial',
+                matchedWords: [],
+                fullyHighlighted: false,
+              },
+            },
+          },
+        },
+      })
+    ).toEqual([
+      {
+        isHighlighted: false,
+        value: 'He',
+      },
+      {
+        isHighlighted: true,
+        value: 'llo t',
+      },
+      {
+        isHighlighted: false,
+        value: 'he',
+      },
+      {
+        isHighlighted: true,
+        value: 're',
+      },
+    ]);
+  });
+
   test('returns the non-highlighted parts when every part matches', () => {
     expect(
       parseAlgoliaHitReverseHighlight({
@@ -203,7 +245,7 @@ describe('parseAlgoliaHitReverseHighlight', () => {
         },
       });
     }).toWarnDev(
-      '[Autocomplete] The attribute path ["description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
+      '[Autocomplete] The attribute "description" described by the path ["description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/'
     );
   });
@@ -246,7 +288,7 @@ describe('parseAlgoliaHitReverseHighlight', () => {
         },
       });
     }).toWarnDev(
-      '[Autocomplete] The attribute path ["description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
+      '[Autocomplete] The attribute "description" described by the path ["description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/'
     );
   });
@@ -291,7 +333,35 @@ describe('parseAlgoliaHitReverseHighlight', () => {
         },
       });
     }).toWarnDev(
-      '[Autocomplete] The attribute path ["title","description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
+      '[Autocomplete] The attribute "title.description" described by the path ["title","description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
+        '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/'
+    );
+  });
+
+  test('warns if the nested array attribute containing a dot does not exist', () => {
+    expect(() => {
+      parseAlgoliaHitReverseHighlight({
+        attribute: ['hierarchy', 'lvl1.inside'],
+        hit: {
+          objectID: '1',
+          hierarchy: {
+            'lvl0.inside': 'Hello there',
+          },
+          _highlightResult: {
+            hierarchy: {
+              'lvl0.inside': {
+                value:
+                  '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+                matchLevel: 'partial',
+                matchedWords: [],
+                fullyHighlighted: false,
+              },
+            },
+          },
+        },
+      });
+    }).toWarnDev(
+      '[Autocomplete] The attribute "hierarchy.lvl1.inside" described by the path ["hierarchy","lvl1.inside"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/'
     );
   });

--- a/packages/autocomplete-preset-algolia/src/highlight/__tests__/parseAlgoliaHitReverseHighlight.test.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/__tests__/parseAlgoliaHitReverseHighlight.test.ts
@@ -22,26 +22,104 @@ describe('parseAlgoliaHitReverseHighlight', () => {
           },
         },
       })
-    ).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "isHighlighted": false,
-          "value": "He",
+    ).toEqual([
+      {
+        isHighlighted: false,
+        value: 'He',
+      },
+      {
+        isHighlighted: true,
+        value: 'llo t',
+      },
+      {
+        isHighlighted: false,
+        value: 'he',
+      },
+      {
+        isHighlighted: true,
+        value: 're',
+      },
+    ]);
+  });
+
+  test('returns the reverse-highlighted parts of the hit with an array attribute', () => {
+    expect(
+      parseAlgoliaHitReverseHighlight({
+        attribute: ['title'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          _highlightResult: {
+            title: {
+              value:
+                '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+              matchLevel: 'partial',
+              matchedWords: [],
+              fullyHighlighted: false,
+            },
+          },
         },
-        Object {
-          "isHighlighted": true,
-          "value": "llo t",
+      })
+    ).toEqual([
+      {
+        isHighlighted: false,
+        value: 'He',
+      },
+      {
+        isHighlighted: true,
+        value: 'llo t',
+      },
+      {
+        isHighlighted: false,
+        value: 'he',
+      },
+      {
+        isHighlighted: true,
+        value: 're',
+      },
+    ]);
+  });
+
+  test('returns the reverse-highlighted parts of the hit with a nested array attribute', () => {
+    expect(
+      parseAlgoliaHitReverseHighlight({
+        attribute: ['hierarchy', 'lvl0'],
+        hit: {
+          objectID: '1',
+          hierarchy: {
+            lvl0: 'Hello there',
+          },
+          _highlightResult: {
+            hierarchy: {
+              lvl0: {
+                value:
+                  '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+                matchLevel: 'partial',
+                matchedWords: [],
+                fullyHighlighted: false,
+              },
+            },
+          },
         },
-        Object {
-          "isHighlighted": false,
-          "value": "he",
-        },
-        Object {
-          "isHighlighted": true,
-          "value": "re",
-        },
-      ]
-    `);
+      })
+    ).toEqual([
+      {
+        isHighlighted: false,
+        value: 'He',
+      },
+      {
+        isHighlighted: true,
+        value: 'llo t',
+      },
+      {
+        isHighlighted: false,
+        value: 'he',
+      },
+      {
+        isHighlighted: true,
+        value: 're',
+      },
+    ]);
   });
 
   test('returns the non-highlighted parts when every part matches', () => {
@@ -51,17 +129,12 @@ describe('parseAlgoliaHitReverseHighlight', () => {
         hit: {
           objectID: '1',
           title: 'Hello there',
-          _highlightResult: { title: { value: 'Hello' } },
+          _highlightResult: {
+            title: { value: '__aa-highlight__Hello there__/aa-highlight__' },
+          },
         },
       })
-    ).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "isHighlighted": false,
-          "value": "Hello",
-        },
-      ]
-    `);
+    ).toEqual([{ isHighlighted: false, value: 'Hello there' }]);
   });
 
   test('returns the attribute value if the attribute cannot be highlighted', () => {
@@ -130,7 +203,95 @@ describe('parseAlgoliaHitReverseHighlight', () => {
         },
       });
     }).toWarnDev(
-      '[Autocomplete] The attribute "_highlightResult.description.value" does not exist on the hit. Did you set it in `attributesToHighlight`?' +
+      '[Autocomplete] The attribute path ["description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
+        '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/'
+    );
+  });
+
+  test('returns empty parts if the array attribute does not exist', () => {
+    expect(
+      parseAlgoliaHitReverseHighlight({
+        attribute: ['description'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          _snippetResult: {
+            title: {
+              value:
+                '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+            },
+          },
+        },
+      })
+    ).toEqual([]);
+  });
+
+  test('warns if the array attribute cannot be highlighted', () => {
+    expect(() => {
+      parseAlgoliaHitReverseHighlight({
+        attribute: ['description'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          description: 'Welcome all',
+          _highlightResult: {
+            title: {
+              value:
+                '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+              matchLevel: 'partial',
+              matchedWords: [],
+              fullyHighlighted: false,
+            },
+          },
+        },
+      });
+    }).toWarnDev(
+      '[Autocomplete] The attribute path ["description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
+        '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/'
+    );
+  });
+
+  test('returns empty parts if the nested array attribute does not exist', () => {
+    expect(
+      parseAlgoliaHitReverseHighlight({
+        attribute: ['title', 'description'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          _snippetResult: {
+            title: {
+              value:
+                '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+            },
+          },
+        },
+      })
+    ).toEqual([]);
+  });
+
+  test('warns if the nested array attribute cannot be highlighted', () => {
+    expect(() => {
+      parseAlgoliaHitReverseHighlight({
+        attribute: ['title', 'description'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          description: 'Welcome all',
+          _highlightResult: {
+            title: {
+              noDescription: {
+                value:
+                  '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+                matchLevel: 'partial',
+                matchedWords: [],
+                fullyHighlighted: false,
+              },
+            },
+          },
+        },
+      });
+    }).toWarnDev(
+      '[Autocomplete] The attribute path ["title","description"] does not exist on the hit. Did you set it in `attributesToHighlight`?' +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/'
     );
   });

--- a/packages/autocomplete-preset-algolia/src/highlight/__tests__/parseAlgoliaHitReverseSnippet.test.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/__tests__/parseAlgoliaHitReverseSnippet.test.ts
@@ -7,7 +7,7 @@ describe('parseAlgoliaHitReverseSnippet', () => {
     warnCache.current = {};
   });
 
-  test('returns the highlighted snippet parts of the hit', () => {
+  test('returns the reverse-highlighted snippet parts of the hit', () => {
     expect(
       parseAlgoliaHitReverseSnippet({
         attribute: 'title',
@@ -22,26 +22,113 @@ describe('parseAlgoliaHitReverseSnippet', () => {
           },
         },
       })
-    ).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "isHighlighted": false,
-          "value": "He",
+    ).toEqual([
+      {
+        isHighlighted: false,
+        value: 'He',
+      },
+      {
+        isHighlighted: true,
+        value: 'llo t',
+      },
+      {
+        isHighlighted: false,
+        value: 'he',
+      },
+      {
+        isHighlighted: true,
+        value: 're',
+      },
+    ]);
+  });
+
+  test('returns the reverse-highlighted parts of the hit with an array attribute', () => {
+    expect(
+      parseAlgoliaHitReverseSnippet({
+        attribute: ['title'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          _snippetResult: {
+            title: {
+              value:
+                '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+            },
+          },
         },
-        Object {
-          "isHighlighted": true,
-          "value": "llo t",
+      })
+    ).toEqual([
+      {
+        isHighlighted: false,
+        value: 'He',
+      },
+      {
+        isHighlighted: true,
+        value: 'llo t',
+      },
+      {
+        isHighlighted: false,
+        value: 'he',
+      },
+      {
+        isHighlighted: true,
+        value: 're',
+      },
+    ]);
+  });
+
+  test('returns the reverse-highlighted parts of the hit with a nested array attribute', () => {
+    expect(
+      parseAlgoliaHitReverseSnippet({
+        attribute: ['hierarchy', 'lvl0'],
+        hit: {
+          objectID: '1',
+          hierarchy: {
+            lvl0: 'Hello there',
+          },
+          _snippetResult: {
+            hierarchy: {
+              lvl0: {
+                value:
+                  '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+              },
+            },
+          },
         },
-        Object {
-          "isHighlighted": false,
-          "value": "he",
+      })
+    ).toEqual([
+      {
+        isHighlighted: false,
+        value: 'He',
+      },
+      {
+        isHighlighted: true,
+        value: 'llo t',
+      },
+      {
+        isHighlighted: false,
+        value: 'he',
+      },
+      {
+        isHighlighted: true,
+        value: 're',
+      },
+    ]);
+  });
+
+  test('returns the non-highlighted parts when every part matches', () => {
+    expect(
+      parseAlgoliaHitReverseSnippet({
+        attribute: 'title',
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          _highlightResult: {
+            title: { value: '__aa-highlight__Hello there__/aa-highlight__' },
+          },
         },
-        Object {
-          "isHighlighted": true,
-          "value": "re",
-        },
-      ]
-    `);
+      })
+    ).toEqual([{ isHighlighted: false, value: 'Hello there' }]);
   });
 
   test('returns the attribute value if the attribute cannot be snippeted', () => {
@@ -104,7 +191,95 @@ describe('parseAlgoliaHitReverseSnippet', () => {
         },
       });
     }).toWarnDev(
-      '[Autocomplete] The attribute "_snippetResult.description.value" does not exist on the hit. Did you set it in `attributesToSnippet`?' +
+      '[Autocomplete] The attribute path ["description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
+        '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/'
+    );
+  });
+
+  test('returns empty parts if the array attribute does not exist', () => {
+    expect(
+      parseAlgoliaHitReverseSnippet({
+        attribute: ['description'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          _snippetResult: {
+            title: {
+              value:
+                '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+            },
+          },
+        },
+      })
+    ).toEqual([]);
+  });
+
+  test('warns if the array attribute cannot be snippeted', () => {
+    expect(() => {
+      parseAlgoliaHitReverseSnippet({
+        attribute: ['description'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          description: 'Welcome all',
+          _highlightResult: {
+            title: {
+              value:
+                '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+              matchLevel: 'partial',
+              matchedWords: [],
+              fullyHighlighted: false,
+            },
+          },
+        },
+      });
+    }).toWarnDev(
+      '[Autocomplete] The attribute path ["description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
+        '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/'
+    );
+  });
+
+  test('returns empty parts if the nested array attribute does not exist', () => {
+    expect(
+      parseAlgoliaHitReverseSnippet({
+        attribute: ['title', 'description'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          _snippetResult: {
+            title: {
+              value:
+                '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+            },
+          },
+        },
+      })
+    ).toEqual([]);
+  });
+
+  test('warns if the nested array attribute cannot be snippeted', () => {
+    expect(() => {
+      parseAlgoliaHitReverseSnippet({
+        attribute: ['title', 'description'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          description: 'Welcome all',
+          _highlightResult: {
+            title: {
+              noDescription: {
+                value:
+                  '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+                matchLevel: 'partial',
+                matchedWords: [],
+                fullyHighlighted: false,
+              },
+            },
+          },
+        },
+      });
+    }).toWarnDev(
+      '[Autocomplete] The attribute path ["title","description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/'
     );
   });

--- a/packages/autocomplete-preset-algolia/src/highlight/__tests__/parseAlgoliaHitReverseSnippet.test.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/__tests__/parseAlgoliaHitReverseSnippet.test.ts
@@ -116,6 +116,45 @@ describe('parseAlgoliaHitReverseSnippet', () => {
     ]);
   });
 
+  test('returns the highlighted snippet parts of the hit with a nested array attribute containing a dot', () => {
+    expect(
+      parseAlgoliaHitReverseSnippet({
+        attribute: ['hierarchy', 'lvl0.inside'],
+        hit: {
+          objectID: '1',
+          hierarchy: {
+            'lvl0.inside': 'Hello there',
+          },
+          _snippetResult: {
+            hierarchy: {
+              'lvl0.inside': {
+                value:
+                  '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+              },
+            },
+          },
+        },
+      })
+    ).toEqual([
+      {
+        isHighlighted: false,
+        value: 'He',
+      },
+      {
+        isHighlighted: true,
+        value: 'llo t',
+      },
+      {
+        isHighlighted: false,
+        value: 'he',
+      },
+      {
+        isHighlighted: true,
+        value: 're',
+      },
+    ]);
+  });
+
   test('returns the non-highlighted parts when every part matches', () => {
     expect(
       parseAlgoliaHitReverseSnippet({
@@ -191,7 +230,7 @@ describe('parseAlgoliaHitReverseSnippet', () => {
         },
       });
     }).toWarnDev(
-      '[Autocomplete] The attribute path ["description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
+      '[Autocomplete] The attribute "description" described by the path ["description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/'
     );
   });
@@ -234,7 +273,7 @@ describe('parseAlgoliaHitReverseSnippet', () => {
         },
       });
     }).toWarnDev(
-      '[Autocomplete] The attribute path ["description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
+      '[Autocomplete] The attribute "description" described by the path ["description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/'
     );
   });
@@ -279,7 +318,35 @@ describe('parseAlgoliaHitReverseSnippet', () => {
         },
       });
     }).toWarnDev(
-      '[Autocomplete] The attribute path ["title","description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
+      '[Autocomplete] The attribute "title.description" described by the path ["title","description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
+        '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/'
+    );
+  });
+
+  test('warns if the nested array attribute containing a dot does not exist', () => {
+    expect(() => {
+      parseAlgoliaHitReverseSnippet({
+        attribute: ['hierarchy', 'lvl1.inside'],
+        hit: {
+          objectID: '1',
+          hierarchy: {
+            'lvl0.inside': 'Hello there',
+          },
+          _highlightResult: {
+            hierarchy: {
+              'lvl0.inside': {
+                value:
+                  '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+                matchLevel: 'partial',
+                matchedWords: [],
+                fullyHighlighted: false,
+              },
+            },
+          },
+        },
+      });
+    }).toWarnDev(
+      '[Autocomplete] The attribute "hierarchy.lvl1.inside" described by the path ["hierarchy","lvl1.inside"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/'
     );
   });

--- a/packages/autocomplete-preset-algolia/src/highlight/__tests__/parseAlgoliaHitSnippet.test.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/__tests__/parseAlgoliaHitSnippet.test.ts
@@ -42,7 +42,7 @@ describe('parseAlgoliaHitSnippet', () => {
     ]);
   });
 
-  test('returns the highlighted parts of the hit with an array attribute', () => {
+  test('returns the highlighted snippet parts of the hit with an array attribute', () => {
     expect(
       parseAlgoliaHitSnippet({
         attribute: ['title'],
@@ -77,7 +77,7 @@ describe('parseAlgoliaHitSnippet', () => {
     ]);
   });
 
-  test('returns the highlighted parts of the hit with a nested array attribute', () => {
+  test('returns the highlighted snippet parts of the hit with a nested array attribute', () => {
     expect(
       parseAlgoliaHitSnippet({
         attribute: ['hierarchy', 'lvl0'],
@@ -89,6 +89,45 @@ describe('parseAlgoliaHitSnippet', () => {
           _snippetResult: {
             hierarchy: {
               lvl0: {
+                value:
+                  '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+              },
+            },
+          },
+        },
+      })
+    ).toEqual([
+      {
+        isHighlighted: true,
+        value: 'He',
+      },
+      {
+        isHighlighted: false,
+        value: 'llo t',
+      },
+      {
+        isHighlighted: true,
+        value: 'he',
+      },
+      {
+        isHighlighted: false,
+        value: 're',
+      },
+    ]);
+  });
+
+  test('returns the highlighted snippet parts of the hit with a nested array attribute containing a dot', () => {
+    expect(
+      parseAlgoliaHitSnippet({
+        attribute: ['hierarchy', 'lvl0.inside'],
+        hit: {
+          objectID: '1',
+          hierarchy: {
+            'lvl0.inside': 'Hello there',
+          },
+          _snippetResult: {
+            hierarchy: {
+              'lvl0.inside': {
                 value:
                   '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
               },
@@ -176,7 +215,7 @@ describe('parseAlgoliaHitSnippet', () => {
         },
       });
     }).toWarnDev(
-      '[Autocomplete] The attribute path ["description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
+      '[Autocomplete] The attribute "description" described by the path ["description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/'
     );
   });
@@ -219,7 +258,7 @@ describe('parseAlgoliaHitSnippet', () => {
         },
       });
     }).toWarnDev(
-      '[Autocomplete] The attribute path ["description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
+      '[Autocomplete] The attribute "description" described by the path ["description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/'
     );
   });
@@ -264,7 +303,35 @@ describe('parseAlgoliaHitSnippet', () => {
         },
       });
     }).toWarnDev(
-      '[Autocomplete] The attribute path ["title","description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
+      '[Autocomplete] The attribute "title.description" described by the path ["title","description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
+        '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/'
+    );
+  });
+
+  test('warns if the nested array attribute containing a dot does not exist', () => {
+    expect(() => {
+      parseAlgoliaHitSnippet({
+        attribute: ['hierarchy', 'lvl1.inside'],
+        hit: {
+          objectID: '1',
+          hierarchy: {
+            'lvl0.inside': 'Hello there',
+          },
+          _highlightResult: {
+            hierarchy: {
+              'lvl0.inside': {
+                value:
+                  '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+                matchLevel: 'partial',
+                matchedWords: [],
+                fullyHighlighted: false,
+              },
+            },
+          },
+        },
+      });
+    }).toWarnDev(
+      '[Autocomplete] The attribute "hierarchy.lvl1.inside" described by the path ["hierarchy","lvl1.inside"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/'
     );
   });

--- a/packages/autocomplete-preset-algolia/src/highlight/__tests__/parseAlgoliaHitSnippet.test.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/__tests__/parseAlgoliaHitSnippet.test.ts
@@ -22,26 +22,98 @@ describe('parseAlgoliaHitSnippet', () => {
           },
         },
       })
-    ).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "isHighlighted": true,
-          "value": "He",
+    ).toEqual([
+      {
+        isHighlighted: true,
+        value: 'He',
+      },
+      {
+        isHighlighted: false,
+        value: 'llo t',
+      },
+      {
+        isHighlighted: true,
+        value: 'he',
+      },
+      {
+        isHighlighted: false,
+        value: 're',
+      },
+    ]);
+  });
+
+  test('returns the highlighted parts of the hit with an array attribute', () => {
+    expect(
+      parseAlgoliaHitSnippet({
+        attribute: ['title'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          _snippetResult: {
+            title: {
+              value:
+                '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+            },
+          },
         },
-        Object {
-          "isHighlighted": false,
-          "value": "llo t",
+      })
+    ).toEqual([
+      {
+        isHighlighted: true,
+        value: 'He',
+      },
+      {
+        isHighlighted: false,
+        value: 'llo t',
+      },
+      {
+        isHighlighted: true,
+        value: 'he',
+      },
+      {
+        isHighlighted: false,
+        value: 're',
+      },
+    ]);
+  });
+
+  test('returns the highlighted parts of the hit with a nested array attribute', () => {
+    expect(
+      parseAlgoliaHitSnippet({
+        attribute: ['hierarchy', 'lvl0'],
+        hit: {
+          objectID: '1',
+          hierarchy: {
+            lvl0: 'Hello there',
+          },
+          _snippetResult: {
+            hierarchy: {
+              lvl0: {
+                value:
+                  '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+              },
+            },
+          },
         },
-        Object {
-          "isHighlighted": true,
-          "value": "he",
-        },
-        Object {
-          "isHighlighted": false,
-          "value": "re",
-        },
-      ]
-    `);
+      })
+    ).toEqual([
+      {
+        isHighlighted: true,
+        value: 'He',
+      },
+      {
+        isHighlighted: false,
+        value: 'llo t',
+      },
+      {
+        isHighlighted: true,
+        value: 'he',
+      },
+      {
+        isHighlighted: false,
+        value: 're',
+      },
+    ]);
   });
 
   test('returns the attribute value if the attribute cannot be snippeted', () => {
@@ -104,7 +176,95 @@ describe('parseAlgoliaHitSnippet', () => {
         },
       });
     }).toWarnDev(
-      '[Autocomplete] The attribute "_snippetResult.description.value" does not exist on the hit. Did you set it in `attributesToSnippet`?' +
+      '[Autocomplete] The attribute path ["description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
+        '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/'
+    );
+  });
+
+  test('returns empty parts if the array attribute does not exist', () => {
+    expect(
+      parseAlgoliaHitSnippet({
+        attribute: ['description'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          _snippetResult: {
+            title: {
+              value:
+                '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+            },
+          },
+        },
+      })
+    ).toEqual([]);
+  });
+
+  test('warns if the array attribute cannot be snippeted', () => {
+    expect(() => {
+      parseAlgoliaHitSnippet({
+        attribute: ['description'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          description: 'Welcome all',
+          _highlightResult: {
+            title: {
+              value:
+                '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+              matchLevel: 'partial',
+              matchedWords: [],
+              fullyHighlighted: false,
+            },
+          },
+        },
+      });
+    }).toWarnDev(
+      '[Autocomplete] The attribute path ["description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
+        '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/'
+    );
+  });
+
+  test('returns empty parts if the nested array attribute does not exist', () => {
+    expect(
+      parseAlgoliaHitSnippet({
+        attribute: ['title', 'description'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          _snippetResult: {
+            title: {
+              value:
+                '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+            },
+          },
+        },
+      })
+    ).toEqual([]);
+  });
+
+  test('warns if the nested array attribute cannot be snippeted', () => {
+    expect(() => {
+      parseAlgoliaHitSnippet({
+        attribute: ['title', 'description'],
+        hit: {
+          objectID: '1',
+          title: 'Hello there',
+          description: 'Welcome all',
+          _highlightResult: {
+            title: {
+              noDescription: {
+                value:
+                  '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+                matchLevel: 'partial',
+                matchedWords: [],
+                fullyHighlighted: false,
+              },
+            },
+          },
+        },
+      });
+    }).toWarnDev(
+      '[Autocomplete] The attribute path ["title","description"] does not exist on the hit. Did you set it in `attributesToSnippet`?' +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/'
     );
   });

--- a/packages/autocomplete-preset-algolia/src/highlight/getAttributeValueByPath.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/getAttributeValueByPath.ts
@@ -1,6 +1,3 @@
-export function getAttributeValueByPath<THit>(hit: THit, path: string): any {
-  const parts = path.split('.');
-  const value = parts.reduce((current, key) => current && current[key], hit);
-
-  return value;
+export function getAttributeValueByPath<THit>(hit: THit, path: string[]): any {
+  return path.reduce((current, key) => current && current[key], hit);
 }

--- a/packages/autocomplete-preset-algolia/src/highlight/parseAlgoliaHitHighlight.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/parseAlgoliaHitHighlight.ts
@@ -10,19 +10,23 @@ export function parseAlgoliaHitHighlight<THit extends Hit<{}>>({
   hit,
   attribute,
 }: ParseAlgoliaHitParams<THit>): ParsedAttribute[] {
-  const path = `_highlightResult.${attribute}.value`;
-  let highlightedValue = getAttributeValueByPath(hit, path);
+  const path = Array.isArray(attribute) ? attribute : ([attribute] as string[]);
+  let highlightedValue = getAttributeValueByPath(hit, [
+    '_highlightResult',
+    ...path,
+    'value',
+  ]);
 
   if (typeof highlightedValue !== 'string') {
     warn(
       false,
-      `The attribute ${JSON.stringify(
+      `The attribute path ${JSON.stringify(
         path
       )} does not exist on the hit. Did you set it in \`attributesToHighlight\`?` +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/'
     );
 
-    highlightedValue = getAttributeValueByPath(hit, attribute as string) || '';
+    highlightedValue = getAttributeValueByPath(hit, path) || '';
   }
 
   return parseAttribute({ highlightedValue });

--- a/packages/autocomplete-preset-algolia/src/highlight/parseAlgoliaHitHighlight.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/parseAlgoliaHitHighlight.ts
@@ -20,7 +20,7 @@ export function parseAlgoliaHitHighlight<THit extends Hit<{}>>({
   if (typeof highlightedValue !== 'string') {
     warn(
       false,
-      `The attribute path ${JSON.stringify(
+      `The attribute "${path.join('.')}" described by the path ${JSON.stringify(
         path
       )} does not exist on the hit. Did you set it in \`attributesToHighlight\`?` +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/'

--- a/packages/autocomplete-preset-algolia/src/highlight/parseAlgoliaHitSnippet.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/parseAlgoliaHitSnippet.ts
@@ -20,7 +20,7 @@ export function parseAlgoliaHitSnippet<THit extends Hit<{}>>({
   if (typeof highlightedValue !== 'string') {
     warn(
       false,
-      `The attribute path ${JSON.stringify(
+      `The attribute "${path.join('.')}" described by the path ${JSON.stringify(
         path
       )} does not exist on the hit. Did you set it in \`attributesToSnippet\`?` +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/'

--- a/packages/autocomplete-preset-algolia/src/highlight/parseAlgoliaHitSnippet.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/parseAlgoliaHitSnippet.ts
@@ -10,19 +10,23 @@ export function parseAlgoliaHitSnippet<THit extends Hit<{}>>({
   hit,
   attribute,
 }: ParseAlgoliaHitParams<THit>): ParsedAttribute[] {
-  const path = `_snippetResult.${attribute}.value`;
-  let highlightedValue = getAttributeValueByPath(hit, path);
+  const path = Array.isArray(attribute) ? attribute : ([attribute] as string[]);
+  let highlightedValue = getAttributeValueByPath(hit, [
+    '_snippetResult',
+    ...path,
+    'value',
+  ]);
 
   if (typeof highlightedValue !== 'string') {
     warn(
       false,
-      `The attribute ${JSON.stringify(
+      `The attribute path ${JSON.stringify(
         path
       )} does not exist on the hit. Did you set it in \`attributesToSnippet\`?` +
         '\nSee https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/'
     );
 
-    highlightedValue = getAttributeValueByPath(hit, attribute as string) || '';
+    highlightedValue = getAttributeValueByPath(hit, path) || '';
   }
 
   return parseAttribute({ highlightedValue });

--- a/packages/website/docs/highlightHit.md
+++ b/packages/website/docs/highlightHit.md
@@ -33,7 +33,7 @@ import { highlightHit } from '@algolia/autocomplete-js';
 // fetch an Algolia hit
 const hit = {
   query: {
-      title: 'Hello there',
+    title: 'Hello there',
   }
   _highlightResult: {
     query: {

--- a/packages/website/docs/highlightHit.md
+++ b/packages/website/docs/highlightHit.md
@@ -4,15 +4,49 @@ id: highlightHit
 
 Returns a virtual node with highlighted matching parts of an Algolia hit.
 
-## Example
+## Example with a single string
 
 ```js
 import { highlightHit } from '@algolia/autocomplete-js';
 
-const hit = {}; // fetch an Algolia hit
+// fetch an Algolia hit
+const hit = {
+  query: 'Hello there',
+  _highlightResult: {
+    query: {
+      value:
+        '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+    },
+  },
+};
 const highlightedValue = highlightHit({
   hit,
   attribute: 'query',
+});
+```
+
+## Example with an nested array of strings
+
+```js
+import { highlightHit } from '@algolia/autocomplete-js';
+
+// fetch an Algolia hit
+const hit = {
+  query: {
+      title: 'Hello there',
+  }
+  _highlightResult: {
+    query: {
+      title: {
+        value:
+          '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+      },
+    },
+  },
+};
+const highlightedValue = highlightHit({
+  hit,
+  attribute: ['query', 'title'],
 });
 ```
 
@@ -26,7 +60,7 @@ The Algolia hit to retrieve the attribute value from.
 
 ### `attribute`
 
-> `string` | required
+> `string | string[]` | required
 
 The attribute to retrieve the highlight value from.
 

--- a/packages/website/docs/highlightHit.md
+++ b/packages/website/docs/highlightHit.md
@@ -25,7 +25,7 @@ const highlightedValue = highlightHit({
 });
 ```
 
-## Example with an nested array of strings
+## Example with nested attributes
 
 ```js
 import { highlightHit } from '@algolia/autocomplete-js';
@@ -62,7 +62,7 @@ The Algolia hit to retrieve the attribute value from.
 
 > `string | string[]` | required
 
-The attribute to retrieve the highlight value from.
+The attribute to retrieve the highlight value from. You can use the array syntax to reference the nested attributes.
 
 ### `tagName`
 

--- a/packages/website/docs/parseAlgoliaHitHighlight.md
+++ b/packages/website/docs/parseAlgoliaHitHighlight.md
@@ -26,7 +26,7 @@ const snippetParts = parseAlgoliaHitHighlight({
 // => [{ value: 'Lap', isHighlighted: true }, { value: 'top', isHighlighted: false }]
 ```
 
-## Example with an nested array of strings
+## Example with nested attributes
 
 ```js
 import { parseAlgoliaHitHighlight } from '@algolia/autocomplete-preset-algolia';
@@ -64,4 +64,4 @@ The Algolia hit to retrieve the attribute value from.
 
 > `string | string[]` | required
 
-The attribute to retrieve the reverse highlight value from.
+The attribute to retrieve the reverse highlight value from. You can use the array syntax to reference the nested attributes.

--- a/packages/website/docs/parseAlgoliaHitHighlight.md
+++ b/packages/website/docs/parseAlgoliaHitHighlight.md
@@ -4,7 +4,7 @@ id: parseAlgoliaHitHighlight
 
 Returns the highlighted parts of an Algolia hit.
 
-## Example
+## Example with a single string
 
 ```js
 import { parseAlgoliaHitHighlight } from '@algolia/autocomplete-preset-algolia';
@@ -18,9 +18,35 @@ const hit = {
     },
   },
 };
-const highlightParts = parseAlgoliaHitHighlight({
+const snippetParts = parseAlgoliaHitHighlight({
   hit,
-  attribute: 'query',
+  attribute: 'name',
+});
+
+// => [{ value: 'Lap', isHighlighted: true }, { value: 'top', isHighlighted: false }]
+```
+
+## Example with an nested array of strings
+
+```js
+import { parseAlgoliaHitHighlight } from '@algolia/autocomplete-preset-algolia';
+
+// Fetch an Algolia hit
+const hit = {
+  name: {
+    type: 'Laptop',
+  },
+  _highlightResult: {
+    name: {
+      type: {
+        value: '__aa_highlight__Lap__/aa_highlight__top',
+      },
+    },
+  },
+};
+const snippetParts = parseAlgoliaHitHighlight({
+  hit,
+  attribute: ['name', 'type'],
 });
 
 // => [{ value: 'Lap', isHighlighted: true }, { value: 'top', isHighlighted: false }]
@@ -36,6 +62,6 @@ The Algolia hit to retrieve the attribute value from.
 
 ### `attribute`
 
-> `string` | required
+> `string | string[]` | required
 
 The attribute to retrieve the reverse highlight value from.

--- a/packages/website/docs/parseAlgoliaHitReverseHighlight.md
+++ b/packages/website/docs/parseAlgoliaHitReverseHighlight.md
@@ -28,7 +28,7 @@ const snippetParts = parseAlgoliaHitReverseHighlight({
 // => [{ value: 'Lap', isHighlighted: false }, { value: 'top', isHighlighted: true }]
 ```
 
-## Example with an nested array of strings
+## Example with nested attributes
 
 ```js
 import { parseAlgoliaHitReverseHighlight } from '@algolia/autocomplete-preset-algolia';
@@ -68,4 +68,4 @@ The Algolia hit to retrieve the attribute value from.
 
 > `string | string[]` | required
 
-The attribute to retrieve the highlight value from.
+The attribute to retrieve the highlight value from. You can use the array syntax to reference the nested attributes.

--- a/packages/website/docs/parseAlgoliaHitReverseHighlight.md
+++ b/packages/website/docs/parseAlgoliaHitReverseHighlight.md
@@ -6,7 +6,7 @@ Returns the highlighted parts of an Algolia hit.
 
 This is a common pattern for Query Suggestions.
 
-# Example
+## Example with a single string
 
 ```js
 import { parseAlgoliaHitReverseHighlight } from '@algolia/autocomplete-preset-algolia';
@@ -20,12 +20,38 @@ const hit = {
     },
   },
 };
-const highlightedAlgoliaHit = parseAlgoliaHitReverseHighlight({
+const snippetParts = parseAlgoliaHitReverseHighlight({
   hit,
-  attribute: 'query',
+  attribute: 'name',
 });
 
-// => [{ value: 'Lap', isHighlighted: true }, { value: 'top', isHighlighted: false }]
+// => [{ value: 'Lap', isHighlighted: false }, { value: 'top', isHighlighted: true }]
+```
+
+## Example with an nested array of strings
+
+```js
+import { parseAlgoliaHitReverseHighlight } from '@algolia/autocomplete-preset-algolia';
+
+// Fetch an Algolia hit
+const hit = {
+  name: {
+    type: 'Laptop',
+  },
+  _highlightResult: {
+    name: {
+      type: {
+        value: '__aa_highlight__Lap__/aa_highlight__top',
+      },
+    },
+  },
+};
+const snippetParts = parseAlgoliaHitReverseHighlight({
+  hit,
+  attribute: ['name', 'type'],
+});
+
+// => [{ value: 'Lap', isHighlighted: false }, { value: 'top', isHighlighted: true }]
 ```
 
 # Reference
@@ -40,6 +66,6 @@ The Algolia hit to retrieve the attribute value from.
 
 ### `attribute`
 
-> `string` | required
+> `string | string[]` | required
 
 The attribute to retrieve the highlight value from.

--- a/packages/website/docs/parseAlgoliaHitReverseSnippet.md
+++ b/packages/website/docs/parseAlgoliaHitReverseSnippet.md
@@ -28,7 +28,7 @@ const snippetParts = parseAlgoliaHitReverseSnippet({
 // => [{ value: 'Lap', isHighlighted: false }, { value: 'top', isHighlighted: true }]
 ```
 
-## Example with an nested array of strings
+## Example with nested attributes
 
 ```js
 import { parseAlgoliaHitReverseSnippet } from '@algolia/autocomplete-preset-algolia';
@@ -66,4 +66,4 @@ The Algolia hit to retrieve the attribute value from.
 
 > `string | string[]` | required
 
-The attribute to retrieve the reverse snippet value from.
+The attribute to retrieve the reverse snippet value from. You can use the array syntax to reference the nested attributes.

--- a/packages/website/docs/parseAlgoliaHitReverseSnippet.md
+++ b/packages/website/docs/parseAlgoliaHitReverseSnippet.md
@@ -6,7 +6,7 @@ Returns the non-matching parts of an Algolia hit snippet.
 
 This is a common pattern for Query Suggestions.
 
-## Example
+## Example with a single string
 
 ```js
 import { parseAlgoliaHitReverseSnippet } from '@algolia/autocomplete-preset-algolia';
@@ -28,6 +28,32 @@ const snippetParts = parseAlgoliaHitReverseSnippet({
 // => [{ value: 'Lap', isHighlighted: false }, { value: 'top', isHighlighted: true }]
 ```
 
+## Example with an nested array of strings
+
+```js
+import { parseAlgoliaHitReverseSnippet } from '@algolia/autocomplete-preset-algolia';
+
+// Fetch an Algolia hit
+const hit = {
+  name: {
+    type: 'Laptop',
+  },
+  _snippetResult: {
+    name: {
+      type: {
+        value: '__aa_highlight__Lap__/aa_highlight__top',
+      },
+    },
+  },
+};
+const snippetParts = parseAlgoliaHitReverseSnippet({
+  hit,
+  attribute: ['name', 'type'],
+});
+
+// => [{ value: 'Lap', isHighlighted: false }, { value: 'top', isHighlighted: true }]
+```
+
 ## Params
 
 ### `hit`
@@ -38,6 +64,6 @@ The Algolia hit to retrieve the attribute value from.
 
 ### `attribute`
 
-> `string` | required
+> `string | string[]` | required
 
 The attribute to retrieve the reverse snippet value from.

--- a/packages/website/docs/parseAlgoliaHitSnippet.md
+++ b/packages/website/docs/parseAlgoliaHitSnippet.md
@@ -26,7 +26,7 @@ const snippetParts = parseAlgoliaHitSnippet({
 // => [{ value: 'Lap', isHighlighted: true }, { value: 'top', isHighlighted: false }]
 ```
 
-## Example with an nested array of strings
+## Example with nested attributes
 
 ```js
 import { parseAlgoliaHitSnippet } from '@algolia/autocomplete-preset-algolia';
@@ -64,4 +64,4 @@ The Algolia hit to retrieve the attribute value from.
 
 > `string | string[]` | required
 
-The attribute to retrieve the snippet value from.
+The attribute to retrieve the snippet value from. You can use the array syntax to reference the nested attributes.

--- a/packages/website/docs/parseAlgoliaHitSnippet.md
+++ b/packages/website/docs/parseAlgoliaHitSnippet.md
@@ -4,7 +4,7 @@ id: parseAlgoliaHitSnippet
 
 Returns the snippeted parts of an Algolia hit.
 
-## Example
+## Example with a single string
 
 ```js
 import { parseAlgoliaHitSnippet } from '@algolia/autocomplete-preset-algolia';
@@ -20,7 +20,33 @@ const hit = {
 };
 const snippetParts = parseAlgoliaHitSnippet({
   hit,
-  attribute: 'query',
+  attribute: 'name',
+});
+
+// => [{ value: 'Lap', isHighlighted: true }, { value: 'top', isHighlighted: false }]
+```
+
+## Example with an nested array of strings
+
+```js
+import { parseAlgoliaHitSnippet } from '@algolia/autocomplete-preset-algolia';
+
+// Fetch an Algolia hit
+const hit = {
+  name: {
+    type: 'Laptop',
+  },
+  _snippetResult: {
+    name: {
+      type: {
+        value: '__aa_highlight__Lap__/aa_highlight__top',
+      },
+    },
+  },
+};
+const snippetParts = parseAlgoliaHitSnippet({
+  hit,
+  attribute: ['name', 'type'],
 });
 
 // => [{ value: 'Lap', isHighlighted: true }, { value: 'top', isHighlighted: false }]
@@ -36,6 +62,6 @@ The Algolia hit to retrieve the attribute value from.
 
 ### `attribute`
 
-> `string` | required
+> `string | string[]` | required
 
 The attribute to retrieve the snippet value from.


### PR DESCRIPTION
**Summary**
Allow `attribute` key to receive a `string[]` containing the path of the highlighted element in the hit.

**TypeScript**
I couldn't find a good way to implement deep object pathing, so it's not typed for now. It also looks like that a `PathOf` type is 
 still discussed.