### PR TITLE
test(plugins): test Recent Searches plugin

### DIFF
--- a/packages/autocomplete-plugin-recent-searches/src/__tests__/createRecentSearchesPlugin.test.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/__tests__/createRecentSearchesPlugin.test.ts
@@ -610,11 +610,10 @@ describe('createRecentSearchesPlugin', () => {
         getSearchParams() {
           return recentSearchesPlugin.data.getAlgoliaSearchParams();
         },
-        // @ts-expect-error
         transformSource({ source }) {
           return {
             ...source,
-            getItemInputValue: noop,
+            getItemInputValue: () => undefined,
           };
         },
       });


### PR DESCRIPTION
This adds test coverage for the `createRecentSearchesPlugin` implementation in `@algolia/autocomplete-plugin-recent-searches`. I'm adding those now to ensure new features don't trigger undetected regressions like the one fixed in https://github.com/algolia/autocomplete/pull/771.

The `createLocalStorageRecentSearchesPlugin` test suite is handled in https://github.com/algolia/autocomplete/pull/785.