### PR TITLE
test(plugins): test Algolia Insights plugin 

### DIFF
--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -579,6 +579,4 @@ describe('createAlgoliaInsightsPlugin', () => {
       expect(track).not.toHaveBeenCalled();
     });
   });
-
-  test.todo('test createSearchInsightsApi API');
 });

--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createSearchInsightsApi.ts.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createSearchInsightsApi.ts.test.ts
@@ -1,0 +1,3 @@
+describe('createSearchInsightsApi', () => {
+  test.todo('tests');
+});


### PR DESCRIPTION
This adds test coverage for `@algolia/autocomplete-plugin-algolia-insights`. I'm adding those now to ensure new features don't trigger undetected regressions like the one fixed in https://github.com/algolia/autocomplete/pull/771.

I've covered the plugin API for now. There are still untested methods from the `insights` wrapper created in [`createSearchInsightsApi`](https://github.com/algolia/autocomplete/blob/next/packages/autocomplete-plugin-algolia-insights/src/createSearchInsightsApi.ts) but we don't document them for now so I believe it can be tackled in another PR.