### PR TITLE
fix(createLocalStorageRecentSearchesPlugin): set default transformSource

### DIFF
--- a/packages/autocomplete-plugin-recent-searches/src/createLocalStorageRecentSearchesPlugin.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/createLocalStorageRecentSearchesPlugin.ts
@@ -87,6 +87,7 @@ function getOptions<TItem extends RecentSearchesItem>(
   return {
     limit: 5,
     search: defaultSearch,
+    transformSource: ({ source }) => source,
     ...options,
   };
 }


### PR DESCRIPTION
This sets a default `transformSource` in `createLocalStorageRecentSearchesPlugin` to prevent `undefined` values. The bug was introduced in #768 because when merging objects,  `undefined` values are not dismissed for the fallback.

## Next steps

The issue wasn't caught early because we don't yet test all plugins. We should add tests for all plugins soon to avoid regressions.