### PR TITLE
feat(sourceId): Add `sourceId` to provide `data-autocomplete-source-id` on `section` source container

### DIFF
--- a/examples/js/app.tsx
+++ b/examples/js/app.tsx
@@ -30,13 +30,11 @@ insightsClient('init', { appId, apiKey });
 
 const algoliaInsightsPlugin = createAlgoliaInsightsPlugin({ insightsClient });
 const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
-  sourceId: 'recentSearchesPlugin',
   key: 'search',
   limit: 3,
 });
 const querySuggestionsPlugin = createQuerySuggestionsPlugin({
   searchClient,
-  sourceId: 'querySuggestionsPlugin',
   indexName: 'instant_search_demo_query_suggestions',
   getSearchParams({ state }) {
     return recentSearchesPlugin.data.getAlgoliaSearchParams({
@@ -64,7 +62,7 @@ autocomplete({
 
     return [
       {
-        sourceId: 'algoliaHits',
+        sourceId: 'products',
         getItems() {
           return getAlgoliaHits<Product>({
             searchClient,

--- a/examples/js/app.tsx
+++ b/examples/js/app.tsx
@@ -30,11 +30,13 @@ insightsClient('init', { appId, apiKey });
 
 const algoliaInsightsPlugin = createAlgoliaInsightsPlugin({ insightsClient });
 const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
+  sourceId: 'recentSearchesPlugin',
   key: 'search',
   limit: 3,
 });
 const querySuggestionsPlugin = createQuerySuggestionsPlugin({
   searchClient,
+  sourceId: 'querySuggestionsPlugin',
   indexName: 'instant_search_demo_query_suggestions',
   getSearchParams({ state }) {
     return recentSearchesPlugin.data.getAlgoliaSearchParams({
@@ -62,6 +64,7 @@ autocomplete({
 
     return [
       {
+        sourceId: 'algoliaHits',
         getItems() {
           return getAlgoliaHits<Product>({
             searchClient,

--- a/examples/js/shortcutsPlugin.tsx
+++ b/examples/js/shortcutsPlugin.tsx
@@ -14,6 +14,7 @@ export const shortcutsPlugin: AutocompletePlugin<DarkModeItem> = {
 
     return [
       {
+        sourceId: 'shortcutsPlugin',
         getItems() {
           return [
             {

--- a/packages/autocomplete-core/src/__tests__/concurrency.test.ts
+++ b/packages/autocomplete-core/src/__tests__/concurrency.test.ts
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event';
 
-import { defer } from '../../../../test/utils';
+import { createSource, defer } from '../../../../test/utils';
 import { createAutocomplete } from '../createAutocomplete';
 
 describe.skip('concurrency', () => {
@@ -14,12 +14,11 @@ describe.skip('concurrency', () => {
 
       return defer(() => {
         return [
-          {
-            sourceId: 'testSource',
+          createSource({
             getItems() {
               return [{ label: query }];
             },
-          },
+          }),
         ];
       }, delays[deferCount]);
     };

--- a/packages/autocomplete-core/src/__tests__/concurrency.test.ts
+++ b/packages/autocomplete-core/src/__tests__/concurrency.test.ts
@@ -15,6 +15,7 @@ describe.skip('concurrency', () => {
       return defer(() => {
         return [
           {
+            sourceId: 'testSource',
             getItems() {
               return [{ label: query }];
             },

--- a/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
@@ -1049,7 +1049,7 @@ describe('getInputProps', () => {
                     { label: '2', url: '#2' },
                   ],
                   source: {
-                    sourceId: 'testSource',
+                    sourceId: expect.any(String),
                     getItemInputValue: expect.any(Function),
                     getItemUrl: expect.any(Function),
                     getItems: expect.any(Function),

--- a/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
@@ -1049,6 +1049,7 @@ describe('getInputProps', () => {
                     { label: '2', url: '#2' },
                   ],
                   source: {
+                    sourceId: 'testSource',
                     getItemInputValue: expect.any(Function),
                     getItemUrl: expect.any(Function),
                     getItems: expect.any(Function),

--- a/packages/autocomplete-core/src/__tests__/getSources.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getSources.test.ts
@@ -47,6 +47,7 @@ describe('getSources', () => {
       getSources: () => {
         return [
           {
+            sourceId: 'testSource',
             getItems() {
               return [];
             },
@@ -78,6 +79,7 @@ describe('getSources', () => {
                 templates: expect.objectContaining({
                   item: expect.any(Function),
                 }),
+                sourceId: expect.any(String),
               },
             }),
           ]),
@@ -92,6 +94,7 @@ describe('getSources', () => {
       getSources: () => {
         return [
           {
+            sourceId: 'pluginSource',
             getItems() {
               return [];
             },
@@ -107,6 +110,7 @@ describe('getSources', () => {
       getSources: () => {
         return [
           {
+            sourceId: 'testSource',
             getItems() {
               return [];
             },

--- a/packages/autocomplete-core/src/__tests__/stallThreshold.test.ts
+++ b/packages/autocomplete-core/src/__tests__/stallThreshold.test.ts
@@ -12,6 +12,7 @@ describe('stallThreshold', () => {
         return defer(() => {
           return [
             {
+              sourceId: 'testSource',
               getItems() {
                 return [{ label: '1' }, { label: 2 }];
               },
@@ -60,6 +61,7 @@ describe('stallThreshold', () => {
         return defer(() => {
           return [
             {
+              sourceId: 'testSource',
               getItems() {
                 return [{ label: '1' }, { label: 2 }];
               },

--- a/packages/autocomplete-core/src/__tests__/stallThreshold.test.ts
+++ b/packages/autocomplete-core/src/__tests__/stallThreshold.test.ts
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event';
 
-import { defer } from '../../../../test/utils';
+import { createSource, defer } from '../../../../test/utils';
 import { createAutocomplete } from '../createAutocomplete';
 
 describe('stallThreshold', () => {
@@ -11,12 +11,11 @@ describe('stallThreshold', () => {
       getSources() {
         return defer(() => {
           return [
-            {
-              sourceId: 'testSource',
+            createSource({
               getItems() {
                 return [{ label: '1' }, { label: 2 }];
               },
-            },
+            }),
           ];
         }, 500);
       },
@@ -60,12 +59,11 @@ describe('stallThreshold', () => {
       getSources() {
         return defer(() => {
           return [
-            {
-              sourceId: 'testSource',
+            createSource({
               getItems() {
                 return [{ label: '1' }, { label: 2 }];
               },
-            },
+            }),
           ];
         }, 500);
       },

--- a/packages/autocomplete-core/src/types/AutocompleteSource.ts
+++ b/packages/autocomplete-core/src/types/AutocompleteSource.ts
@@ -57,7 +57,7 @@ export interface AutocompleteSource<TItem extends BaseItem> {
    * An item is highlighted either via keyboard navigation or via mouse over.
    * You can trigger different behaviors based on the event `type`.
    */
-  onActive?(params: OnHighlightParams<TItem>): void;
+  onActive?(params: OnActiveParams<TItem>): void;
   /**
    * Identifier for the source.
    */

--- a/packages/autocomplete-core/src/types/AutocompleteSource.ts
+++ b/packages/autocomplete-core/src/types/AutocompleteSource.ts
@@ -59,7 +59,7 @@ export interface AutocompleteSource<TItem extends BaseItem> {
    */
   onActive?(params: OnHighlightParams<TItem>): void;
   /**
-   * Applied to data-autocomplete-source-id on the section source container
+   * Identifier for the source.
    */
   sourceId: string;
 }

--- a/packages/autocomplete-core/src/types/AutocompleteSource.ts
+++ b/packages/autocomplete-core/src/types/AutocompleteSource.ts
@@ -58,6 +58,10 @@ export interface AutocompleteSource<TItem extends BaseItem> {
    * You can trigger different behaviors based on the event `type`.
    */
   onActive?(params: OnHighlightParams<TItem>): void;
+  /**
+   * Applied to data-autocomplete-source-id on the section source container
+   */
+  sourceId: string;
 }
 
 export type InternalAutocompleteSource<TItem extends BaseItem> = {

--- a/packages/autocomplete-core/src/utils/__tests__/getNormalizedSources.test.ts
+++ b/packages/autocomplete-core/src/utils/__tests__/getNormalizedSources.test.ts
@@ -70,7 +70,7 @@ describe('getNormalizedSources', () => {
     );
   });
 
-  test('with with missing sourceId triggers invariant', async () => {
+  test('with missing sourceId triggers invariant', async () => {
     const getSources = () => [
       {
         getItems() {

--- a/packages/autocomplete-core/src/utils/__tests__/getNormalizedSources.test.ts
+++ b/packages/autocomplete-core/src/utils/__tests__/getNormalizedSources.test.ts
@@ -70,7 +70,7 @@ describe('getNormalizedSources', () => {
     );
   });
 
-  test('with missing sourceId triggers invariant', async () => {
+  test('with missing `sourceId` triggers invariant', async () => {
     const getSources = () => [
       {
         getItems() {
@@ -89,9 +89,31 @@ describe('getNormalizedSources', () => {
 
     // @ts-expect-error
     await expect(getNormalizedSources(getSources, params)).rejects.toEqual(
-      new Error(
-        '[Autocomplete] The `getSources` function must return a `sourceId` string but returned type "undefined":\n\nundefined'
-      )
+      new Error('[Autocomplete] A source must provide a `sourceId` string.')
+    );
+  });
+
+  test('with wrong `sourceId` type triggers invariant', async () => {
+    const getSources = () => [
+      {
+        sourceId: ['testSource'],
+        getItems() {
+          return [];
+        },
+        templates: {
+          item() {},
+        },
+      },
+    ];
+    const params = {
+      query: '',
+      state: createState({}),
+      ...createScopeApi(),
+    };
+
+    // @ts-expect-error
+    await expect(getNormalizedSources(getSources, params)).rejects.toEqual(
+      new Error('[Autocomplete] A source must provide a `sourceId` string.')
     );
   });
 

--- a/packages/autocomplete-core/src/utils/__tests__/getNormalizedSources.test.ts
+++ b/packages/autocomplete-core/src/utils/__tests__/getNormalizedSources.test.ts
@@ -7,7 +7,7 @@ import { getNormalizedSources } from '../getNormalizedSources';
 
 describe('getNormalizedSources', () => {
   test('returns a promise of sources', async () => {
-    const getSources = () => [{ getItems: () => [] }];
+    const getSources = () => [{ sourceId: 'testSource', getItems: () => [] }];
     const params = {
       query: '',
       state: createState({
@@ -23,12 +23,17 @@ describe('getNormalizedSources', () => {
         getItems: expect.any(Function),
         onActive: expect.any(Function),
         onSelect: expect.any(Function),
+        sourceId: 'testSource',
       },
     ]);
   });
 
   test('filters out falsy sources', async () => {
-    const getSources = () => [{ getItems: () => [] }, false, undefined];
+    const getSources = () => [
+      { sourceId: 'testSource', getItems: () => [] },
+      false,
+      undefined,
+    ];
     const params = {
       query: '',
       state: createState({
@@ -44,6 +49,7 @@ describe('getNormalizedSources', () => {
         getItems: expect.any(Function),
         onActive: expect.any(Function),
         onSelect: expect.any(Function),
+        sourceId: 'testSource',
       },
     ]);
   });
@@ -64,8 +70,33 @@ describe('getNormalizedSources', () => {
     );
   });
 
+  test('with with missing sourceId triggers invariant', async () => {
+    const getSources = () => [
+      {
+        getItems() {
+          return [];
+        },
+        templates: {
+          item() {},
+        },
+      },
+    ];
+    const params = {
+      query: '',
+      state: createState({}),
+      ...createScopeApi(),
+    };
+
+    // @ts-expect-error
+    await expect(getNormalizedSources(getSources, params)).rejects.toEqual(
+      new Error(
+        '[Autocomplete] The `getSources` function must return a `sourceId` string but returned type "undefined":\n\nundefined'
+      )
+    );
+  });
+
   test('provides a default implementation for getItemInputValue which returns the query', async () => {
-    const getSources = () => [{ getItems: () => [] }];
+    const getSources = () => [{ sourceId: 'testSource', getItems: () => [] }];
     const params = {
       query: '',
       state: createState({
@@ -82,7 +113,7 @@ describe('getNormalizedSources', () => {
   });
 
   test('provides a default implementation for getItemUrl', async () => {
-    const getSources = () => [{ getItems: () => [] }];
+    const getSources = () => [{ sourceId: 'testSource', getItems: () => [] }];
     const params = {
       query: '',
       state: createState({}),
@@ -97,7 +128,7 @@ describe('getNormalizedSources', () => {
   });
 
   test('provides a default implementation for onSelect', async () => {
-    const getSources = () => [{ getItems: () => [] }];
+    const getSources = () => [{ sourceId: 'testSource', getItems: () => [] }];
     const params = {
       query: '',
       state: createState({}),
@@ -119,7 +150,7 @@ describe('getNormalizedSources', () => {
   });
 
   test('provides a default implementation for onActive', async () => {
-    const getSources = () => [{ getItems: () => [] }];
+    const getSources = () => [{ sourceId: 'testSource', getItems: () => [] }];
     const params = {
       query: '',
       state: createState({}),

--- a/packages/autocomplete-core/src/utils/getNormalizedSources.ts
+++ b/packages/autocomplete-core/src/utils/getNormalizedSources.ts
@@ -33,10 +33,8 @@ export function getNormalizedSources<TItem extends BaseItem>(
         )
         .map((source) => {
           invariant(
-            source.sourceId !== undefined,
-            `The \`getSources\` function must return a \`sourceId\` string but returned type ${JSON.stringify(
-              typeof source.sourceId
-            )}:\n\n${JSON.stringify(source.sourceId, null, 2)}`
+            typeof source.sourceId === 'string',
+            'A source must provide a `sourceId` string.'
           );
 
           const normalizedSource: InternalAutocompleteSource<TItem> = {

--- a/packages/autocomplete-core/src/utils/getNormalizedSources.ts
+++ b/packages/autocomplete-core/src/utils/getNormalizedSources.ts
@@ -32,6 +32,13 @@ export function getNormalizedSources<TItem extends BaseItem>(
           Boolean(maybeSource)
         )
         .map((source) => {
+          invariant(
+            source.sourceId !== undefined,
+            `The \`getSources\` function must return a \`sourceId\` string but returned type ${JSON.stringify(
+              typeof source.sourceId
+            )}:\n\n${JSON.stringify(source.sourceId, null, 2)}`
+          );
+
           const normalizedSource: InternalAutocompleteSource<TItem> = {
             getItemInputValue({ state }) {
               return state.query;

--- a/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
+++ b/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
@@ -11,6 +11,7 @@ describe('autocomplete-js', () => {
       getSources() {
         return [
           {
+            sourceId: 'testSource',
             getItems() {
               return [
                 { label: 'Item 1' },
@@ -167,6 +168,7 @@ describe('autocomplete-js', () => {
       getSources() {
         return [
           {
+            sourceId: 'testSource',
             getItems() {
               return [];
             },
@@ -206,6 +208,7 @@ describe('autocomplete-js', () => {
       getSources() {
         return [
           {
+            sourceId: 'testSource',
             getItems() {
               return [];
             },
@@ -245,6 +248,7 @@ describe('autocomplete-js', () => {
       getSources() {
         return [
           {
+            sourceId: 'testSource',
             getItems() {
               return [];
             },
@@ -290,6 +294,7 @@ describe('autocomplete-js', () => {
       getSources() {
         return [
           {
+            sourceId: 'testSource',
             getItems() {
               return [];
             },
@@ -338,6 +343,7 @@ describe('autocomplete-js', () => {
       getSources() {
         return [
           {
+            sourceId: 'testSource',
             getItems() {
               return [];
             },
@@ -383,6 +389,7 @@ describe('autocomplete-js', () => {
       getSources() {
         return [
           {
+            sourceId: 'testSource',
             getItems() {
               return [
                 { label: 'Item 1' },
@@ -418,6 +425,7 @@ describe('autocomplete-js', () => {
       getSources() {
         return [
           {
+            sourceId: 'testSource',
             getItems() {
               return [
                 { label: 'Item 1' },
@@ -449,6 +457,7 @@ describe('autocomplete-js', () => {
       getSources() {
         return [
           {
+            sourceId: 'testSource',
             getItems() {
               return [
                 { label: 'Item 1' },
@@ -482,6 +491,7 @@ describe('autocomplete-js', () => {
       getSources() {
         return [
           {
+            sourceId: 'testSource',
             getItems() {
               return [
                 { label: 'Item 1' },
@@ -512,6 +522,7 @@ describe('autocomplete-js', () => {
       getSources() {
         return [
           {
+            sourceId: 'testSource',
             getItems() {
               return [
                 { label: 'Item 1' },

--- a/packages/autocomplete-js/src/__tests__/positioning.test.ts
+++ b/packages/autocomplete-js/src/__tests__/positioning.test.ts
@@ -35,6 +35,7 @@ const querySuggestionsFixturePlugin: AutocompletePlugin<
   getSources() {
     return [
       {
+        sourceId: 'testSource',
         getItems() {
           return querySuggestions;
         },

--- a/packages/autocomplete-js/src/render.tsx
+++ b/packages/autocomplete-js/src/render.tsx
@@ -92,7 +92,11 @@ export function renderPanel<TItem extends BaseItem>(
   dom.panel.classList.toggle('aa-Panel--stalled', state.status === 'stalled');
 
   const sections = state.collections.map(({ source, items }, sourceIndex) => (
-    <section key={sourceIndex} className={classNames.source}>
+    <section
+      key={sourceIndex}
+      className={classNames.source}
+      data-autocomplete-source-id={source.sourceId}
+    >
       {source.templates.header && (
         <div className={classNames.sourceHeader}>
           {source.templates.header({

--- a/packages/autocomplete-js/src/types/AutocompleteSource.ts
+++ b/packages/autocomplete-js/src/types/AutocompleteSource.ts
@@ -53,8 +53,17 @@ type WithTemplates<TType, TItem extends BaseItem> = TType & {
   templates: SourceTemplates<TItem>;
 };
 
+export interface AutocompleteCoreSourceWithDocs<TItem extends BaseItem>
+  extends AutocompleteCoreSource<TItem> {
+  /**
+   * Identifier for the source.
+   * It is used as value for the `data-autocomplete-source-id` attribute of the source `section` container.
+   */
+  sourceId: string;
+}
+
 export type AutocompleteSource<TItem extends BaseItem> = WithTemplates<
-  AutocompleteCoreSource<TItem>,
+  AutocompleteCoreSourceWithDocs<TItem>,
   TItem
 >;
 

--- a/packages/autocomplete-js/src/types/AutocompleteSource.ts
+++ b/packages/autocomplete-js/src/types/AutocompleteSource.ts
@@ -57,6 +57,7 @@ export type AutocompleteSource<TItem extends BaseItem> = WithTemplates<
   AutocompleteCoreSource<TItem>,
   TItem
 >;
+
 export type InternalAutocompleteSource<TItem extends BaseItem> = WithTemplates<
   InternalAutocompleteCoreSource<TItem>,
   TItem

--- a/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
+++ b/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
@@ -17,6 +17,7 @@ export type CreateQuerySuggestionsPluginParams<
 > = {
   searchClient: SearchClient;
   indexName: string;
+  sourceId: string;
   getSearchParams?(params: { state: AutocompleteState<TItem> }): SearchOptions;
   getTemplates?(params: GetTemplatesParams<TItem>): SourceTemplates<TItem>;
 };
@@ -26,6 +27,7 @@ export function createQuerySuggestionsPlugin<
 >({
   searchClient,
   indexName,
+  sourceId,
   getSearchParams = () => ({}),
   getTemplates = defaultGetTemplates,
 }: CreateQuerySuggestionsPluginParams<TItem>): AutocompletePlugin<
@@ -36,6 +38,7 @@ export function createQuerySuggestionsPlugin<
     getSources({ query, setQuery, refresh, state }) {
       return [
         {
+          sourceId,
           getItemInputValue({ item }) {
             return item.query;
           },

--- a/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
+++ b/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
@@ -17,7 +17,6 @@ export type CreateQuerySuggestionsPluginParams<
 > = {
   searchClient: SearchClient;
   indexName: string;
-  sourceId: string;
   getSearchParams?(params: { state: AutocompleteState<TItem> }): SearchOptions;
   getTemplates?(params: GetTemplatesParams<TItem>): SourceTemplates<TItem>;
 };
@@ -27,7 +26,6 @@ export function createQuerySuggestionsPlugin<
 >({
   searchClient,
   indexName,
-  sourceId,
   getSearchParams = () => ({}),
   getTemplates = defaultGetTemplates,
 }: CreateQuerySuggestionsPluginParams<TItem>): AutocompletePlugin<
@@ -38,7 +36,7 @@ export function createQuerySuggestionsPlugin<
     getSources({ query, setQuery, refresh, state }) {
       return [
         {
-          sourceId,
+          sourceId: 'querySuggestionsPlugin',
           getItemInputValue({ item }) {
             return item.query;
           },

--- a/packages/autocomplete-plugin-recent-searches/src/createLocalStorageRecentSearchesPlugin.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/createLocalStorageRecentSearchesPlugin.ts
@@ -34,10 +34,6 @@ export type CreateRecentSearchesLocalStorageOptions<
    * Function to search in the recent items.
    */
   search?(params: SearchParams<TItem>): Array<Highlighted<TItem>>;
-  /**
-   * Applied to data-autocomplete-source-id on the section source container
-   */
-  sourceId: string;
 };
 
 type LocalStorageRecentSearchesPluginOptions<
@@ -52,7 +48,6 @@ export function createLocalStorageRecentSearchesPlugin<
   limit = 5,
   getTemplates,
   search = defaultSearch,
-  sourceId,
 }: LocalStorageRecentSearchesPluginOptions<TItem>): AutocompletePlugin<
   TItem,
   RecentSearchesPluginData
@@ -61,12 +56,10 @@ export function createLocalStorageRecentSearchesPlugin<
     key: [LOCAL_STORAGE_KEY, key].join(':'),
     limit,
     search,
-    sourceId,
   });
 
   return createRecentSearchesPlugin({
     getTemplates,
     storage,
-    sourceId,
   });
 }

--- a/packages/autocomplete-plugin-recent-searches/src/createLocalStorageRecentSearchesPlugin.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/createLocalStorageRecentSearchesPlugin.ts
@@ -34,6 +34,10 @@ export type CreateRecentSearchesLocalStorageOptions<
    * Function to search in the recent items.
    */
   search?(params: SearchParams<TItem>): Array<Highlighted<TItem>>;
+  /**
+   * Applied to data-autocomplete-source-id on the section source container
+   */
+  sourceId: string;
 };
 
 type LocalStorageRecentSearchesPluginOptions<
@@ -48,6 +52,7 @@ export function createLocalStorageRecentSearchesPlugin<
   limit = 5,
   getTemplates,
   search = defaultSearch,
+  sourceId,
 }: LocalStorageRecentSearchesPluginOptions<TItem>): AutocompletePlugin<
   TItem,
   RecentSearchesPluginData
@@ -56,10 +61,12 @@ export function createLocalStorageRecentSearchesPlugin<
     key: [LOCAL_STORAGE_KEY, key].join(':'),
     limit,
     search,
+    sourceId,
   });
 
   return createRecentSearchesPlugin({
     getTemplates,
     storage,
+    sourceId,
   });
 }

--- a/packages/autocomplete-plugin-recent-searches/src/createRecentSearchesPlugin.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/createRecentSearchesPlugin.ts
@@ -21,14 +21,12 @@ export type RecentSearchesPluginData = {
 export type CreateRecentSearchesPluginParams<
   TItem extends RecentSearchesItem
 > = {
-  sourceId: string;
   storage: RecentSearchesStorage<TItem>;
   getTemplates?(params: GetTemplatesParams): SourceTemplates<TItem>;
 };
 
 export function createRecentSearchesPlugin<TItem extends RecentSearchesItem>({
   storage,
-  sourceId,
   getTemplates = defaultGetTemplates,
 }: CreateRecentSearchesPluginParams<TItem>): AutocompletePlugin<
   TItem,
@@ -70,7 +68,7 @@ export function createRecentSearchesPlugin<TItem extends RecentSearchesItem>({
 
         return [
           {
-            sourceId,
+            sourceId: 'recentSearchesPlugin',
             getItemInputValue({ item }) {
               return item.query;
             },

--- a/packages/autocomplete-plugin-recent-searches/src/createRecentSearchesPlugin.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/createRecentSearchesPlugin.ts
@@ -21,12 +21,14 @@ export type RecentSearchesPluginData = {
 export type CreateRecentSearchesPluginParams<
   TItem extends RecentSearchesItem
 > = {
+  sourceId: string;
   storage: RecentSearchesStorage<TItem>;
   getTemplates?(params: GetTemplatesParams): SourceTemplates<TItem>;
 };
 
 export function createRecentSearchesPlugin<TItem extends RecentSearchesItem>({
   storage,
+  sourceId,
   getTemplates = defaultGetTemplates,
 }: CreateRecentSearchesPluginParams<TItem>): AutocompletePlugin<
   TItem,
@@ -68,6 +70,7 @@ export function createRecentSearchesPlugin<TItem extends RecentSearchesItem>({
 
         return [
           {
+            sourceId,
             getItemInputValue({ item }) {
               return item.query;
             },

--- a/packages/website/docs/autocomplete-js.md
+++ b/packages/website/docs/autocomplete-js.md
@@ -29,6 +29,7 @@ const autocompleteSearch = autocomplete({
   getSources() {
     return [
       {
+        sourceId: 'querySuggestionsSources',
         getItemInputValue: ({ item }) => item.query,
         getItems({ query }) {
           return getAlgoliaHits({

--- a/packages/website/docs/createAutocomplete.md
+++ b/packages/website/docs/createAutocomplete.md
@@ -22,6 +22,7 @@ const autocomplete = createAutocomplete({
   getSources() {
     return [
       {
+        sourceId: 'querySuggestionsSource',
         getItemInputValue: ({ item }) => item.query,
         getItems({ query }) {
           return getAlgoliaHits({

--- a/packages/website/docs/creating-a-renderer.md
+++ b/packages/website/docs/creating-a-renderer.md
@@ -44,6 +44,7 @@ function Autocomplete() {
         return [
           // (3) Use an Algolia index source.
           {
+            sourceId: 'querySuggestionsSource',
             getItemInputValue({ item }) {
               return item.query;
             },

--- a/packages/website/docs/keyboard-navigation.md
+++ b/packages/website/docs/keyboard-navigation.md
@@ -24,6 +24,7 @@ const autocomplete = createAutocomplete({
   getSources() {
     return [
       {
+        sourceId: 'mySource',
         getItemUrl({ item }) {
           return item.url;
         },

--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -16,6 +16,7 @@ const autocomplete = createAutocomplete({
   getSources() {
     return [
       {
+        sourceId: 'staticSource',
         getItems() {
           return [
             { label: 'Twitter', url: 'https://twitter.com' },
@@ -40,6 +41,7 @@ const autocomplete = createAutocomplete({
   getSources() {
     return [
       {
+        sourceId: 'staticSource',
         getItems({ query }) {
           return [
             { label: 'Twitter', url: 'https://twitter.com' },
@@ -71,6 +73,7 @@ const autocomplete = createAutocomplete({
   getSources() {
     return [
       {
+        sourceId: 'algoliaHits',
         getItems({ query }) {
           return getAlgoliaHits({
             searchClient,
@@ -112,6 +115,7 @@ const autocomplete = createAutocomplete({
     if (!query) {
       [
         {
+          sourceId: 'staticSource',
           getItems() {
             return [
               { label: 'Twitter', url: 'https://twitter.com' },
@@ -127,6 +131,7 @@ const autocomplete = createAutocomplete({
 
     return [
       {
+        sourceId: 'algoliaHits',
         getItems() {
           return getAlgoliaHits({
             searchClient,
@@ -184,12 +189,14 @@ const autocomplete = createAutocomplete({
 
       return [
         {
+          sourceId: 'querySuggestionsSource',
           getItems() {
             return querySuggestions.hits;
           },
           getItemInputValue: ({ item }) => item.query,
         },
         {
+          sourceId: 'algoliaHits',
           getItems() {
             return products.hits;
           },
@@ -283,6 +290,12 @@ Called when an item is active.
 
 You can trigger different behaviors if the item is active following a mouse event or a keyboard event based on the `event` param.
 
+### `sourceId`
+
+> `string`
+
+Applied to `data-autocomplete-source-id` on the `section` source container
+
 ### `templates` (specific to `@algolia/autocomplete-js`)
 
 > `SourceTemplate`
@@ -336,6 +349,7 @@ const autocompleteSearch = autocomplete({
   getSources() {
     return [
       {
+        sourceId: 'querySuggestionsSource',
         getItemInputValue({ item }) {
           return item.query;
         },

--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -294,7 +294,7 @@ You can trigger different behaviors if the item is active following a mouse even
 
 > `string`
 
-Applied to `data-autocomplete-source-id` on the `section` source container
+Identifier for the source. It is used as value for the `data-autocomplete-source-id` attribute of the source `section` container.
 
 ### `templates` (specific to `@algolia/autocomplete-js`)
 

--- a/test/utils/createSource.ts
+++ b/test/utils/createSource.ts
@@ -8,6 +8,7 @@ export function createSource<TItem extends BaseItem>(
   source?: Partial<AutocompleteSource<TItem>>
 ): InternalAutocompleteSource<TItem> {
   return {
+    sourceId: 'testSource',
     getItemInputValue: ({ state }) => state.query,
     getItemUrl: () => undefined,
     onActive: () => {},


### PR DESCRIPTION
**Summary**
- Add a required `sourceId` option to `AutocompleteSource` interface in `core`
- Provide `data-autocomplete-source-id` based on `sourceId` on source DOM container (section)
- Update `getSources` related tests
- Update docs