### PR TITLE
docs: add dynamic sources guide

### DIFF
--- a/packages/website/docs/sources.md
+++ b/packages/website/docs/sources.md
@@ -125,7 +125,7 @@ autocomplete({
 
 ### Using dynamic sources
 
-Static sources can be useful, especially [when the user hasn't typed anything yet](#mixing-static-and-dynamic-sources-based-on-the-query). However, you might want more robust search capabilities beyond exact matches in strings.
+Static sources can be useful, especially [when the user hasn't typed anything yet](changing-behavior-based-on-query). However, you might want more robust search capabilities beyond exact matches in strings.
 
 In this case, you could search into one or more Algolia indices using the built-in [`getAlgoliaHits`](getAlgoliaHits) function from the `autocomplete-preset-algolia` preset.
 
@@ -165,71 +165,6 @@ autocomplete({
 });
 ```
 
-:::note
-
-The [`getItems`](#getitems) function supports [promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), meaning you can plug it to any asynchronous API.
-
-:::
-
-### Mixing static and dynamic sources based on the query
-
-You don't have to show an empty screen until the user types a query. A typical pattern is to display a different source when the query is empty and switch once the user starts typing.
-
-```js
-import algoliasearch from 'algoliasearch/lite';
-import { autocomplete } from '@algolia/autocomplete-js';
-import { getAlgoliaHits } from '@algolia/autocomplete-preset-algolia';
-
-const searchClient = algoliasearch(
-  'latency',
-  '6be0576ff61c053d5f9a3225e2a90f76'
-);
-
-autocomplete({
-  // ...
-  getSources({ query }) {
-    if (!query) {
-      return [
-        {
-          getItems() {
-            return [
-              { label: 'Twitter', url: 'https://twitter.com' },
-              { label: 'GitHub', url: 'https://github.com' },
-            ];
-          },
-          getItemUrl({ item }) {
-            return item.url;
-          },
-        },
-      ];
-    }
-
-    return [
-      {
-        getItems() {
-          return getAlgoliaHits({
-            searchClient,
-            queries: [
-              {
-                indexName: 'instant_search',
-                query,
-              },
-            ],
-          });
-        },
-        getItemUrl({ item }) {
-          return item.url;
-        },
-      },
-    ];
-  },
-});
-```
-
-The [`getSources`](#getsources) function provides access to the current `query`, which you can use to return sources conditionally. You can use this pattern to display recent searches when the query is empty and search results when the user types.
-
-Note that you have access to the [full autocomplete state](state), not only the query. It lets you compute sources based on [various aspects](state#state), such as the query, but also the autocomplete status, whether the autocomplete is open or not, the context, etc.
-
 ### Using asynchronous sources
 
 The [`getSources`](#getsources) function supports promises so that you can fetch sources from any asynchronous API. It can be Algolia or any third-party API you can query with an HTTP request.
@@ -266,7 +201,7 @@ Note the usage of the [`getItemInputValue`](#getiteminputvalue) function to retu
 
 An autocomplete experience doesn't have to return only a single set of results. Autocomplete lets you fetch from different sources and display different types of results that serve different purposes.
 
-For example, you may want to display Algolia search results and Query Suggestions based on the current query to let users refine it and yield better results.
+For example, you may want to display Algolia search results and [Query Suggestions](https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/query-suggestions/js/) based on the current query to let users refine it and yield better results.
 
 ```js
 import algoliasearch from 'algoliasearch/lite';
@@ -321,9 +256,11 @@ autocomplete({
 
 :::note
 
-You can use the official [`autocomplete-plugin-query-suggestions`](createQuerySuggestionsPlugin) plugin to retrieve Query Suggestions from Algolia.
+You can use the official [`autocomplete-plugin-query-suggestions`](createQuerySuggestionsPlugin) plugin to retrieve [Query Suggestions](https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/query-suggestions/js/) from Algolia.
 
 :::
+
+For more information, check out the guide on [adding multiple sources to one autocomplete](adding-multiple-categories).
 
 ## Sources
 

--- a/packages/website/docs/using-dynamic-sources-based-on-query.md
+++ b/packages/website/docs/using-dynamic-sources-based-on-query.md
@@ -63,7 +63,7 @@ Learn how to use conditional sources depending on the query.
 
 You may want to change which [sources](sources) you use depending on the query. A typical pattern is to display a different source when the query is empty and switch once the user starts typing.
 
-This tutorial explains how to show [static predefined items](sources/#using-static-sources) when the query is empty,and results from an [Algolia index](https://www.algolia.com/doc/faq/basics/what-is-an-index/) when it isn't.
+This tutorial explains how to show [static predefined items](sources/#using-static-sources) when the query is empty, and results from an [Algolia index](https://www.algolia.com/doc/faq/basics/what-is-an-index/) when it isn't.
 
 ## Prerequisites
 
@@ -117,6 +117,7 @@ autocomplete({
         },
       ];
     }
+
     return [
       {
         getItems() {
@@ -139,16 +140,15 @@ autocomplete({
 });
 ```
 
-The [`getSources`](#getsources) function provides access to the current `query`, which you can use to return sources conditionally. You can use this pattern to display predefined items like these, [recent searches](adding-recent-searches), and / or [suggested searches](adding-suggested-searches) when the query is empty. When the user begins to type, you can show search results.
+The [`getSources`](#getsources) function provides access to the current `query`, which you can use to return sources conditionally. You can use this pattern to display predefined items like these, [recent searches](adding-recent-searches), and [suggested searches](adding-suggested-searches) when the query is empty. When the user begins to type, you can show search results.
 
-When there isn't a query, this autocomplete instance returns links to Twitter and Github. When there is, it searches an Algolia index. For more information on using Algolia as a source, follow the [Getting Started guide](getting-started).
+When there isn't a query, this autocomplete instance returns links to Twitter and GitHub. When there is, it searches an Algolia index. For more information on using Algolia as a source, follow the [Getting Started guide](getting-started).
 
 Try it out:
 
 <AutocompleteExample
-  debug={true}
   openOnFocus={true}
   plugins={[dynamicPlugin]}
 />
 
-Note that you have access to the [full autocomplete state](state), not only the query. It lets you compute sources based on [various aspects](state#state), such as the query, but also the autocomplete status, whether the autocomplete is open or not, the context, etc.
+Note that you have access to the [full autocomplete state](state), not only the query. It lets you compute sources based on [various parameters](state#state), such as the query, but also the autocomplete status, whether the autocomplete is open or not, the [context](context), etc.

--- a/packages/website/docs/using-dynamic-sources-based-on-query.md
+++ b/packages/website/docs/using-dynamic-sources-based-on-query.md
@@ -4,6 +4,7 @@ title: Changing behavior based on the query
 ---
 import { AutocompleteExample } from '@site/src/components/AutocompleteExample';
 import { AutocompleteProduct } from '@site/src/components/AutocompleteProduct';
+import { AutocompleteStaticItem } from '@site/src/components/AutocompleteStaticItem';
 import { getAlgoliaHits } from '@algolia/autocomplete-js';
 import algoliasearch from 'algoliasearch/lite';
 const searchClient = algoliasearch(
@@ -26,7 +27,7 @@ const dynamicPlugin = {
           },
           templates: {
             item({item}){
-              return item.label
+              return <AutocompleteStaticItem hit={item} />;
             }
           }
         },
@@ -145,6 +146,7 @@ When there isn't a query, this autocomplete instance returns links to Twitter an
 Try it out:
 
 <AutocompleteExample
+  debug={true}
   openOnFocus={true}
   plugins={[dynamicPlugin]}
 />

--- a/packages/website/docs/using-dynamic-sources-based-on-query.md
+++ b/packages/website/docs/using-dynamic-sources-based-on-query.md
@@ -3,15 +3,39 @@ id: changing-behavior-based-on-query
 title: Changing behavior based on the query
 ---
 
+Learn how to use conditional sources depending on the query.
 
-### Mixing static and dynamic sources based on the query
+You may want to change which [sources](sources) you use depending on the query. A typical pattern is to display a different source when the query is empty and switch once the user starts typing.
 
-You don't have to show an empty screen until the user types a query. A typical pattern is to display a different source when the query is empty and switch once the user starts typing.
+This tutorial explains how to show [static predefined items](sources/#using-static-sources) when the query is empty,and results from an [Algolia index](https://www.algolia.com/doc/faq/basics/what-is-an-index/) when it isn't.
 
-```js
-import algoliasearch from 'algoliasearch/lite';
+## Prerequisites
+
+This tutorial assumes that you have:
+- existing markup containing an input element where you want to implement the autocomplete dropdown
+- front-end development proficiency with HTML, CSS, and JavaScript
+
+## Getting started
+
+First, begin with some boilerplate for the autocomplete implementation. Create a file called `index.js` in your `src` directory, and add the boilerplate below:
+
+```js title="index.js"
 import { autocomplete } from '@algolia/autocomplete-js';
-import { getAlgoliaHits } from '@algolia/autocomplete-preset-algolia';
+
+autocomplete({
+  container: '#autocomplete',
+  openOnFocus: true,
+});
+```
+
+This boilerplate assumes you want to insert the autocomplete into a DOM element with `autocomplete` as an [`id`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id). You should change the [`container`](autocomplete-js/#container) to [match your markup](basic-options). Setting [`openOnFocus`](autocomplete-js/#openonfocus) to `true` ensures that the dropdown appears as soon as a user focuses the input.
+
+## Adding conditional sources
+
+
+```js title="index.js"
+import algoliasearch from 'algoliasearch/lite';
+import { autocomplete, getAlgoliaHits } from '@algolia/autocomplete-js';
 
 const searchClient = algoliasearch(
   'latency',
@@ -19,7 +43,8 @@ const searchClient = algoliasearch(
 );
 
 autocomplete({
-  // ...
+  container: '#autocomplete',
+  openOnFocus: true,
   getSources({ query }) {
     if (!query) {
       return [
@@ -59,6 +84,8 @@ autocomplete({
 });
 ```
 
-The [`getSources`](#getsources) function provides access to the current `query`, which you can use to return sources conditionally. You can use this pattern to display recent searches when the query is empty and search results when the user types.
+When there isn't a query, this autocomplete instance returns links to Twitter and Github. When there is, it searches an Algolia index. For more information on using Algolia as a source, follow the [Getting Started guide](getting-started).
+
+The [`getSources`](#getsources) function provides access to the current `query`, which you can use to return sources conditionally. You can use this pattern to display predefined items like these, [recent searches](adding-recent-searches), and / or [suggested searches](adding-suggested-searches) when the query is empty. When the user begins to type, you can show search results.
 
 Note that you have access to the [full autocomplete state](state), not only the query. It lets you compute sources based on [various aspects](state#state), such as the query, but also the autocomplete status, whether the autocomplete is open or not, the context, etc.

--- a/packages/website/docs/using-dynamic-sources-based-on-query.md
+++ b/packages/website/docs/using-dynamic-sources-based-on-query.md
@@ -1,8 +1,64 @@
 ---
-id: using-dynamic-sources-based-on-query
-title: Using dynamic sources based on the query
+id: changing-behavior-based-on-query
+title: Changing behavior based on the query
 ---
 
-import Draft from './partials/draft.md'
 
-<Draft />
+### Mixing static and dynamic sources based on the query
+
+You don't have to show an empty screen until the user types a query. A typical pattern is to display a different source when the query is empty and switch once the user starts typing.
+
+```js
+import algoliasearch from 'algoliasearch/lite';
+import { autocomplete } from '@algolia/autocomplete-js';
+import { getAlgoliaHits } from '@algolia/autocomplete-preset-algolia';
+
+const searchClient = algoliasearch(
+  'latency',
+  '6be0576ff61c053d5f9a3225e2a90f76'
+);
+
+autocomplete({
+  // ...
+  getSources({ query }) {
+    if (!query) {
+      return [
+        {
+          getItems() {
+            return [
+              { label: 'Twitter', url: 'https://twitter.com' },
+              { label: 'GitHub', url: 'https://github.com' },
+            ];
+          },
+          getItemUrl({ item }) {
+            return item.url;
+          },
+        },
+      ];
+    }
+
+    return [
+      {
+        getItems() {
+          return getAlgoliaHits({
+            searchClient,
+            queries: [
+              {
+                indexName: 'instant_search',
+                query,
+              },
+            ],
+          });
+        },
+        getItemUrl({ item }) {
+          return item.url;
+        },
+      },
+    ];
+  },
+});
+```
+
+The [`getSources`](#getsources) function provides access to the current `query`, which you can use to return sources conditionally. You can use this pattern to display recent searches when the query is empty and search results when the user types.
+
+Note that you have access to the [full autocomplete state](state), not only the query. It lets you compute sources based on [various aspects](state#state), such as the query, but also the autocomplete status, whether the autocomplete is open or not, the context, etc.

--- a/packages/website/sidebars.js
+++ b/packages/website/sidebars.js
@@ -18,7 +18,7 @@ module.exports = {
       'adding-recent-searches',
       'sending-algolia-insights-events',
       'adding-multiple-categories',
-      'using-dynamic-sources-based-on-query',
+      'changing-behavior-based-on-query',
       'creating-a-renderer',
       'upgrading',
       'debugging',

--- a/packages/website/src/components/AutocompleteProduct.tsx
+++ b/packages/website/src/components/AutocompleteProduct.tsx
@@ -1,0 +1,42 @@
+import { Hit } from '@algolia/client-search';
+import { snippetHit } from '@algolia/autocomplete-js';
+import React from 'react';
+
+type Product = {
+  name: string;
+  image: string;
+  description: string;
+};
+
+type ProductHit = Hit<Product>;
+
+type ProductItemProps = {
+  hit: ProductHit;
+};
+
+export function AutocompleteProduct({ hit }: ProductItemProps) {
+  return (
+    <>
+      <div className="aa-ItemIcon">
+        <img src={hit.image} alt={hit.name} width="40" height="40" />
+      </div>
+      <div className="aa-ItemContent">
+        <div className="aa-ItemContentTitle">
+          {snippetHit<ProductHit>({ hit, attribute: 'name' })}
+        </div>
+        <div className="aa-ItemContentDescription">
+          {snippetHit<ProductHit>({ hit, attribute: 'description' })}
+        </div>
+      </div>
+      <button
+        className="aa-ItemActionButton aa-TouchOnly aa-ActiveOnly"
+        type="button"
+        title="Select"
+      >
+        <svg fill="currentColor" viewBox="0 0 24 24" width="20" height="20">
+          <path d="M18.984 6.984h2.016v6h-15.188l3.609 3.609-1.406 1.406-6-6 6-6 1.406 1.406-3.609 3.609h13.172v-4.031z"></path>
+        </svg>
+      </button>
+    </>
+  );
+}

--- a/packages/website/src/components/AutocompleteStaticItem.tsx
+++ b/packages/website/src/components/AutocompleteStaticItem.tsx
@@ -1,0 +1,31 @@
+import { Hit } from '@algolia/client-search';
+import { reverseHighlightHit } from '@algolia/autocomplete-js';
+import React from 'react';
+
+type StaticItem = {
+  label: string;
+  url: string;
+};
+
+type StaticItemHit = Hit<StaticItem>;
+
+type StaticItemProps = {
+  hit: StaticItemHit;
+};
+
+export function AutocompleteStaticItem({ hit }: StaticItemProps) {
+  return (
+    <>
+      <div className="aa-ItemContent">
+        <div className="aa-ItemContentTitle">
+          <a href={hit.url}>
+          {reverseHighlightHit<StaticItemHit>({
+            hit,
+            attribute: 'label',
+          })}
+          </a>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
This PR extracts a section from the sources Core Concept and creates a guide from it.

The reason to put it in its own guide is to emphasize this as a UX recommendation. Future iterations of this guide docs could add:

- using Favorite Searches
- using Context