### PR TITLE
feat(core): remove `onInput` option

### DIFF
--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -36,17 +36,6 @@ export function onInput<TItem extends BaseItem>({
   store,
   ...setters
 }: OnInputParams<TItem>): Promise<void> {
-  if (props.onInput) {
-    return Promise.resolve(
-      props.onInput({
-        query,
-        refresh,
-        state: store.getState(),
-        ...setters,
-      })
-    );
-  }
-
   if (lastStalledId) {
     props.environment.clearTimeout(lastStalledId);
   }

--- a/packages/autocomplete-core/src/types/AutocompleteOptions.ts
+++ b/packages/autocomplete-core/src/types/AutocompleteOptions.ts
@@ -123,13 +123,6 @@ export interface AutocompleteOptions<TItem extends BaseItem> {
    */
   onReset?(params: OnResetParams<TItem>): void;
   /**
-   * The function called when the input changes.
-   *
-   * This turns the experience in controlled mode, leaving you in charge of
-   * updating the state.
-   */
-  onInput?(params: OnInputParams<TItem>): void;
-  /**
    * The array of plugins.
    */
   plugins?: Array<AutocompletePlugin<TItem, unknown>>;

--- a/packages/website/docs/partials/createAutocomplete-props.md
+++ b/packages/website/docs/partials/createAutocomplete-props.md
@@ -90,14 +90,6 @@ The function called when the Autocomplete form is submitted.
 
 The function called when the Autocomplete form is reset.
 
-### `onInput`
-
-> `(params: { query: string, state: AutocompleteState, ...setters }) => void`
-
-The function called when the input changes.
-
-This turns the experience in controlled mode, leaving you in charge of updating the state.
-
 ### `debug`
 
 > `boolean` | defaults to `false`


### PR DESCRIPTION
The `onInput` user param was originally introduced to enable controlled mode, but we've managed to create all the search experiences we wanted without this option. We can therefore remove it before public release.