### PR TITLE
fix(scripts): use standard

### DIFF
--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -5,9 +5,9 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "start": "vite",
-    "build": "vite build",
-    "serve": "vite preview"
+    "dev": "vite",
+    "serve": "vite start",
+    "build": "vite build"
   },
   "dependencies": {
     "@algolia/autocomplete-js": "1.4.1",


### PR DESCRIPTION
Hey! I noticed that Algolia's template is no longer working on CodeSandbox, and the reason why is that the scripts don't follow the Vite documentation standards. Updating these scripts should be enough to fix it

https://vitejs.dev/guide/#command-line-interface

Thanks 😄 