### PR TITLE
chore: adjust bundlesize to actual bundle sizes

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -18,15 +18,15 @@
     },
     {
       "path": "packages/autocomplete-plugin-recent-searches/dist/umd/index.production.js",
-      "maxSize": "4 kB"
+      "maxSize": "3 kB"
     },
     {
       "path": "packages/autocomplete-plugin-query-suggestions/dist/umd/index.production.js",
-      "maxSize": "4 kB"
+      "maxSize": "3 kB"
     },
     {
       "path": "packages/autocomplete-plugin-tags/dist/umd/index.production.js",
-      "maxSize": "2.25 kB"
+      "maxSize": "1.75 kB"
     },
     {
       "path": "packages/autocomplete-theme-classic/dist/theme.min.css",


### PR DESCRIPTION
The threshold for `autocomplete-plugin-recent-searches`, `autocomplete-plugin-query-suggestions`, and `autocomplete-plugin-tags` is too high compared to the actual bundle sizes.

This PR brings them down (following our convention of 0.25 increments) so we can better monitor size spikes.