### PR TITLE
docs(examples): add space after query replacement

### DIFF
--- a/examples/twitter-compose-with-typeahead/src/Autocomplete.tsx
+++ b/examples/twitter-compose-with-typeahead/src/Autocomplete.tsx
@@ -35,7 +35,7 @@ export function Autocomplete(
             sourceId: 'accounts',
             onSelect({ item, setQuery }) {
               const [index] = activeToken.range;
-              const replacement = `@${item.handle}`;
+              const replacement = `@${item.handle} `;
               const newQuery = replaceAt(
                 query,
                 replacement,


### PR DESCRIPTION
Adding a space after the query replacement allows users to keep typing right away instead of having to type a space themselves.