### PR TITLE
docs: add "Using Autocomplete with Vue/React" guides

### DIFF
--- a/packages/website/docs/using-react.md
+++ b/packages/website/docs/using-react.md
@@ -96,10 +96,10 @@ The usage below sets [`openOnFocus`](autocomplete-js#openonfocus) and [sources](
 
 ```jsx title=App.jsx"
 import React, { createElement } from 'react';
-import { Autocomplete } from './components/Autocomplete';
-import { ProductItem } from './components/ProductItem';
 import { getAlgoliaHits } from 'autocomplete-js';
 import algoliasearch from "algoliasearch";
+import { Autocomplete } from './components/Autocomplete';
+import { ProductItem } from './components/ProductItem';
 
 const appId = "latency";
 const apiKey = "6be0576ff61c053d5f9a3225e2a90f76";

--- a/packages/website/docs/using-react.md
+++ b/packages/website/docs/using-react.md
@@ -111,28 +111,28 @@ function App() {
       <h1>React Application</h1>
       <Autocomplete
         openOnFocus={true}
-          getSources={({ query }) =>
-            [
-              {
-                getItems() {
-                  return getAlgoliaHits({
-                    searchClient,
-                    queries: [
-                      {
-                        indexName: "instant_search",
-                        query,
-                      }
-                    ]
-                  });
-                },
-                templates: {
-                  item({ item }) {
-                    return <ProductItem hit={item} />;
-                  }
+        getSources={({ query }) =>
+          [
+            {
+              getItems() {
+                return getAlgoliaHits({
+                  searchClient,
+                  queries: [
+                    {
+                      indexName: "instant_search",
+                      query,
+                    }
+                  ]
+                });
+              },
+              templates: {
+                item({ item }) {
+                  return <ProductItem hit={item} />;
                 }
               }
-            ];
-          }
+            }
+          ];
+        }
       />
     </div>
   );

--- a/packages/website/docs/using-react.md
+++ b/packages/website/docs/using-react.md
@@ -141,9 +141,15 @@ export default App;
 
 ### Creating templates
 
-The example above passes `<ProductItem />`, another React component, for the `item` [template](templates).  If you're using the highlighting and snippeting utilities ([`snippetHit`](snippethit) and [`highlightHit`](highlighthit)), you must pass them React's `createElement` function. Without doing this, the utilities refault to `preact.createElement`.
+The example above passes `<ProductItem />`, another React component, for the `item` [template](templates). If you're using the highlighting and snippeting utilities, there's one thing to keep in mind: you must pass them React's `createElement` function. Without doing this, the utilities default to `preact.createElement` and won't work properly.
 
-Here's an example of an  `item` template using [`HighlightHit`](highlighthit):
+The highlighting and snippeting utilities are:
+- [`highlightHit`](highlighthit)
+- [`snippetHit`](snippethit)
+- [`reverseHighlightHit`](reversehighlighthit)
+- [`reverseSnippetHit`](reversesnippethit)
+
+Here's an example using [`highlightHit`](highlighthit):
 
 ```jsx title="ProductItem.jsx"
 import { highlightHit } from '@algolia/autocomplete-js';

--- a/packages/website/docs/using-react.md
+++ b/packages/website/docs/using-react.md
@@ -1,0 +1,56 @@
+---
+id: using-react
+title: Using Autocomplete with React
+---
+
+Learn how to embed Autocomplete into a React application.
+
+This guide shows how to embed an autocomplete with [recent searches](adding-recent-searches) into a React application. Though it uses the [recent searches plugin](adding-recent-searches) for the [source](sources) of items, you could use any other source or sources you like.
+
+## Prerequisites
+
+This tutorial assumes that you have:
+- an existing [React application](https://reactjs.org/docs/getting-started.html) where you want to implement the autocomplete dropdown
+- familiarity with the [basic Autocomplete configuration options](basic-options)
+
+## Getting started
+
+Begin by adding a container for your autocomplete menu. This example adds a `div` with `autocomplete` as an [`id`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id).
+
+```js
+```
+
+Then, import the necessary packages for a basic implementation. Since the example displays only recent searches, it imports the [`createLocalStorageRecentSearchesPlugin`](createlocalstoragerecentsearchesplugin) function from the [`autocomplete-plugin-recent-searches`](createlocalstoragerecentsearchesplugin) package. Depending on your desired [sources](sources) you may need to import other plugins and packages.
+
+Include some boilerplate to insert the autocomplete into:
+
+```js
+```
+
+## Adding recent searches
+
+The  Autocomplete library provides the [`createLocalStorageRecentSearchesPlugin`](createlocalstoragerecentsearchesplugin) function for creating a recent searches [plugin](plugins) out-of-the-box. To use it, you need to provide a `key` and `limit`.
+
+The `key` can be any string and is required to differentiate search histories if you have multiple autocompletes on one page. The `limit` defines the maximum number of recent searches to display.
+
+```js
+const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
+  key: 'RECENT_SEARCH',
+  limit: 5,
+});
+```
+
+## Mounting the autocomplete
+
+Now that your [source](sources) is ready, you can instantiate and mount your autocomplete instance.
+
+```js
+```
+
+## Customizing templates
+
+This guide uses the recent searches plugin, which takes care of the display [templates](templates).
+
+## Further UI customization
+
+If you want to build a custom UI that differs from the `autocomplete-js` output, check out the [guide on creating a custom renderer](creating-a-renderer). This guide outlines how to create a custom React renderer, but the underlying principles are the same for any other front-end framework.

--- a/packages/website/docs/using-react.md
+++ b/packages/website/docs/using-react.md
@@ -87,7 +87,7 @@ export function Autocomplete(props) {
 
 Now that you've created an `<Autocomplete/>` component, you can use it in your React application.
 
-The example component sets the [`placeholder`](autocomplete-js#placeholder) and [`container`](autocomplete-js/#container) options, but lets everything else get configured through props.
+The example component sets only the [`container`](autocomplete-js/#container) option. It specifies where to mount your Autocomplete component, but lets all other [options](basic-options) get configured through props.
 
 The example below sets [`openOnFocus`](autocomplete-js#openonfocus) and [sources](sources) (via [`plugins`](plugins)) through props. This example uses [recent searches](adding-recent-searches) as a [source](sources), but you could use anything else you want.
 

--- a/packages/website/docs/using-react.md
+++ b/packages/website/docs/using-react.md
@@ -42,9 +42,11 @@ export function Autocomplete(props) {
 
 ### Mounting the autocomplete
 
-Now that you have access to the DOM through the `containerRef` object, you can create and mount the Autocomplete instance.
+Now that you have access to the DOM through the `containerRef` object, you can create and mount the Autocomplete instance. Upon instantiation, you can include any desired [Autocomplete options](basic-options) and rely on `props` to pass any options you want to remain configurable.
 
-You can use the same [Autocomplete options](basic-options), but you must also pass the `renderer` and `render` parameters. You can rely on `props` to pass any Autocomplete options you want to remain configurable.
+The example component below sets only the [`container`](autocomplete-js/#container) option. It specifies where to mount your Autocomplete component, but lets all other [options](basic-options) get configured through props.
+
+**You must also pass the `renderer` and `render` parameters.** This is because the default Autocomplete implementation uses [Preact's](https://preactjs.com/) version of `createElement`, `Fragment` and `render`. Without providing React's version of these, the Autocomplete instance won't render the views properly.
 
 Don't forget to [clean up the effect](https://reactjs.org/docs/hooks-reference.html#cleaning-up-an-effect) by returning a function that destroys the Autocomplete instance.
 
@@ -87,9 +89,9 @@ export function Autocomplete(props) {
 
 Now that you've created an `<Autocomplete/>` component, you can use it in your React application.
 
-The example component sets only the [`container`](autocomplete-js/#container) option. It specifies where to mount your Autocomplete component, but lets all other [options](basic-options) get configured through props.
+As previously state, the example component sets only the [`container`](autocomplete-js/#container) option, but lets all other [options](basic-options) get configured through props.
 
-The example below sets [`openOnFocus`](autocomplete-js#openonfocus) and [sources](sources) through props. This example uses an [Algolia index](https://www.algolia.com/doc/faq/basics/what-is-an-index/) as a [source](sources), but you could use anything else you want, including [plugins](plugins). For more information on using Algolia as a source, check out the [Getting Started guide](getting-started).
+The usage below sets [`openOnFocus`](autocomplete-js#openonfocus) and [sources](sources) through props. This example uses an [Algolia index](https://www.algolia.com/doc/faq/basics/what-is-an-index/) as a [source](sources), but you could use anything else you want, including [plugins](plugins). For more information on using Algolia as a source, check out the [Getting Started guide](getting-started).
 
 
 ```jsx title=App.jsx"

--- a/packages/website/docs/using-react.md
+++ b/packages/website/docs/using-react.md
@@ -3,54 +3,125 @@ id: using-react
 title: Using Autocomplete with React
 ---
 
-Learn how to embed Autocomplete into a React application.
+Learn how to create and use an React Autocomplete component.
 
-This guide shows how to embed an autocomplete with [recent searches](adding-recent-searches) into a React application. Though it uses the [recent searches plugin](adding-recent-searches) for the [source](sources) of items, you could use any other source or sources you like.
+This guide shows how to create a React Autocomplete component. It uses the [`useRef`](https://reactjs.org/docs/hooks-reference.html#useref) and [`useEffect`](https://reactjs.org/docs/hooks-reference.html#useeffect) hooks to create and mount the component. It doesn't define specific [sources](sources). Rather, you can pass [sources](sources) and other [options](basic-options) as [props](https://reactjs.org/docs/components-and-props.html).
 
 ## Prerequisites
 
 This tutorial assumes that you have:
-- an existing [React application](https://reactjs.org/docs/getting-started.html) where you want to implement the autocomplete dropdown
+- an existing [React (v 16.8+) application](https://reactjs.org/docs/getting-started.html) where you want to implement the autocomplete dropdown
 - familiarity with the [basic Autocomplete configuration options](basic-options)
 
-## Getting started
+## Creating the component
 
-Begin by adding a container for your autocomplete menu. This example adds a `div` with `autocomplete` as an [`id`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id).
+Start with some boilerplate for creating a React component. This component uses the [`useRef`](https://reactjs.org/docs/hooks-reference.html#useref) hook to create a mutable ref object, `containerRef`, to mount the autocomplete on. To learn more about this hook, check out the [`useRef` React documentation](https://reactjs.org/docs/hooks-reference.html#useref).
 
-```js
+ All that you need to render is a `div` with the `containerRef` as the `ref`.
+
+```jsx title="Autocomplete.jsx"
+import React, { createElement, Fragment, useEffect, useRef } from 'react';
+import { render } from 'react-dom';
+
+export function Autocomplete(props) {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!containerRef.current) {
+      return undefined;
+    }
+  }, [props]);
+
+  return (
+    <div
+      ref={containerRef}
+    />
+  );
+}
 ```
 
-Then, import the necessary packages for a basic implementation. Since the example displays only recent searches, it imports the [`createLocalStorageRecentSearchesPlugin`](createlocalstoragerecentsearchesplugin) function from the [`autocomplete-plugin-recent-searches`](createlocalstoragerecentsearchesplugin) package. Depending on your desired [sources](sources) you may need to import other plugins and packages.
+### Mounting the autocomplete
 
-Include some boilerplate to insert the autocomplete into:
+Now that you have access to the DOM through the `containerRef` object, you can create and mount the autocomplete instance.
 
-```js
+You can use the same [Autocomplete options](basic-options), but you must also pass the `renderer` and `render` parameters. You can rely on `props` to pass any autocomplete options you want to remain configurable.
+
+Don't forget to [clean up the effect](https://reactjs.org/docs/hooks-reference.html#cleaning-up-an-effect) by returning a function that destroys the autocomplete instance.
+
+```jsx title="Autocomplete.jsx"
+import { autocomplete } from '@algolia/autocomplete-js';
+import React, { createElement, Fragment, useEffect, useRef } from 'react';
+import { render } from 'react-dom';
+
+export function Autocomplete(props) {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!containerRef.current) {
+      return undefined;
+    }
+
+    const search = autocomplete({
+      container: containerRef.current,
+      placeholder: 'Search',
+      renderer: { createElement, Fragment },
+      render({ children }, root) {
+        render(children, root);
+      },
+      ...props,
+    });
+
+    return () => {
+      search.destroy();
+    };
+  }, [props]);
+
+  return (
+    <div
+      ref={containerRef}
+    />
+  );
+}
 ```
 
-## Adding recent searches
+## Using the component
+
+Now that you've created an `<Autocomplete/>` component, you can use it in your React application.
+
+The example component sets the [`placeholder`](autocomplete-js#placeholder) and [`container`](autocomplete-js/#container) options, but lets everything else get configured through props.
+
+The example below sets [`openOnFocus`](autocomplete-js#openonfocus) and [sources](sources) (via [`plugins`](plugins)) through props. This example uses [recent searches](adding-recent-searches) as a [source](sources), but you could use anything else you want.
 
 The  Autocomplete library provides the [`createLocalStorageRecentSearchesPlugin`](createlocalstoragerecentsearchesplugin) function for creating a recent searches [plugin](plugins) out-of-the-box. To use it, you need to provide a `key` and `limit`.
 
 The `key` can be any string and is required to differentiate search histories if you have multiple autocompletes on one page. The `limit` defines the maximum number of recent searches to display.
 
-```js
+```js title=App.js"
+import React from 'react';
+import { Autocomplete } from '/components/Autocomplete';
+import { createLocalStorageRecentSearchesPlugin } from 'autocomplete-plugin-recent-searches';
+
 const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
   key: 'RECENT_SEARCH',
   limit: 5,
 });
+
+function App() {
+  return (
+    <div className="app-container">
+      <h1>React Application</h1>
+      <Autocomplete
+        plugins={[recentSearchesPlugin]}
+        openOnFocus={true}
+      />
+    </div>
+  );
+}
+
+export default App;
 ```
 
-## Mounting the autocomplete
-
-Now that your [source](sources) is ready, you can instantiate and mount your autocomplete instance.
-
-```js
-```
-
-## Customizing templates
-
-This guide uses the recent searches plugin, which takes care of the display [templates](templates).
 
 ## Further UI customization
 
-If you want to build a custom UI that differs from the `autocomplete-js` output, check out the [guide on creating a custom renderer](creating-a-renderer). This guide outlines how to create a custom React renderer, but the underlying principles are the same for any other front-end framework.
+If you want to build a custom UI that differs from the `autocomplete-js` output, check out the [guide on creating a custom renderer](creating-a-renderer). This guide outlines how to create a custom React renderer specifically, but the underlying principles are the same for any other front-end framework.

--- a/packages/website/docs/using-react.md
+++ b/packages/website/docs/using-react.md
@@ -87,9 +87,9 @@ export function Autocomplete(props) {
 
 ## Using the component
 
-Now that you've created an `<Autocomplete/>` component, you can use it in your React application.
+Now that you've created an `<Autocomplete />` component, you can use it in your React application.
 
-As previously state, the example component sets only the [`container`](autocomplete-js/#container) option, but lets all other [options](basic-options) get configured through props.
+As previously stated, the example component sets only the [`container`](autocomplete-js/#container) option, but lets all other [options](basic-options) get configured through props.
 
 The usage below sets [`openOnFocus`](autocomplete-js#openonfocus) and [sources](sources) through props. This example uses an [Algolia index](https://www.algolia.com/doc/faq/basics/what-is-an-index/) as a [source](sources), but you could use anything else you want, including [plugins](plugins). For more information on using Algolia as a source, check out the [Getting Started guide](getting-started).
 
@@ -157,7 +157,7 @@ Here's an example using [`highlightHit`](highlighthit):
 import { highlightHit } from '@algolia/autocomplete-js';
 import React, { createElement } from 'react';
 
-export function AutocompleteItem({ hit }) {
+export function ProductItem({ hit }) {
   return (
     <a href={hit.url} className="aa-ItemLink">
       <div className="aa-ItemContent">

--- a/packages/website/docs/using-react.md
+++ b/packages/website/docs/using-react.md
@@ -94,7 +94,8 @@ The example below sets [`openOnFocus`](autocomplete-js#openonfocus) and [sources
 
 ```jsx title=App.jsx"
 import React, { createElement } from 'react';
-import { Autocomplete, getAlgoliaHits } from './components/Autocomplete';
+import { Autocomplete } from './components/Autocomplete';
+import { getAlgoliaHits } from 'autocomplete-js';
 import algoliasearch from "algoliasearch";
 
 const appId = "latency";

--- a/packages/website/docs/using-react.md
+++ b/packages/website/docs/using-react.md
@@ -89,8 +89,6 @@ export function Autocomplete(props) {
 
 Now that you've created an `<Autocomplete />` component, you can use it in your React application.
 
-As previously stated, the example component sets only the [`container`](autocomplete-js/#container) option, but lets all other [options](basic-options) get configured through props.
-
 The usage below sets [`openOnFocus`](autocomplete-js#openonfocus) and [sources](sources) through props. This example uses an [Algolia index](https://www.algolia.com/doc/faq/basics/what-is-an-index/) as a [source](sources), but you could use anything else you want, including [plugins](plugins). For more information on using Algolia as a source, check out the [Getting Started guide](getting-started).
 
 

--- a/packages/website/docs/using-react.md
+++ b/packages/website/docs/using-react.md
@@ -3,14 +3,14 @@ id: using-react
 title: Using Autocomplete with React
 ---
 
-Learn how to create and use an React Autocomplete component.
+Learn how to create and use a React Autocomplete component.
 
 This guide shows how to create a React Autocomplete component. It uses the [`useRef`](https://reactjs.org/docs/hooks-reference.html#useref) and [`useEffect`](https://reactjs.org/docs/hooks-reference.html#useeffect) hooks to create and mount the component. It doesn't define specific [sources](sources). Rather, you can pass [sources](sources) and other [options](basic-options) as [props](https://reactjs.org/docs/components-and-props.html).
 
 ## Prerequisites
 
 This tutorial assumes that you have:
-- an existing [React (v 16.8+) application](https://reactjs.org/docs/getting-started.html) where you want to implement the autocomplete dropdown
+- an existing [React (v16.8+) application](https://reactjs.org/docs/getting-started.html) where you want to implement the autocomplete dropdown
 - familiarity with the [basic Autocomplete configuration options](basic-options)
 
 ## Creating the component
@@ -63,7 +63,6 @@ export function Autocomplete(props) {
 
     const search = autocomplete({
       container: containerRef.current,
-      placeholder: 'Search',
       renderer: { createElement, Fragment },
       render({ children }, root) {
         render(children, root);
@@ -96,9 +95,9 @@ The  Autocomplete library provides the [`createLocalStorageRecentSearchesPlugin`
 
 The `key` can be any string and is required to differentiate search histories if you have multiple autocompletes on one page. The `limit` defines the maximum number of recent searches to display.
 
-```js title=App.js"
+```jsx title=App.jsx"
 import React from 'react';
-import { Autocomplete } from '/components/Autocomplete';
+import { Autocomplete } from './components/Autocomplete';
 import { createLocalStorageRecentSearchesPlugin } from 'autocomplete-plugin-recent-searches';
 
 const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({

--- a/packages/website/docs/using-react.md
+++ b/packages/website/docs/using-react.md
@@ -89,7 +89,7 @@ Now that you've created an `<Autocomplete/>` component, you can use it in your R
 
 The example component sets only the [`container`](autocomplete-js/#container) option. It specifies where to mount your Autocomplete component, but lets all other [options](basic-options) get configured through props.
 
-The example below sets [`openOnFocus`](autocomplete-js#openonfocus) and [sources](sources) through props. This example uses an Algolia index as a [source](sources), but you could use anything else you want.
+The example below sets [`openOnFocus`](autocomplete-js#openonfocus) and [sources](sources) through props. This example uses an [Algolia index](https://www.algolia.com/doc/faq/basics/what-is-an-index/) as a [source](sources), but you could use anything else you want, including [plugins](plugins). For more information on using Algolia as a source, check out the [Getting Started guide](getting-started).
 
 
 ```jsx title=App.jsx"
@@ -141,7 +141,7 @@ export default App;
 
 ### Creating templates
 
-The example above passes `<ProductItem />`, another React component, for the `item` [template](templates). If you're using the highlighting and snippeting utilities, there's one thing to keep in mind: you must pass them React's `createElement` function. Without doing this, the utilities default to `preact.createElement` and won't work properly.
+The example above passes `<ProductItem />`, another React component, for the `item` [template](templates). When creating templates, there's one thing to keep in mind. If you're using the highlighting and snippeting utilities, you must pass them React's `createElement` function. Without doing this, the utilities default to `preact.createElement` and won't work properly.
 
 The highlighting and snippeting utilities are:
 - [`highlightHit`](highlighthit)

--- a/packages/website/docs/using-react.md
+++ b/packages/website/docs/using-react.md
@@ -89,28 +89,18 @@ Now that you've created an `<Autocomplete/>` component, you can use it in your R
 
 The example component sets only the [`container`](autocomplete-js/#container) option. It specifies where to mount your Autocomplete component, but lets all other [options](basic-options) get configured through props.
 
-The example below sets [`openOnFocus`](autocomplete-js#openonfocus) and [sources](sources) (via [`plugins`](plugins)) through props. This example uses [recent searches](adding-recent-searches) as a [source](sources), but you could use anything else you want.
+The example below sets [`openOnFocus`](autocomplete-js#openonfocus) and [sources](sources) through props. This example uses an Algolia index as a [source](sources), but you could use anything else you want.
 
-The  Autocomplete library provides the [`createLocalStorageRecentSearchesPlugin`](createlocalstoragerecentsearchesplugin) function for creating a recent searches [plugin](plugins) out-of-the-box. To use it, you need to provide a `key` and `limit`.
-
-The `key` can be any string and is required to differentiate search histories if you have multiple autocompletes on one page. The `limit` defines the maximum number of recent searches to display.
 
 ```jsx title=App.jsx"
 import React from 'react';
 import { Autocomplete } from './components/Autocomplete';
-import { createLocalStorageRecentSearchesPlugin } from 'autocomplete-plugin-recent-searches';
-
-const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
-  key: 'RECENT_SEARCH',
-  limit: 5,
-});
 
 function App() {
   return (
     <div className="app-container">
       <h1>React Application</h1>
       <Autocomplete
-        plugins={[recentSearchesPlugin]}
         openOnFocus={true}
       />
     </div>

--- a/packages/website/docs/using-react.md
+++ b/packages/website/docs/using-react.md
@@ -10,7 +10,7 @@ This guide shows how to create a React Autocomplete component. It uses the [`use
 ## Prerequisites
 
 This tutorial assumes that you have:
-- an existing [React (v16.8+) application](https://reactjs.org/docs/getting-started.html) where you want to implement the autocomplete dropdown
+- an existing [React (v16.8+) application](https://reactjs.org/docs/getting-started.html) where you want to implement the autocomplete menu
 - familiarity with the [basic Autocomplete configuration options](basic-options)
 
 ## Creating the component
@@ -42,11 +42,11 @@ export function Autocomplete(props) {
 
 ### Mounting the autocomplete
 
-Now that you have access to the DOM through the `containerRef` object, you can create and mount the autocomplete instance.
+Now that you have access to the DOM through the `containerRef` object, you can create and mount the Autocomplete instance.
 
-You can use the same [Autocomplete options](basic-options), but you must also pass the `renderer` and `render` parameters. You can rely on `props` to pass any autocomplete options you want to remain configurable.
+You can use the same [Autocomplete options](basic-options), but you must also pass the `renderer` and `render` parameters. You can rely on `props` to pass any Autocomplete options you want to remain configurable.
 
-Don't forget to [clean up the effect](https://reactjs.org/docs/hooks-reference.html#cleaning-up-an-effect) by returning a function that destroys the autocomplete instance.
+Don't forget to [clean up the effect](https://reactjs.org/docs/hooks-reference.html#cleaning-up-an-effect) by returning a function that destroys the Autocomplete instance.
 
 ```jsx title="Autocomplete.jsx"
 import { autocomplete } from '@algolia/autocomplete-js';

--- a/packages/website/docs/using-react.md
+++ b/packages/website/docs/using-react.md
@@ -95,6 +95,7 @@ The example below sets [`openOnFocus`](autocomplete-js#openonfocus) and [sources
 ```jsx title=App.jsx"
 import React, { createElement } from 'react';
 import { Autocomplete } from './components/Autocomplete';
+import { ProductItem } from './components/ProductItem';
 import { getAlgoliaHits } from 'autocomplete-js';
 import algoliasearch from "algoliasearch";
 
@@ -137,6 +138,32 @@ function App() {
 
 export default App;
 ```
+
+### Creating templates
+
+The example above passes `<ProductItem />`, another React component, for the `item` [template](templates).  If you're using the highlighting and snippeting utilities ([`snippetHit`](snippethit) and [`highlightHit`](highlighthit)), you must pass them React's `createElement` function. Without doing this, the utilities refault to `preact.createElement`.
+
+Here's an example of an  `item` template using [`HighlightHit`](highlighthit):
+
+```jsx title="ProductItem.jsx"
+import { highlightHit } from '@algolia/autocomplete-js';
+import React, { createElement } from 'react';
+
+export function AutocompleteItem({ hit }) {
+  return (
+    <a href={hit.url} className="aa-ItemLink">
+      <div className="aa-ItemContent">
+        <div className="aa-ItemTitle">
+          {highlightHit({
+            hit,
+            attribute: 'name',
+            createElement,
+          })}
+        </div>
+      </div>
+    </a>
+  )
+  ```
 
 
 ## Further UI customization

--- a/packages/website/docs/using-react.md
+++ b/packages/website/docs/using-react.md
@@ -93,8 +93,13 @@ The example below sets [`openOnFocus`](autocomplete-js#openonfocus) and [sources
 
 
 ```jsx title=App.jsx"
-import React from 'react';
-import { Autocomplete } from './components/Autocomplete';
+import React, { createElement } from 'react';
+import { Autocomplete, getAlgoliaHits } from './components/Autocomplete';
+import algoliasearch from "algoliasearch";
+
+const appId = "latency";
+const apiKey = "6be0576ff61c053d5f9a3225e2a90f76";
+const searchClient = algoliasearch(appId, apiKey);
 
 function App() {
   return (
@@ -102,6 +107,28 @@ function App() {
       <h1>React Application</h1>
       <Autocomplete
         openOnFocus={true}
+          getSources={({ query }) =>
+            [
+              {
+                getItems() {
+                  return getAlgoliaHits({
+                    searchClient,
+                    queries: [
+                      {
+                        indexName: "instant_search",
+                        query,
+                      }
+                    ]
+                  });
+                },
+                templates: {
+                  item({ item }) {
+                    return <ProductItem hit={item} />;
+                  }
+                }
+              }
+            ];
+          }
       />
     </div>
   );

--- a/packages/website/docs/using-vue.md
+++ b/packages/website/docs/using-vue.md
@@ -22,7 +22,7 @@ Begin by adding a container for your autocomplete menu. This example adds a `div
 ```vue title="App.vue"
 <template>
   <div className="app-container">
-    <h1>Application title</h1>
+    <h1>Vue Application</h1>
     <div id="autocomplete" />
   </div>
 </template>

--- a/packages/website/docs/using-vue.md
+++ b/packages/website/docs/using-vue.md
@@ -131,9 +131,13 @@ export default {
 
 ## Customizing templates
 
-This guide uses the recent searches plugin, which takes care of the display [templates](templates). If you want to define your own templates there are two things to keep in mind:
-- You must use Vue JSX syntax.
-- If you're using the highlighting and snippeting utilities ([`snippetHit`](snippethit) and [`highlightHit`](highlighthit)), you must pass them `createElement`.
+This guide uses the recent searches plugin, which takes care of the display [templates](templates). If you're using the highlighting and snippeting utilities, there's one thing to keep in mind: you must pass them Vue's `createElement` function. Without doing this, the utilities default to `preact.createElement` and won't work properly.
+
+The highlighting and snippeting utilities are:
+- [`highlightHit`](highlighthit)
+- [`snippetHit`](snippethit)
+- [`reverseHighlightHit`](reversehighlighthit)
+- [`reverseSnippetHit`](reversesnippethit)
 
 Here's an example of a custom `item` template using [`snippetHit`](snippethit):
 
@@ -192,6 +196,8 @@ export default {
 };
 </script>
 ```
+
+Keep in mind that you should use JSX syntax for your templates.
 
 ## Further UI customization
 

--- a/packages/website/docs/using-vue.md
+++ b/packages/website/docs/using-vue.md
@@ -87,6 +87,8 @@ export default {
 
 Now that your [source](sources) is ready, you can instantiate and mount your Autocomplete instance. Doing so requires passing the `renderer` and `render` parameters.
 
+This is because the default Autocomplete implementation uses [Preact's](https://preactjs.com/) version of `createElement`, `Fragment` and `render`. Without providing Vue's version of these, the Autocomplete instance won't render the views properly.
+
 ```html title="App.vue"
 <template>
   <div className="container">

--- a/packages/website/docs/using-vue.md
+++ b/packages/website/docs/using-vue.md
@@ -32,7 +32,7 @@ Then, import the necessary packages for a basic implementation. Since the exampl
 
 Include some boilerplate to insert the autocomplete into:
 
-```vue title="App.vue"
+```html title="App.vue"
 <template>
   <div className="app-container">
     <h1>Application title</h1>
@@ -58,7 +58,7 @@ The  Autocomplete library provides the [`createLocalStorageRecentSearchesPlugin`
 
 The `key` can be any string and is required to differentiate search histories if you have multiple autocompletes on one page. The `limit` defines the maximum number of recent searches to display.
 
-```vue title="App.vue"
+```html title="App.vue"
 <template>
   <div className="app-container">
     <h1>Application title</h1>
@@ -87,7 +87,7 @@ export default {
 
 Now that your [source](sources) is ready, you can instantiate and mount your Autocomplete instance. Doing so requires passing the `renderer` and `render` parameters.
 
-```vue title="App.vue"
+```html title="App.vue"
 <template>
   <div className="container">
     <h1>Autocomplete with Vue</h1>
@@ -137,7 +137,7 @@ This guide uses the recent searches plugin, which takes care of the display [tem
 
 Here's an example of a custom `item` template using [`snippetHit`](snippethit):
 
-```vue title="App.vue"
+```html title="App.vue"
 <script>
 import { h, Fragment, render, onMounted } from "vue";
 import { autocomplete, snippetHit } from "@algolia/autocomplete-js";

--- a/packages/website/docs/using-vue.md
+++ b/packages/website/docs/using-vue.md
@@ -5,14 +5,14 @@ title: Using Autocomplete with Vue
 
 Learn how to embed Autocomplete into a Vue application.
 
-You can integrate an autocomplete instance into a Vue application using [Vue's Composition API](https://v3.vuejs.org/guide/composition-api-introduction.html#why-composition-api). Specifically you can instantiate an Autocomplete instance in the [`onMounted`](https://v3.vuejs.org/api/composition-api.html#lifecycle-hooks) lifecycle hook in the [`setup`](https://v3.vuejs.org/guide/composition-api-setup.html) function.
+You can integrate an Autocomplete instance into a Vue application using [Vue's Composition API](https://v3.vuejs.org/guide/composition-api-introduction.html#why-composition-api). Specifically you can instantiate an Autocomplete instance in the [`onMounted`](https://v3.vuejs.org/api/composition-api.html#lifecycle-hooks) lifecycle hook in the [`setup`](https://v3.vuejs.org/guide/composition-api-setup.html) function.
 
 This guide shows how to embed an autocomplete with [recent searches](adding-recent-searches) into a Vue application. Though it uses the [recent searches plugin](adding-recent-searches) for the [source](sources) of items, you could use any other source or sources you like.
 
 ## Prerequisites
 
 This tutorial assumes that you have:
-- an existing [Vue (v3) application](https://v3.vuejs.org/) where you want to implement the autocomplete dropdown
+- an existing [Vue (v3) application](https://v3.vuejs.org/) where you want to implement the autocomplete menu
 - familiarity with the [basic Autocomplete configuration options](basic-options)
 
 ## Getting started
@@ -85,7 +85,7 @@ export default {
 
 ## Mounting the autocomplete
 
-Now that your [source](sources) is ready, you can instantiate and mount your autocomplete instance. Doing so requires passing the `renderer` and `render` parameters.
+Now that your [source](sources) is ready, you can instantiate and mount your Autocomplete instance. Doing so requires passing the `renderer` and `render` parameters.
 
 ```vue title="App.vue"
 <template>

--- a/packages/website/docs/using-vue.md
+++ b/packages/website/docs/using-vue.md
@@ -12,7 +12,7 @@ This guide shows how to embed an autocomplete with [recent searches](adding-rece
 ## Prerequisites
 
 This tutorial assumes that you have:
-- an existing [Vue application](https://v3.vuejs.org/) where you want to implement the autocomplete dropdown
+- an existing [Vue (v3) application](https://v3.vuejs.org/) where you want to implement the autocomplete dropdown
 - familiarity with the [basic Autocomplete configuration options](basic-options)
 
 ## Getting started

--- a/packages/website/docs/using-vue.md
+++ b/packages/website/docs/using-vue.md
@@ -1,0 +1,4 @@
+---
+id: using-vue
+title: Using Autocomplete with Vue
+---

--- a/packages/website/docs/using-vue.md
+++ b/packages/website/docs/using-vue.md
@@ -2,3 +2,197 @@
 id: using-vue
 title: Using Autocomplete with Vue
 ---
+
+Learn how to embed Autocomplete into a Vue application.
+
+You can integrate an autocomplete instance into a Vue application using [Vue's Composition API](https://v3.vuejs.org/guide/composition-api-introduction.html#why-composition-api). Specifically you can instantiate an Autocomplete instance in the [`onMounted`](https://v3.vuejs.org/api/composition-api.html#lifecycle-hooks) lifecycle hook in the [`setup`](https://v3.vuejs.org/guide/composition-api-setup.html) function.
+
+This guide shows how to embed an autocomplete with [recent searches](adding-recent-searches) into a Vue application. Though it uses the [recent searches plugin](adding-recent-searches) for the [source](sources) of items, you could use any other source or sources you like.
+
+## Prerequisites
+
+This tutorial assumes that you have:
+- an existing [Vue application](https://v3.vuejs.org/) where you want to implement the autocomplete dropdown
+- familiarity with the [basic Autocomplete configuration options](basic-options)
+
+## Getting started
+
+Begin by adding a container for your autocomplete menu. This example adds a `div` with `autocomplete` as an [`id`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id).
+
+```vue title="App.vue"
+<template>
+  <div className="app-container">
+    <h1>Application title</h1>
+    <div id="autocomplete" />
+  </div>
+</template>
+```
+
+Then, import the necessary packages for a basic implementation. Since the example displays only recent searches, it imports the [`createLocalStorageRecentSearchesPlugin`](createlocalstoragerecentsearchesplugin) function from the [`autocomplete-plugin-recent-searches`](createlocalstoragerecentsearchesplugin) package. Depending on your desired [sources](sources) you may need to import other plugins and packages.
+
+Include some boilerplate to insert the autocomplete into:
+
+```vue title="App.vue"
+<template>
+  <div className="app-container">
+    <h1>Application title</h1>
+    <div id="autocomplete" />
+  </div>
+</template>
+
+<script>
+import { h, Fragment, render, onMounted } from "vue";
+import { autocomplete } from "@algolia/autocomplete-js";
+import { createLocalStorageRecentSearchesPlugin } from "@algolia/autocomplete-plugin-recent-searches";
+
+export default {
+  name: "App",
+};
+</script>
+
+```
+
+## Adding recent searches
+
+The  Autocomplete library provides the [`createLocalStorageRecentSearchesPlugin`](createlocalstoragerecentsearchesplugin) function for creating a recent searches [plugin](plugins) out-of-the-box. To use it, you need to provide a `key` and `limit`.
+
+The `key` can be any string and is required to differentiate search histories if you have multiple autocompletes on one page. The `limit` defines the maximum number of recent searches to display.
+
+```vue title="App.vue"
+<template>
+  <div className="app-container">
+    <h1>Application title</h1>
+    <div id="autocomplete" />
+  </div>
+</template>
+
+<script>
+import { h, Fragment, render, onMounted } from "vue";
+import { autocomplete } from "@algolia/autocomplete-js";
+import { createLocalStorageRecentSearchesPlugin } from "@algolia/autocomplete-plugin-recent-searches";
+
+const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
+  key: 'RECENT_SEARCH',
+  limit: 5,
+});
+
+export default {
+  name: "App",
+};
+</script>
+
+```
+
+## Mounting the autocomplete
+
+Now that your [source](sources) is ready, you can instantiate and mount your autocomplete instance. Doing so requires passing the `renderer` and `render` parameters.
+
+```vue title="App.vue"
+<template>
+  <div className="container">
+    <h1>Autocomplete with Vue</h1>
+    <div id="autocomplete" />
+  </div>
+</template>
+
+<script>
+import { h, Fragment, render, onMounted } from "vue";
+import { autocomplete } from "@algolia/autocomplete-js";
+import { createLocalStorageRecentSearchesPlugin } from "@algolia/autocomplete-plugin-recent-searches";
+
+import "@algolia/autocomplete-theme-classic";
+
+const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
+  key: "search",
+  limit: 3,
+});
+
+export default {
+  name: "App",
+  setup() {
+    onMounted(() => {
+      autocomplete({
+        container: "#autocomplete",
+        openOnFocus: true,
+        plugins: [recentSearchesPlugin],
+        renderer: {
+          createElement: h,
+          Fragment,
+        },
+        render({ children }, root) {
+          render(children, root);
+        },
+      });
+    });
+  },
+};
+</script>
+```
+
+## Customizing templates
+
+This guide uses the recent searches plugin, which takes care of the display [templates](templates). If you want to define your own templates there are two things to keep in mind:
+- You must use Vue JSX syntax.
+- If you're using the highlighting and snippeting utilities ([`snippetHit`](snippethit) and [`highlightHit`](highlighthit)), you must pass them `createElement`.
+
+Here's an example of a custom `item` template using [`snippetHit`](snippethit):
+
+```vue title="App.vue"
+<script>
+import { h, Fragment, render, onMounted } from "vue";
+import { autocomplete, snippetHit } from "@algolia/autocomplete-js";
+
+export default {
+  name: "App",
+  setup() {
+    onMounted(() => {
+      autocomplete({
+        // ...
+        getSources({ query }) {
+          return [
+            {
+              // ...
+              templates: {
+                item({ item }) {
+                  return (
+                    <Fragment>
+                      <div className="aa-ItemContent">
+                        <div className="aa-ItemContentTitle">
+                          {snippetHit({
+                            hit: item,
+                            attribute: "name",
+                            createElement: h,
+                          })}
+                        </div>
+                        <div className="aa-ItemContentDescription">
+                          {snippetHit({
+                            hit: item,
+                            attribute: "description",
+                            createElement: h,
+                          })}
+                        </div>
+                      </div>
+                    </Fragment>
+                  );
+                },
+              },
+            },
+          ];
+        },
+        renderer: {
+          createElement: h,
+          Fragment,
+        },
+        render({ children }, root) {
+          render(children, root);
+        },
+      });
+    });
+  },
+};
+</script>
+```
+
+## Further UI customization
+
+If you want to build a custom UI that differs from the `autocomplete-js` output, check out the [guide on creating a custom renderer](creating-a-renderer). This guide outlines how to create a custom React renderer, but the underlying principles are the same for any other front-end framework.

--- a/packages/website/docs/using-vue.md
+++ b/packages/website/docs/using-vue.md
@@ -19,7 +19,7 @@ This tutorial assumes that you have:
 
 Begin by adding a container for your autocomplete menu. This example adds a `div` with `autocomplete` as an [`id`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id).
 
-```vue title="App.vue"
+```html title="App.vue"
 <template>
   <div className="app-container">
     <h1>Vue Application</h1>

--- a/packages/website/sidebars.js
+++ b/packages/website/sidebars.js
@@ -19,6 +19,7 @@ module.exports = {
       'including-multiple-result-types',
       'changing-behavior-based-on-query',
       'sending-algolia-insights-events',
+      'using-vue',
       'creating-a-renderer',
       'upgrading',
       'debugging',

--- a/packages/website/sidebars.js
+++ b/packages/website/sidebars.js
@@ -19,6 +19,7 @@ module.exports = {
       'including-multiple-result-types',
       'changing-behavior-based-on-query',
       'sending-algolia-insights-events',
+      'using-react',
       'using-vue',
       'creating-a-renderer',
       'upgrading',


### PR DESCRIPTION
This PR creates guides on using the Autocomplete library in a Vue and React application.

(It was originally going to add just the Vue guide, hence the name.)