### PR TITLE
docs(two-column-layout-example): add reshape functions and quick access plugin

### DIFF
--- a/examples/two-column-layout/package.json
+++ b/examples/two-column-layout/package.json
@@ -14,6 +14,7 @@
     "@algolia/autocomplete-plugin-query-suggestions": "1.5.3",
     "@algolia/autocomplete-plugin-recent-searches": "1.5.3",
     "@algolia/autocomplete-theme-classic": "1.5.3",
+    "@algolia/autocomplete-shared": "1.5.3",
     "@algolia/client-search": "4.12.1",
     "algoliasearch": "4.12.1",
     "blurhash": "^1.1.5",

--- a/examples/two-column-layout/src/app.tsx
+++ b/examples/two-column-layout/src/app.tsx
@@ -16,6 +16,25 @@ import { recentSearchesPlugin } from './plugins/recentSearchesPlugin';
 
 import '@algolia/autocomplete-theme-classic';
 
+const removeDuplicates = uniqBy(({ source, item }) => {
+  if (
+    ['recentSearchesPlugin', 'querySuggestionsPlugin'].indexOf(
+      source.sourceId
+    ) === -1
+  ) {
+    return item;
+  }
+
+  return source.sourceId === 'querySuggestionsPlugin' ? item.query : item.label;
+});
+
+const fillWith = populate({
+  mainSourceId: 'querySuggestionsPlugin',
+  limit: 8,
+});
+
+const combine = pipe(removeDuplicates, fillWith);
+
 autocomplete({
   container: '#autocomplete',
   placeholder: 'Search products, articles, and FAQs',
@@ -41,27 +60,6 @@ autocomplete({
       faqPlugin: faq,
       ...rest
     } = sourcesBySourceId;
-
-    const removeDuplicates = uniqBy(({ source, item }) => {
-      if (
-        ['recentSearchesPlugin', 'querySuggestionsPlugin'].indexOf(
-          source.sourceId
-        ) === -1
-      ) {
-        return item;
-      }
-
-      return source.sourceId === 'querySuggestionsPlugin'
-        ? item.query
-        : item.label;
-    });
-
-    const fillWith = populate({
-      mainSourceId: 'querySuggestionsPlugin',
-      limit: 8,
-    });
-
-    const combine = pipe(removeDuplicates, fillWith);
 
     return [
       combine(recentSearches, querySuggestions, categories, brands, faq),

--- a/examples/two-column-layout/src/app.tsx
+++ b/examples/two-column-layout/src/app.tsx
@@ -11,6 +11,7 @@ import { faqPlugin } from './plugins/faqPlugin';
 import { popularPlugin } from './plugins/popularPlugin';
 import { productsPlugin } from './plugins/productsPlugin';
 import { querySuggestionsPlugin } from './plugins/querySuggestionsPlugin';
+import { quickAccessPlugin } from './plugins/quickAccessPlugin';
 import { recentSearchesPlugin } from './plugins/recentSearchesPlugin';
 
 import '@algolia/autocomplete-theme-classic';
@@ -29,6 +30,7 @@ autocomplete({
     productsPlugin,
     articlesPlugin,
     popularPlugin,
+    quickAccessPlugin,
   ],
   reshape({ sourcesBySourceId }) {
     const {
@@ -76,6 +78,7 @@ autocomplete({
       productsPlugin: products,
       articlesPlugin: articles,
       popularPlugin: popular,
+      quickAccessPlugin: quickAccess,
     } = elements;
 
     const hasResults =
@@ -111,6 +114,9 @@ autocomplete({
               <div className="aa-PanelSection--articles">
                 <div className="aa-PanelSectionSource">{articles}</div>
               </div>
+            )}
+            {quickAccess && (
+              <div className="aa-PanelSection--quickAccess">{quickAccess}</div>
             )}
           </div>
         </div>

--- a/examples/two-column-layout/src/components/Blurhash.tsx
+++ b/examples/two-column-layout/src/components/Blurhash.tsx
@@ -10,12 +10,12 @@ export interface BlurhashProps {
   punch?: number;
 }
 
-export const Blurhash = ({
+export function Blurhash({
   hash,
   width = 128,
   height = 128,
   punch = 1,
-}: BlurhashProps) => {
+}: BlurhashProps) {
   const ref = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
@@ -32,11 +32,13 @@ export const Blurhash = ({
   }, [hash, width, height, punch]);
 
   return (
-    <canvas
-      ref={ref}
-      height={height}
-      width={width}
-      className="aa-BlurhashCanvas"
-    />
+    hash && (
+      <canvas
+        ref={ref}
+        height={height}
+        width={width}
+        className="aa-BlurhashCanvas"
+      />
+    )
   );
-};
+}

--- a/examples/two-column-layout/src/components/Breadcrumb.tsx
+++ b/examples/two-column-layout/src/components/Breadcrumb.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h } from 'preact';
 
-import { intersperse } from '../utils/intersperse';
+import { intersperse } from '../utils';
 
 import { ChevronRightIcon } from './Icons';
 

--- a/examples/two-column-layout/src/components/Breadcrumb.tsx
+++ b/examples/two-column-layout/src/components/Breadcrumb.tsx
@@ -6,10 +6,10 @@ import { intersperse } from '../utils';
 import { ChevronRightIcon } from './Icons';
 
 type BreadcrumbProps = {
-  items: string[];
+  items: string[] | JSX.Element[];
 };
 
-export const Breadcrumb = ({ items }: BreadcrumbProps) => {
+export function Breadcrumb({ items }: BreadcrumbProps) {
   return (
     <div className="aa-Breadcrumb">
       {intersperse(
@@ -20,4 +20,4 @@ export const Breadcrumb = ({ items }: BreadcrumbProps) => {
       )}
     </div>
   );
-};
+}

--- a/examples/two-column-layout/src/components/FaqPreview.tsx
+++ b/examples/two-column-layout/src/components/FaqPreview.tsx
@@ -1,0 +1,32 @@
+/** @jsx h */
+import { AutocompleteComponents } from '@algolia/autocomplete-js';
+import { h } from 'preact';
+
+import { FaqHit } from '../types';
+
+import { Breadcrumb } from './Breadcrumb';
+
+type FaqPreviewProps = {
+  hit: FaqHit;
+  components: AutocompleteComponents;
+};
+
+export function FaqPreview({ hit, components }: FaqPreviewProps) {
+  return (
+    <div className="aa-FaqPreview aa-Item">
+      <div className="aa-ItemContent">
+        <div className="aa-ItemContentBody">
+          <h3>{hit.title}</h3>
+          <Breadcrumb items={hit.list_categories} />
+
+          <p className="aa-ItemContentDescription">
+            <components.Snippet hit={hit} attribute="description" />
+          </p>
+
+          <h4>More questions?</h4>
+          <a href="#">Please contact our support team here</a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/examples/two-column-layout/src/components/index.ts
+++ b/examples/two-column-layout/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from './Icons';
 export * from './Blurhash';
 export * from './Breadcrumb';
+export * from './FaqPreview';

--- a/examples/two-column-layout/src/functions/AutocompleteReshapeFunction.ts
+++ b/examples/two-column-layout/src/functions/AutocompleteReshapeFunction.ts
@@ -1,0 +1,12 @@
+import {
+  AutocompleteReshapeSource,
+  BaseItem,
+} from '@algolia/autocomplete-core';
+
+export type AutocompleteReshapeFunction<TParams = any> = <
+  TItem extends BaseItem
+>(
+  ...params: TParams[]
+) => (
+  ...expressions: Array<AutocompleteReshapeSource<TItem>>
+) => Array<AutocompleteReshapeSource<TItem>>;

--- a/examples/two-column-layout/src/functions/AutocompleteReshapeFunction.ts
+++ b/examples/two-column-layout/src/functions/AutocompleteReshapeFunction.ts
@@ -3,7 +3,7 @@ import {
   BaseItem,
 } from '@algolia/autocomplete-core';
 
-export type AutocompleteReshapeFunction<TParams = any> = <
+export type AutocompleteReshapeFunction<TParams = unknown> = <
   TItem extends BaseItem
 >(
   ...params: TParams[]

--- a/examples/two-column-layout/src/functions/index.ts
+++ b/examples/two-column-layout/src/functions/index.ts
@@ -1,0 +1,2 @@
+export * from './uniqBy';
+export * from './populate';

--- a/examples/two-column-layout/src/functions/normalizeReshapeSources.ts
+++ b/examples/two-column-layout/src/functions/normalizeReshapeSources.ts
@@ -1,0 +1,13 @@
+import {
+  AutocompleteReshapeSource,
+  BaseItem,
+} from '@algolia/autocomplete-core';
+import { flatten } from '@algolia/autocomplete-shared';
+
+// We filter out falsy values because dynamic sources may not exist at every render.
+// We flatten to support pipe operators from functional libraries like Ramda.
+export function normalizeReshapeSources<TItem extends BaseItem>(
+  sources: Array<AutocompleteReshapeSource<TItem>>
+) {
+  return flatten(sources).filter(Boolean);
+}

--- a/examples/two-column-layout/src/functions/populate.ts
+++ b/examples/two-column-layout/src/functions/populate.ts
@@ -6,6 +6,8 @@ type PopulateOptions = {
   limit: number;
 };
 
+// This reshape function computes the total number of source items and
+// limits the provided main source number of items until it reaches the provided limit.
 export const populate: AutocompleteReshapeFunction<PopulateOptions> = ({
   mainSourceId,
   limit,
@@ -16,18 +18,22 @@ export const populate: AutocompleteReshapeFunction<PopulateOptions> = ({
       (s) => s.sourceId !== mainSourceId
     );
 
-    let itemNb = 0;
+    // Compute the total number of items per source.
+    let totalItemNb = 0;
     otherSources.forEach((source) => {
-      itemNb += source.getItems().length;
+      totalItemNb += source.getItems().length;
     });
 
     return originalSources.map((source) => {
       let transformedSource = source;
+
+      // Limit the main source items length based on the provided limit and
+      // the computed total number of items.
       if (source.sourceId === mainSourceId) {
         transformedSource = {
           ...source,
           getItems() {
-            return source.getItems().slice(0, Math.max(limit - itemNb, 0));
+            return source.getItems().slice(0, Math.max(limit - totalItemNb, 0));
           },
         };
       }

--- a/examples/two-column-layout/src/functions/populate.ts
+++ b/examples/two-column-layout/src/functions/populate.ts
@@ -1,0 +1,37 @@
+import { AutocompleteReshapeFunction } from './AutocompleteReshapeFunction';
+import { normalizeReshapeSources } from './normalizeReshapeSources';
+
+type PopulateOptions = {
+  mainSourceId: string;
+  limit: number;
+};
+
+export const populate: AutocompleteReshapeFunction<PopulateOptions> = ({
+  mainSourceId,
+  limit,
+}) => {
+  return function runUniqBy(...rawSources) {
+    const originalSources = normalizeReshapeSources(rawSources);
+    const otherSources = originalSources.filter(
+      (s) => s.sourceId !== mainSourceId
+    );
+
+    let itemNb = 0;
+    otherSources.forEach((source) => {
+      itemNb += source.getItems().length;
+    });
+
+    return originalSources.map((source) => {
+      let transformedSource = source;
+      if (source.sourceId === mainSourceId) {
+        transformedSource = {
+          ...source,
+          getItems() {
+            return source.getItems().slice(0, Math.max(limit - itemNb, 0));
+          },
+        };
+      }
+      return transformedSource;
+    });
+  };
+};

--- a/examples/two-column-layout/src/functions/populate.ts
+++ b/examples/two-column-layout/src/functions/populate.ts
@@ -37,6 +37,7 @@ export const populate: AutocompleteReshapeFunction<PopulateOptions> = ({
           },
         };
       }
+
       return transformedSource;
     });
   };

--- a/examples/two-column-layout/src/functions/uniqBy.ts
+++ b/examples/two-column-layout/src/functions/uniqBy.ts
@@ -1,0 +1,41 @@
+import {
+  AutocompleteReshapeSource,
+  BaseItem,
+} from '@algolia/autocomplete-core';
+
+import { AutocompleteReshapeFunction } from './AutocompleteReshapeFunction';
+import { normalizeReshapeSources } from './normalizeReshapeSources';
+
+type UniqByPredicate<TItem extends BaseItem> = (params: {
+  source: AutocompleteReshapeSource<TItem>;
+  item: TItem;
+}) => TItem;
+
+export const uniqBy: AutocompleteReshapeFunction<UniqByPredicate<any>> = <
+  TItem extends BaseItem
+>(
+  predicate: UniqByPredicate<any>
+) => {
+  return function runUniqBy(...rawSources) {
+    const sources = normalizeReshapeSources(rawSources);
+    const seen = new Set<TItem>();
+
+    return sources.map((source) => {
+      const items = source.getItems().filter((item) => {
+        const appliedItem = predicate({ source, item });
+        const hasSeen = seen.has(appliedItem);
+
+        seen.add(appliedItem);
+
+        return !hasSeen;
+      });
+
+      return {
+        ...source,
+        getItems() {
+          return items;
+        },
+      };
+    });
+  };
+};

--- a/examples/two-column-layout/src/plugins/articlesPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/articlesPlugin.tsx
@@ -3,6 +3,7 @@ import {
   AutocompletePlugin,
   getAlgoliaResults,
 } from '@algolia/autocomplete-js';
+import { SearchResponse } from '@algolia/client-search';
 import { h } from 'preact';
 
 import { ALGOLIA_ARTICLES_INDEX_NAME } from '../constants';
@@ -10,7 +11,7 @@ import { searchClient } from '../searchClient';
 import { ArticleHit } from '../types';
 
 export const articlesPlugin: AutocompletePlugin<ArticleHit, {}> = {
-  getSources({ query }) {
+  getSources({ query, setContext }) {
     if (!query) {
       return [];
     }
@@ -30,6 +31,13 @@ export const articlesPlugin: AutocompletePlugin<ArticleHit, {}> = {
                 },
               },
             ],
+            transformResponse({ hits, results }) {
+              setContext({
+                nbArticles: (results[0] as SearchResponse<ArticleHit>).nbHits,
+              });
+
+              return hits;
+            },
           });
         },
         onSelect({ setIsOpen }) {
@@ -47,6 +55,24 @@ export const articlesPlugin: AutocompletePlugin<ArticleHit, {}> = {
           item({ item }) {
             return <ArticleItem hit={item} />;
           },
+          footer({ state }) {
+            return (
+              state.context.nbArticles > 2 && (
+                <div style={{ textAlign: 'center' }}>
+                  <a
+                    href="https://example.org/"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="aa-SeeAllLink"
+                  >
+                    See All Articles{' '}
+                    {state.context.nbArticles &&
+                      `(${state.context.nbArticles})`}
+                  </a>
+                </div>
+              )
+            );
+          },
         },
       },
     ];
@@ -57,7 +83,7 @@ type ArticleItemProps = {
   hit: ArticleHit;
 };
 
-const ArticleItem = ({ hit }: ArticleItemProps) => {
+function ArticleItem({ hit }: ArticleItemProps) {
   const articleDate = new Date(hit.date);
   const articleMonth = articleDate.toLocaleDateString('en-US', {
     month: 'long',
@@ -80,4 +106,4 @@ const ArticleItem = ({ hit }: ArticleItemProps) => {
       </div>
     </a>
   );
-};
+}

--- a/examples/two-column-layout/src/plugins/brandsPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/brandsPlugin.tsx
@@ -9,6 +9,7 @@ import { h } from 'preact';
 import { TagIcon } from '../components';
 import { ALGOLIA_PRODUCTS_INDEX_NAME } from '../constants';
 import { searchClient } from '../searchClient';
+import { setSmartPreview } from '../setSmartPreview';
 import { BrandHit } from '../types';
 
 export const brandsPlugin: AutocompletePlugin<BrandHit, {}> = {
@@ -38,9 +39,26 @@ export const brandsPlugin: AutocompletePlugin<BrandHit, {}> = {
         getItemInputValue({ item }) {
           return item.label;
         },
+        onActive(params) {
+          setSmartPreview({
+            preview: {
+              facetName: 'brand',
+              facetValue: params.item.label,
+            },
+            ...params,
+          });
+        },
         templates: {
-          item({ item, components }) {
-            return <BrandItem hit={item} components={components} />;
+          item({ item, components, state }) {
+            return (
+              <BrandItem
+                hit={item}
+                components={components}
+                active={
+                  state.context.lastActiveItemId === item.__autocomplete_id
+                }
+              />
+            );
           },
         },
       },
@@ -51,11 +69,12 @@ export const brandsPlugin: AutocompletePlugin<BrandHit, {}> = {
 type BrandItemProps = {
   hit: BrandHit;
   components: AutocompleteComponents;
+  active: boolean;
 };
 
-const BrandItem = ({ hit, components }: BrandItemProps) => {
+function BrandItem({ hit, components, active }: BrandItemProps) {
   return (
-    <div className="aa-ItemWrapper">
+    <div className="aa-ItemWrapper" data-active={active}>
       <div className="aa-ItemContent">
         <div className="aa-ItemIcon aa-ItemIcon--noBorder">
           <TagIcon />
@@ -68,4 +87,4 @@ const BrandItem = ({ hit, components }: BrandItemProps) => {
       </div>
     </div>
   );
-};
+}

--- a/examples/two-column-layout/src/plugins/faqPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/faqPlugin.tsx
@@ -9,6 +9,7 @@ import { h } from 'preact';
 import { Breadcrumb, InfoIcon } from '../components';
 import { ALGOLIA_FAQ_INDEX_NAME } from '../constants';
 import { searchClient } from '../searchClient';
+import { setSmartPreview } from '../setSmartPreview';
 import { FaqHit } from '../types';
 
 export const faqPlugin: AutocompletePlugin<FaqHit, {}> = {
@@ -34,9 +35,23 @@ export const faqPlugin: AutocompletePlugin<FaqHit, {}> = {
             ],
           });
         },
+        onActive(params) {
+          setSmartPreview({
+            preview: params.item,
+            ...params,
+          });
+        },
         templates: {
-          item({ item, components }) {
-            return <FaqItem hit={item} components={components} />;
+          item({ item, components, state }) {
+            return (
+              <FaqItem
+                hit={item}
+                components={components}
+                active={
+                  state.context.lastActiveItemId === item.__autocomplete_id
+                }
+              />
+            );
           },
         },
       },
@@ -47,13 +62,12 @@ export const faqPlugin: AutocompletePlugin<FaqHit, {}> = {
 type FaqItemProps = {
   hit: FaqHit;
   components: AutocompleteComponents;
+  active: boolean;
 };
 
-const FaqItem = ({ hit, components }: FaqItemProps) => {
-  const breadcrumbItems = hit.list_categories;
-
+function FaqItem({ hit, components, active }: FaqItemProps) {
   return (
-    <div className="aa-ItemWrapper aa-FaqItem">
+    <div className="aa-ItemWrapper aa-FaqItem" data-active={active}>
       <div className="aa-ItemContent">
         <div className="aa-ItemIcon aa-ItemIcon--noBorder">
           <InfoIcon />
@@ -64,7 +78,15 @@ const FaqItem = ({ hit, components }: FaqItemProps) => {
           </div>
         </div>
       </div>
-      <Breadcrumb items={breadcrumbItems} />
+      <Breadcrumb
+        items={hit.list_categories.map((_, index) => (
+          <components.ReverseHighlight
+            key={index}
+            hit={hit}
+            attribute={['list_categories', `${index}`]}
+          />
+        ))}
+      />
     </div>
   );
-};
+}

--- a/examples/two-column-layout/src/plugins/popularCategoriesPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/popularCategoriesPlugin.tsx
@@ -1,0 +1,90 @@
+/** @jsx h */
+import {
+  AutocompleteComponents,
+  AutocompletePlugin,
+  getAlgoliaFacets,
+} from '@algolia/autocomplete-js';
+import { h } from 'preact';
+
+import { ALGOLIA_PRODUCTS_INDEX_NAME } from '../constants';
+import { searchClient } from '../searchClient';
+import { PopularCategoryHit } from '../types';
+
+const baseUrl = 'https://res.cloudinary.com/hilnmyskv/image/upload/v1646067858';
+const images = {
+  Women: `${baseUrl}/women_category_vwzkln.jpg`,
+  Bags: `${baseUrl}/bags_category_qd7ssj.jpg`,
+  Clothing: `${baseUrl}/clothing_category_xhiz1s.jpg`,
+  Men: `${baseUrl}/men_category_wfcley.jpg`,
+  'T-shirts': `${baseUrl}/t-shirts_category_gzqcvd.jpg`,
+  Shoes: `${baseUrl}/shoes_category_u4fi0q.jpg`,
+};
+
+export const popularCategoriesPlugin: AutocompletePlugin<
+  PopularCategoryHit,
+  {}
+> = {
+  getSources() {
+    return [
+      {
+        sourceId: 'popularCategoriesPlugin',
+        getItems() {
+          return getAlgoliaFacets({
+            searchClient,
+            queries: [
+              {
+                indexName: ALGOLIA_PRODUCTS_INDEX_NAME,
+                facet: 'list_categories',
+                params: {
+                  facetQuery: '',
+                  maxFacetHits: 6,
+                },
+              },
+            ],
+          });
+        },
+        getItemInputValue({ item }) {
+          return item.label;
+        },
+        onSelect({ setIsOpen }) {
+          setIsOpen(true);
+        },
+        templates: {
+          header({ Fragment }) {
+            return (
+              <Fragment>
+                <span className="aa-SourceHeaderTitle">Popular categories</span>
+                <div className="aa-SourceHeaderLine" />
+              </Fragment>
+            );
+          },
+          item({ item, components }) {
+            return <CategoryItem hit={item} components={components} />;
+          },
+        },
+      },
+    ];
+  },
+};
+
+type CategoryItemProps = {
+  hit: PopularCategoryHit;
+  components: AutocompleteComponents;
+};
+
+function CategoryItem({ hit }: CategoryItemProps) {
+  return (
+    <div className="aa-ItemWrapper aa-PopularCategoryItem">
+      <div className="aa-ItemContent">
+        <div className="aa-ItemPicture">
+          <img src={images[hit.label]} alt={hit.label} />
+        </div>
+        <div className="aa-ItemContentBody">
+          <div className="aa-ItemContentTitle">
+            {hit.label} <span>({hit.count})</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/examples/two-column-layout/src/plugins/popularPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/popularPlugin.tsx
@@ -13,7 +13,7 @@ export const popularPlugin = createQuerySuggestionsPlugin({
   getSearchParams() {
     return {
       query: '',
-      hitsPerPage: 7,
+      hitsPerPage: 6,
     };
   },
   transformSource({ source }) {
@@ -47,7 +47,7 @@ type PopularItemProps = {
   hit: PopularHit;
 };
 
-const PopularItem = ({ hit }: PopularItemProps) => {
+function PopularItem({ hit }: PopularItemProps) {
   return (
     <div className="aa-ItemWrapper">
       <div className="aa-ItemIcon aa-ItemIcon--noBorder">
@@ -60,4 +60,4 @@ const PopularItem = ({ hit }: PopularItemProps) => {
       </div>
     </div>
   );
-};
+}

--- a/examples/two-column-layout/src/plugins/productsPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/productsPlugin.tsx
@@ -10,7 +10,7 @@ import { Blurhash, StarIcon, FavoriteIcon } from '../components';
 import { ALGOLIA_PRODUCTS_INDEX_NAME } from '../constants';
 import { searchClient } from '../searchClient';
 import { ProductHit } from '../types';
-import { cx } from '../utils/cx';
+import { cx } from '../utils';
 
 export interface ProductsPluginContext {
   facetName: string;

--- a/examples/two-column-layout/src/plugins/productsPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/productsPlugin.tsx
@@ -1,8 +1,10 @@
 /** @jsx h */
 import {
+  AutocompleteComponents,
   AutocompletePlugin,
   getAlgoliaResults,
 } from '@algolia/autocomplete-js';
+import { SearchResponse } from '@algolia/client-search';
 import { h } from 'preact';
 import { useState } from 'preact/hooks';
 
@@ -27,34 +29,76 @@ export const productsPlugin: AutocompletePlugin<ProductHit, {}> = {
     return [
       {
         sourceId: 'productsPlugin',
-        getItems() {
-          return getAlgoliaResults({
+        getItems({ state, setContext }) {
+          const preview = state.context.preview as ProductsPluginContext;
+
+          const facetFilters = [];
+
+          if (preview?.facetName) {
+            facetFilters.push(`${preview.facetName}:${preview.facetValue}`);
+          }
+
+          return getAlgoliaResults<ProductHit>({
             searchClient,
             queries: [
               {
                 indexName: ALGOLIA_PRODUCTS_INDEX_NAME,
-                query,
+                query: preview?.query || query,
                 params: {
                   hitsPerPage: 4,
+                  facetFilters,
                 },
               },
             ],
+            transformResponse({ hits, results }) {
+              setContext({
+                nbProducts: (results[0] as SearchResponse<ProductHit>).nbHits,
+              });
+
+              return hits;
+            },
           });
         },
         onSelect({ setIsOpen }) {
           setIsOpen(true);
         },
         templates: {
-          header({ Fragment }) {
+          header({ state, Fragment }) {
+            const preview = state.context.preview as ProductsPluginContext;
+
             return (
               <Fragment>
-                <span className="aa-SourceHeaderTitle">Products</span>
+                <div className="aa-SourceHeaderTitle">
+                  Products {preview?.facetValue ? 'in' : 'for'} "
+                  {preview?.query || preview?.facetValue || state.query}"{' '}
+                  {preview?.facetName === 'list_categories'
+                    ? 'category'
+                    : preview?.facetName}
+                </div>
                 <div className="aa-SourceHeaderLine" />
               </Fragment>
             );
           },
-          item({ item }) {
-            return <ProductItem hit={item} />;
+          item({ item, components }) {
+            return <ProductItem hit={item} components={components} />;
+          },
+          footer({ state }) {
+            return (
+              state.context.nbProducts > 4 && (
+                <div style={{ textAlign: 'center' }}>
+                  <a
+                    href="https://example.org/"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="aa-SeeAllBtn"
+                  >
+                    See All Products{' '}
+                    {state.context.nbProducts &&
+                      `(${state.context.nbProducts})`}
+                  </a>
+                </div>
+              )
+            );
           },
         },
       },
@@ -68,14 +112,20 @@ function formatPrice(value: number, currency = 'EUR') {
 
 type ProductItemProps = {
   hit: ProductHit;
+  components: AutocompleteComponents;
 };
 
-function ProductItem({ hit }: ProductItemProps) {
+function ProductItem({ hit, components }: ProductItemProps) {
   const [loaded, setLoaded] = useState(false);
   const [favorite, setFavorite] = useState(false);
 
   return (
-    <a href="#" className="aa-ItemLink aa-ProductItem">
+    <a
+      href="https://example.org/"
+      target="_blank"
+      rel="noreferrer noopener"
+      className="aa-ItemLink aa-ProductItem"
+    >
       <div className="aa-ItemContent">
         <div
           className={cx('aa-ItemPicture', loaded && 'aa-ItemPicture--loaded')}
@@ -98,9 +148,15 @@ function ProductItem({ hit }: ProductItemProps) {
         <div className="aa-ItemContentBody">
           <div>
             {hit.brand && (
-              <div className="aa-ItemContentBrand">{hit.brand}</div>
+              <div className="aa-ItemContentBrand">
+                <components.Highlight hit={hit} attribute="brand" />
+              </div>
             )}
-            <div className="aa-ItemContentTitle">{hit.name}</div>
+            <div className="aa-ItemContentTitleWrapper">
+              <div className="aa-ItemContentTitle">
+                <components.Highlight hit={hit} attribute="name" />
+              </div>
+            </div>
           </div>
           <div>
             <div className="aa-ItemContentPrice">

--- a/examples/two-column-layout/src/plugins/querySuggestionsPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/querySuggestionsPlugin.tsx
@@ -1,15 +1,97 @@
 /** @jsx h */
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
+import { h } from 'preact';
 
 import { ALGOLIA_PRODUCTS_QUERY_SUGGESTIONS_INDEX_NAME } from '../constants';
 import { searchClient } from '../searchClient';
+import { setSmartPreview } from '../setSmartPreview';
+import { QuerySuggestionsHit } from '../types';
 
 export const querySuggestionsPlugin = createQuerySuggestionsPlugin({
   searchClient,
   indexName: ALGOLIA_PRODUCTS_QUERY_SUGGESTIONS_INDEX_NAME,
   getSearchParams({ state }) {
     return {
-      hitsPerPage: !state.query ? 0 : 8,
+      hitsPerPage: !state.query ? 0 : 20,
+    };
+  },
+  transformSource({ source, onTapAhead }) {
+    return {
+      ...source,
+      onActive(params) {
+        setSmartPreview({
+          preview: {
+            query: params.itemInputValue,
+          },
+          ...params,
+        });
+      },
+      templates: {
+        ...source.templates,
+        item({ item, components, state }) {
+          if (item.__autocomplete_qsCategory) {
+            return (
+              <div
+                className="aa-ItemWrapper"
+                data-active={
+                  state.context.lastActiveItemId ===
+                  (item as QuerySuggestionsHit).__autocomplete_id
+                }
+              >
+                <div className="aa-ItemContent aa-ItemContent--indented">
+                  <div className="aa-ItemContentSubtitle aa-ItemContentSubtitle--standalone">
+                    <span className="aa-ItemContentSubtitleIcon" />
+                    <span>
+                      in{' '}
+                      <span className="aa-ItemContentSubtitleCategory">
+                        {item.__autocomplete_qsCategory}
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            );
+          }
+
+          return (
+            <div
+              className="aa-ItemWrapper"
+              data-active={
+                state.context.lastActiveItemId ===
+                (item as QuerySuggestionsHit).__autocomplete_id
+              }
+            >
+              <div className="aa-ItemContent">
+                <div className="aa-ItemIcon aa-ItemIcon--noBorder">
+                  <svg viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M16.041 15.856c-0.034 0.026-0.067 0.055-0.099 0.087s-0.060 0.064-0.087 0.099c-1.258 1.213-2.969 1.958-4.855 1.958-1.933 0-3.682-0.782-4.95-2.050s-2.050-3.017-2.050-4.95 0.782-3.682 2.050-4.95 3.017-2.050 4.95-2.050 3.682 0.782 4.95 2.050 2.050 3.017 2.050 4.95c0 1.886-0.745 3.597-1.959 4.856zM21.707 20.293l-3.675-3.675c1.231-1.54 1.968-3.493 1.968-5.618 0-2.485-1.008-4.736-2.636-6.364s-3.879-2.636-6.364-2.636-4.736 1.008-6.364 2.636-2.636 3.879-2.636 6.364 1.008 4.736 2.636 6.364 3.879 2.636 6.364 2.636c2.125 0 4.078-0.737 5.618-1.968l3.675 3.675c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414z" />
+                  </svg>
+                </div>
+                <div className="aa-ItemContentBody">
+                  <div className="aa-ItemContentTitle">
+                    <components.ReverseHighlight hit={item} attribute="query" />
+                  </div>
+                </div>
+              </div>
+              <div className="aa-ItemActions">
+                <button
+                  className="aa-ItemActionButton"
+                  title={`Fill query with "${item.query}"`}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onTapAhead(item);
+                  }}
+                >
+                  <svg viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M8 17v-7.586l8.293 8.293c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-8.293-8.293h7.586c0.552 0 1-0.448 1-1s-0.448-1-1-1h-10c-0.552 0-1 0.448-1 1v10c0 0.552 0.448 1 1 1s1-0.448 1-1z" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          );
+        },
+      },
     };
   },
 });

--- a/examples/two-column-layout/src/plugins/quickAccessPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/quickAccessPlugin.tsx
@@ -62,7 +62,7 @@ type QuickAccessItemProps = {
   hit: QuickAccessHit;
 };
 
-const QuickAccessItem = ({ hit }: QuickAccessItemProps) => {
+function QuickAccessItem({ hit }: QuickAccessItemProps) {
   return (
     <a
       href={hit.href}
@@ -102,4 +102,4 @@ const QuickAccessItem = ({ hit }: QuickAccessItemProps) => {
       </div>
     </a>
   );
-};
+}

--- a/examples/two-column-layout/src/plugins/quickAccessPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/quickAccessPlugin.tsx
@@ -1,0 +1,102 @@
+/** @jsx h */
+import {
+  AutocompletePlugin,
+  getAlgoliaResults,
+} from '@algolia/autocomplete-js';
+import { SearchResponse } from '@algolia/client-search';
+import { h } from 'preact';
+
+import { ALGOLIA_PRODUCTS_INDEX_NAME } from '../constants';
+import { searchClient } from '../searchClient';
+import { QuickAccessHit } from '../types';
+
+export const quickAccessPlugin: AutocompletePlugin<QuickAccessHit, {}> = {
+  getSources({ query }) {
+    if (query) {
+      return [];
+    }
+
+    return [
+      {
+        sourceId: 'quickAccessPlugin',
+        getItems() {
+          return getAlgoliaResults<QuickAccessHit>({
+            searchClient,
+            queries: [
+              {
+                indexName: ALGOLIA_PRODUCTS_INDEX_NAME,
+                query,
+                params: {
+                  hitsPerPage: 0,
+                  ruleContexts: ['quickAccess'],
+                },
+              },
+            ],
+            transformResponse({ results }) {
+              const resultsAs = results as SearchResponse[];
+              const userData = resultsAs?.[0].userData;
+              const items = userData?.[0]?.items;
+              return items || [];
+            },
+          });
+        },
+        templates: {
+          header() {
+            return <div className="aa-SourceHeaderTitle">Quick access</div>;
+          },
+          item({ item }) {
+            return <QuickAccessItem hit={item} />;
+          },
+        },
+      },
+    ];
+  },
+};
+
+type QuickAccessItemProps = {
+  hit: QuickAccessHit;
+};
+
+const QuickAccessItem = ({ hit }: QuickAccessItemProps) => {
+  return (
+    <a
+      href={hit.href}
+      className={[
+        'aa-ItemLink aa-QuickAccessItem',
+        `aa-QuickAccessItem--${hit.template}`,
+      ].join(' ')}
+    >
+      <div className="aa-ItemContent">
+        {hit.image && (
+          <div className="aa-ItemPicture">
+            <img src={hit.image} alt={hit.title} />
+          </div>
+        )}
+
+        <div className="aa-ItemContentBody">
+          {hit.date && <div className="aa-ItemContentDate">{hit.date}</div>}
+          <div
+            className="aa-ItemContentTitle"
+            dangerouslySetInnerHTML={{ __html: hit.title }}
+          />
+          {hit.subtitle && (
+            <div
+              className="aa-ItemContentSubTitle"
+              dangerouslySetInnerHTML={{ __html: hit.subtitle }}
+            />
+          )}
+
+          {hit.links && (
+            <ul>
+              {hit.links.map((link, i) => (
+                <li key={i}>
+                  <a href={link.href}>{link.text}</a>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </a>
+  );
+};

--- a/examples/two-column-layout/src/plugins/quickAccessPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/quickAccessPlugin.tsx
@@ -9,6 +9,7 @@ import { h } from 'preact';
 import { ALGOLIA_PRODUCTS_INDEX_NAME } from '../constants';
 import { searchClient } from '../searchClient';
 import { QuickAccessHit } from '../types';
+import { cx, intersperse } from '../utils';
 
 export const quickAccessPlugin: AutocompletePlugin<QuickAccessHit, {}> = {
   getSources({ query }) {
@@ -20,7 +21,7 @@ export const quickAccessPlugin: AutocompletePlugin<QuickAccessHit, {}> = {
       {
         sourceId: 'quickAccessPlugin',
         getItems() {
-          return getAlgoliaResults<QuickAccessHit>({
+          return getAlgoliaResults({
             searchClient,
             queries: [
               {
@@ -33,16 +34,20 @@ export const quickAccessPlugin: AutocompletePlugin<QuickAccessHit, {}> = {
               },
             ],
             transformResponse({ results }) {
-              const resultsAs = results as SearchResponse[];
-              const userData = resultsAs?.[0].userData;
-              const items = userData?.[0]?.items;
-              return items || [];
+              return (
+                (results as SearchResponse[])?.[0].userData?.[0]?.items || []
+              );
             },
           });
         },
         templates: {
-          header() {
-            return <div className="aa-SourceHeaderTitle">Quick access</div>;
+          header({ Fragment }) {
+            return (
+              <Fragment>
+                <span className="aa-SourceHeaderTitle">Quick access</span>
+                <div className="aa-SourceHeaderLine" />
+              </Fragment>
+            );
           },
           item({ item }) {
             return <QuickAccessItem hit={item} />;
@@ -61,10 +66,10 @@ const QuickAccessItem = ({ hit }: QuickAccessItemProps) => {
   return (
     <a
       href={hit.href}
-      className={[
+      className={cx(
         'aa-ItemLink aa-QuickAccessItem',
-        `aa-QuickAccessItem--${hit.template}`,
-      ].join(' ')}
+        `aa-QuickAccessItem--${hit.template}`
+      )}
     >
       <div className="aa-ItemContent">
         {hit.image && (
@@ -75,21 +80,19 @@ const QuickAccessItem = ({ hit }: QuickAccessItemProps) => {
 
         <div className="aa-ItemContentBody">
           {hit.date && <div className="aa-ItemContentDate">{hit.date}</div>}
-          <div
-            className="aa-ItemContentTitle"
-            dangerouslySetInnerHTML={{ __html: hit.title }}
-          />
+          <div className="aa-ItemContentTitle">
+            {intersperse(hit.title.split('\n'), <br />)}
+          </div>
           {hit.subtitle && (
-            <div
-              className="aa-ItemContentSubTitle"
-              dangerouslySetInnerHTML={{ __html: hit.subtitle }}
-            />
+            <div className="aa-ItemContentSubTitle">
+              {intersperse(hit.subtitle.split('\n'), <br />)}
+            </div>
           )}
 
           {hit.links && (
             <ul>
-              {hit.links.map((link, i) => (
-                <li key={i}>
+              {hit.links.map((link) => (
+                <li key={link.text}>
                   <a href={link.href}>{link.text}</a>
                 </li>
               ))}

--- a/examples/two-column-layout/src/plugins/recentSearchesPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/recentSearchesPlugin.tsx
@@ -5,25 +5,90 @@ import {
 } from '@algolia/autocomplete-plugin-recent-searches';
 import { h } from 'preact';
 
+import { setSmartPreview } from '../setSmartPreview';
+import { RecentSearchesHit } from '../types';
+
 export const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
   key: 'autocomplete-two-column-layout-example',
   search(params) {
     const limit = params.query ? 1 : 4;
     return search({ ...params, limit });
   },
-  transformSource({ source }) {
+  transformSource({ source, onRemove, onTapAhead }) {
     return {
       ...source,
+      onActive(params) {
+        if (!params.state.query) {
+          return;
+        }
+
+        setSmartPreview({
+          preview: {
+            query: params.item.label,
+          },
+          ...params,
+        });
+      },
       templates: {
         ...source.templates,
-        header({ state, Fragment }) {
+        item({ item, components, state }) {
           return (
-            <Fragment>
-              <span className="aa-SourceHeaderTitle">
-                {state.query ? 'Suggestions' : 'Recent searches'}
-              </span>
-              <div className="aa-SourceHeaderLine" />
-            </Fragment>
+            <div
+              className="aa-ItemWrapper"
+              data-active={
+                state.context.lastActiveItemId ===
+                (item as RecentSearchesHit).__autocomplete_id
+              }
+            >
+              <div className="aa-ItemContent">
+                <div className="aa-ItemIcon aa-ItemIcon--noBorder">
+                  <svg viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M12.516 6.984v5.25l4.5 2.672-0.75 1.266-5.25-3.188v-6h1.5zM12 20.016q3.281 0 5.648-2.367t2.367-5.648-2.367-5.648-5.648-2.367-5.648 2.367-2.367 5.648 2.367 5.648 5.648 2.367zM12 2.016q4.125 0 7.055 2.93t2.93 7.055-2.93 7.055-7.055 2.93-7.055-2.93-2.93-7.055 2.93-7.055 7.055-2.93z" />
+                  </svg>
+                </div>
+                <div className="aa-ItemContentBody">
+                  <div className="aa-ItemContentTitle">
+                    <components.ReverseHighlight hit={item} attribute="label" />
+                    {item.category && (
+                      <span className="aa-ItemContentSubtitle aa-ItemContentSubtitle--inline">
+                        <span className="aa-ItemContentSubtitleIcon" /> in{' '}
+                        <span className="aa-ItemContentSubtitleCategory">
+                          {item.category}
+                        </span>
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+              <div className="aa-ItemActions">
+                <button
+                  className="aa-ItemActionButton"
+                  title="Remove this search"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onRemove(item.id);
+                  }}
+                >
+                  <svg viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M18 7v13c0 0.276-0.111 0.525-0.293 0.707s-0.431 0.293-0.707 0.293h-10c-0.276 0-0.525-0.111-0.707-0.293s-0.293-0.431-0.293-0.707v-13zM17 5v-1c0-0.828-0.337-1.58-0.879-2.121s-1.293-0.879-2.121-0.879h-4c-0.828 0-1.58 0.337-2.121 0.879s-0.879 1.293-0.879 2.121v1h-4c-0.552 0-1 0.448-1 1s0.448 1 1 1h1v13c0 0.828 0.337 1.58 0.879 2.121s1.293 0.879 2.121 0.879h10c0.828 0 1.58-0.337 2.121-0.879s0.879-1.293 0.879-2.121v-13h1c0.552 0 1-0.448 1-1s-0.448-1-1-1zM9 5v-1c0-0.276 0.111-0.525 0.293-0.707s0.431-0.293 0.707-0.293h4c0.276 0 0.525 0.111 0.707 0.293s0.293 0.431 0.293 0.707v1zM9 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1zM13 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1z" />
+                  </svg>
+                </button>
+                <button
+                  className="aa-ItemActionButton"
+                  title={`Fill query with "${item.label}"`}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onTapAhead(item);
+                  }}
+                >
+                  <svg viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M8 17v-7.586l8.293 8.293c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-8.293-8.293h7.586c0.552 0 1-0.448 1-1s-0.448-1-1-1h-10c-0.552 0-1 0.448-1 1v10c0 0.552 0.448 1 1 1s1-0.448 1-1z" />
+                  </svg>
+                </button>
+              </div>
+            </div>
           );
         },
       },

--- a/examples/two-column-layout/src/setSmartPreview.ts
+++ b/examples/two-column-layout/src/setSmartPreview.ts
@@ -1,0 +1,29 @@
+import {
+  AutocompleteScopeApi,
+  AutocompleteState,
+  BaseItem,
+} from '@algolia/autocomplete-core';
+import { dequal } from 'dequal/lite';
+
+import { isTouchDevice } from './utils';
+
+type smartPreviewParams<
+  TItem extends BaseItem
+> = AutocompleteScopeApi<TItem> & {
+  state: AutocompleteState<TItem>;
+  preview: {
+    [key: string]: unknown;
+  };
+};
+
+export function setSmartPreview<TItem extends BaseItem>({
+  state,
+  setContext,
+  refresh,
+  preview,
+}: smartPreviewParams<TItem>) {
+  if (!dequal(state.context.preview, preview) && !isTouchDevice()) {
+    setContext({ preview, lastActiveItemId: state.activeItemId });
+    refresh();
+  }
+}

--- a/examples/two-column-layout/src/types/AutocompleteHit.ts
+++ b/examples/two-column-layout/src/types/AutocompleteHit.ts
@@ -1,0 +1,7 @@
+import { Hit } from '@algolia/client-search';
+
+export type AutocompleteHit<THit> = Hit<
+  THit & {
+    __autocomplete_id: number;
+  }
+>;

--- a/examples/two-column-layout/src/types/BrandHit.ts
+++ b/examples/two-column-layout/src/types/BrandHit.ts
@@ -1,8 +1,8 @@
-import { Hit } from '@algolia/client-search';
+import { AutocompleteHit } from './AutocompleteHit';
 
 type BrandRecord = {
   label: string;
   count: number;
 };
 
-export type BrandHit = Hit<BrandRecord>;
+export type BrandHit = AutocompleteHit<BrandRecord>;

--- a/examples/two-column-layout/src/types/CategoryHit.ts
+++ b/examples/two-column-layout/src/types/CategoryHit.ts
@@ -1,7 +1,7 @@
-import { Hit } from '@algolia/client-search';
+import { AutocompleteHit } from './AutocompleteHit';
 
 type CategoryRecord = {
   list_categories: string[];
 };
 
-export type CategoryHit = Hit<CategoryRecord>;
+export type CategoryHit = AutocompleteHit<CategoryRecord>;

--- a/examples/two-column-layout/src/types/FaqHit.ts
+++ b/examples/two-column-layout/src/types/FaqHit.ts
@@ -1,4 +1,4 @@
-import { Hit } from '@algolia/client-search';
+import { AutocompleteHit } from './AutocompleteHit';
 
 type FaqRecord = {
   list_categories: string[];
@@ -6,4 +6,4 @@ type FaqRecord = {
   description: string;
 };
 
-export type FaqHit = Hit<FaqRecord>;
+export type FaqHit = AutocompleteHit<FaqRecord>;

--- a/examples/two-column-layout/src/types/PopularCategoryHit.ts
+++ b/examples/two-column-layout/src/types/PopularCategoryHit.ts
@@ -1,0 +1,8 @@
+import { Hit } from '@algolia/client-search';
+
+type PopularCategoryRecord = {
+  label: string;
+  count: number;
+};
+
+export type PopularCategoryHit = Hit<PopularCategoryRecord>;

--- a/examples/two-column-layout/src/types/QuerySuggestionsHit.ts
+++ b/examples/two-column-layout/src/types/QuerySuggestionsHit.ts
@@ -1,0 +1,5 @@
+import { AutocompleteQuerySuggestionsHit } from '@algolia/autocomplete-plugin-query-suggestions/dist/esm/types';
+
+import { AutocompleteHit } from './AutocompleteHit';
+
+export type QuerySuggestionsHit = AutocompleteHit<AutocompleteQuerySuggestionsHit>;

--- a/examples/two-column-layout/src/types/QuickAccessHit.ts
+++ b/examples/two-column-layout/src/types/QuickAccessHit.ts
@@ -1,10 +1,5 @@
 import { Hit } from '@algolia/client-search';
 
-type QuickAccessRecordLink = {
-  text: string;
-  href: string;
-};
-
 type QuickAccessRecord = {
   template: 'sales-banner' | 'sales-code' | 'new-collection' | 'help';
   href: string;
@@ -12,7 +7,10 @@ type QuickAccessRecord = {
   title: string;
   subtitle: string;
   date?: string;
-  links?: QuickAccessRecordLink[];
+  links?: Array<{
+    text: string;
+    href: string;
+  }>;
 };
 
 export type QuickAccessHit = Hit<QuickAccessRecord>;

--- a/examples/two-column-layout/src/types/QuickAccessHit.ts
+++ b/examples/two-column-layout/src/types/QuickAccessHit.ts
@@ -1,0 +1,18 @@
+import { Hit } from '@algolia/client-search';
+
+type QuickAccessRecordLink = {
+  text: string;
+  href: string;
+};
+
+type QuickAccessRecord = {
+  template: 'sales-banner' | 'sales-code' | 'new-collection' | 'help';
+  href: string;
+  image: string;
+  title: string;
+  subtitle: string;
+  date?: string;
+  links?: QuickAccessRecordLink[];
+};
+
+export type QuickAccessHit = Hit<QuickAccessRecord>;

--- a/examples/two-column-layout/src/types/RecentSearchesHit.ts
+++ b/examples/two-column-layout/src/types/RecentSearchesHit.ts
@@ -1,0 +1,5 @@
+import { RecentSearchesItem } from '@algolia/autocomplete-plugin-recent-searches/dist/esm/types';
+
+import { AutocompleteHit } from './AutocompleteHit';
+
+export type RecentSearchesHit = AutocompleteHit<RecentSearchesItem>;

--- a/examples/two-column-layout/src/types/index.ts
+++ b/examples/two-column-layout/src/types/index.ts
@@ -4,3 +4,4 @@ export * from './BrandHit';
 export * from './FaqHit';
 export * from './ArticleHit';
 export * from './PopularHit';
+export * from './QuickAccessHit';

--- a/examples/two-column-layout/src/types/index.ts
+++ b/examples/two-column-layout/src/types/index.ts
@@ -5,3 +5,6 @@ export * from './FaqHit';
 export * from './ArticleHit';
 export * from './PopularHit';
 export * from './QuickAccessHit';
+export * from './PopularCategoryHit';
+export * from './RecentSearchesHit';
+export * from './QuerySuggestionsHit';

--- a/examples/two-column-layout/src/utils/index.ts
+++ b/examples/two-column-layout/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './cx';
+export * from './intersperse';

--- a/examples/two-column-layout/src/utils/index.ts
+++ b/examples/two-column-layout/src/utils/index.ts
@@ -1,2 +1,4 @@
 export * from './cx';
 export * from './intersperse';
+export * from './isTouchDevice';
+export * from './isDetached';

--- a/examples/two-column-layout/src/utils/isDetached.ts
+++ b/examples/two-column-layout/src/utils/isDetached.ts
@@ -1,0 +1,7 @@
+export function isDetached() {
+  return window.matchMedia(
+    getComputedStyle(document.documentElement).getPropertyValue(
+      '--aa-detached-media-query'
+    )
+  ).matches;
+}

--- a/examples/two-column-layout/src/utils/isTouchDevice.ts
+++ b/examples/two-column-layout/src/utils/isTouchDevice.ts
@@ -1,0 +1,3 @@
+export function isTouchDevice() {
+  return 'ontouchstart' in window;
+}

--- a/examples/two-column-layout/style.css
+++ b/examples/two-column-layout/style.css
@@ -344,12 +344,133 @@ body {
   height: var(--aa-spacing);
 }
 
+/* Quick access */
+.aa-PanelSection--quickAccess .aa-List {
+  display: flex;
+  column-gap: var(--aa-spacing-half);
+  align-items: stretch;
+}
+
+.aa-PanelSection--quickAccess .aa-Item {
+  width: 100%;
+}
+
+.aa-QuickAccessItem {
+  height: 100%;
+}
+
+.aa-QuickAccessItem.aa-ItemLink {
+  display: flex;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.aa-QuickAccessItem .aa-ItemContent {
+  position: relative;
+  color: #fff;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.aa-QuickAccessItem .aa-ItemContentTitle {
+  margin: 0;
+}
+
+.aa-QuickAccessItem .aa-ItemContentBody {
+  padding: var(--aa-spacing);
+  width: 100%;
+}
+
+/* --- Sales banner template */
+.aa-QuickAccessItem--sales-banner .aa-ItemContentBody {
+  width: 100%;
+  background-color: #f78125;
+  bottom: 0;
+  text-align: center;
+  position: absolute;
+}
+
+.aa-QuickAccessItem--sales-banner .aa-ItemContentTitle {
+  font-weight: bold;
+}
+
+/* --- Sale code template */
+.aa-QuickAccessItem--sales-code .aa-ItemContentBody {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  height: 100%;
+  width: 100%;
+  text-align: center;
+  position: absolute;
+}
+
+.aa-QuickAccessItem--sales-code .aa-ItemContentTitle {
+  font-size: 1.2em;
+  line-height: 1.3em;
+  font-weight: bold;
+}
+
+/* --- New collection template */
+.aa-QuickAccessItem--new-collection .aa-ItemContentBody {
+  position: absolute;
+}
+
+.aa-QuickAccessItem--new-collection .aa-ItemContent {
+  text-transform: uppercase;
+}
+
+.aa-QuickAccessItem--new-collection .aa-ItemContentTitle {
+  font-weight: bold;
+  margin-bottom: var(--aa-spacing-half);
+}
+
+/* --- Help template */
+.aa-QuickAccessItem.aa-QuickAccessItem--help {
+  background-color: #f78125;
+}
+
+.aa-QuickAccessItem--help .aa-ItemContent {
+  align-items: flex-start;
+}
+
+.aa-QuickAccessItem--help .aa-ItemContentTitle {
+  text-transform: uppercase;
+  font-size: 1.2em;
+  font-weight: bold;
+  line-height: 1.3em;
+}
+
+.aa-QuickAccessItem--help ul {
+  list-style: none;
+  padding: 0;
+  font-size: 0.9em;
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--aa-spacing-half);
+  margin-top: var(--aa-spacing);
+}
+
+.aa-QuickAccessItem--help a {
+  color: #fff;
+  transition: opacity 0.2s ease-out;
+}
+
+.aa-QuickAccessItem--help a:hover {
+  opacity: 0.6;
+}
+
 /* Media queries */
 @media screen and (prefers-reduced-motion: reduce) {
   .aa-Item,
   .aa-PanelSection--products,
   .aa-ProductItem .aa-ItemPictureBlurred,
-  .aa-ProductItem .aa-ItemFavorite {
+  .aa-ProductItem .aa-ItemFavorite,
+  .aa-QuickAccessItem--help a {
     transition: none;
   }
 }
@@ -365,6 +486,10 @@ body {
 
   .aa-PanelSection--right {
     width: 60%;
+  }
+
+  .aa-PanelSection--quickAccess .aa-Item:nth-child(3) {
+    display: none;
   }
 }
 
@@ -408,6 +533,22 @@ body {
 
   .aa-PanelSection--articles .aa-Item {
     width: 100%;
+  }
+
+  /* Quick access */
+  .aa-PanelSection--quickAccess .aa-List {
+    overflow: auto;
+    scroll-snap-type: x;
+  }
+
+  .aa-PanelSection--quickAccess .aa-Item {
+    min-width: 40vw;
+    scroll-snap-align: start;
+    padding: 0;
+  }
+
+  .aa-PanelSection--quickAccess .aa-Item:nth-child(3) {
+    display: block;
   }
 }
 

--- a/examples/two-column-layout/style.css
+++ b/examples/two-column-layout/style.css
@@ -355,14 +355,20 @@ body {
   width: 100%;
 }
 
-.aa-QuickAccessItem {
-  height: 100%;
-}
-
-.aa-QuickAccessItem.aa-ItemLink {
+.aa-PanelSection--quickAccess .aa-QuickAccessItem {
   display: flex;
   border-radius: 3px;
   overflow: hidden;
+  height: 100%;
+}
+
+.aa-QuickAccessItem .aa-ItemPicture:after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.25);
 }
 
 .aa-QuickAccessItem .aa-ItemContent {

--- a/examples/two-column-layout/style.css
+++ b/examples/two-column-layout/style.css
@@ -3,6 +3,13 @@
 }
 
 body {
+  --aa-panel-max-height: 660px;
+
+  --aa-selected-color-rgb: 240, 238, 246;
+  --aa-selected-color-alpha: 1;
+
+  --aa-icon-size: 18px;
+
   background-color: #f4f4f9;
   color: #000;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -15,28 +22,24 @@ body {
 
 .container {
   margin: 0 auto;
-  max-width: 1280px;
+  max-width: 1024px;
   width: 100%;
 }
 
-/* Blurhash */
-.aa-BlurhashCanvas {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
+/* Panel */
+.aa-Panel .aa-SourceHeader {
+  margin: var(--aa-spacing-half) 0 var(--aa-spacing-half) 0;
 }
 
 /* Panel section */
 .aa-PanelSections {
-  column-gap: var(--aa-spacing-half);
+  column-gap: var(--aa-spacing);
   display: flex;
 }
 
 .aa-PanelSection--left {
   display: flex;
   flex-direction: column;
-  row-gap: var(--aa-spacing);
   width: 30%;
 }
 
@@ -46,7 +49,7 @@ body {
 
 .aa-PanelSection--left .aa-ItemWrapper {
   height: 100%;
-  padding: calc(var(--aa-spacing-half) / 2);
+  border-radius: calc(var(--aa-spacing-half) / 2);
 }
 
 .aa-PanelSection--right {
@@ -56,25 +59,33 @@ body {
   width: 70%;
 }
 
+.aa-PanelSectionSources {
+  display: grid;
+  row-gap: var(--aa-spacing);
+}
+
 /* Item */
 .aa-Item {
   transition: background 0.2s ease-out;
 }
 
-.aa-Item:hover .aa-ItemPicture img {
-  transform: scale(1.1);
+.aa-ItemWrapper[data-active='true'] {
+  background-color: rgba(
+    var(--aa-selected-color-rgb),
+    var(--aa-selected-color-alpha)
+  );
 }
 
 .aa-ItemPicture {
   width: 100%;
-  border-radius: 3px;
+  border-radius: calc(var(--aa-spacing-half) / 2);
   overflow: hidden;
 }
 
 .aa-ItemPicture img {
   object-fit: cover;
   width: 100%;
-  height: 100%;
+  height: auto;
   transition: transform 1.8s ease-out, opacity 0.2s ease-out;
   transform-origin: center;
   position: relative;
@@ -103,6 +114,10 @@ body {
   text-transform: capitalize;
 }
 
+.aa-Breadcrumb mark {
+  text-transform: none;
+}
+
 .aa-Breadcrumb .aa-ItemIcon {
   width: var(--aa-icon-size);
   height: var(--aa-icon-size);
@@ -113,42 +128,53 @@ body {
   height: calc(var(--aa-icon-size) * 0.6);
 }
 
+.aa-Breadcrumb mark {
+  background: none;
+  color: inherit;
+  font-style: normal;
+  font-weight: var(--aa-font-weight-bold);
+}
+
 /* Products */
 .aa-PanelSection--products {
   transition: background 0.2s ease-out;
 }
 
-.aa-PanelSection--products-preview {
+.aa-PanelSection--products-preview .aa-List {
   background: rgba(
     var(--aa-selected-color-rgb),
     var(--aa-selected-color-alpha)
   );
-  border-radius: 3px;
+  border-radius: calc(var(--aa-spacing-half) / 2);
+}
+
+.aa-PanelSection--products-preview .aa-Item[aria-selected='true'] {
+  background: none;
 }
 
 .aa-PanelSection--products .aa-List {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: var(--aa-spacing);
+  padding: var(--aa-spacing-half);
 }
 
 .aa-PanelSection--products .aa-Item {
   align-items: flex-start;
   width: 100%;
-}
-
-.aa-PanelSection--products .aa-Item:hover .aa-ItemFavorite {
-  opacity: 1;
+  padding: var(--aa-spacing-half);
 }
 
 .aa-ProductItem {
   height: 100%;
-  min-height: 380px;
 }
 
 .aa-ProductItem.aa-ItemLink {
   align-items: flex-start;
   justify-content: stretch;
+}
+
+.aa-ProductItem .aa-ItemContent mark {
+  color: rgb(var(--aa-primary-color-rgb));
 }
 
 .aa-ProductItem .aa-ItemPicture {
@@ -170,7 +196,7 @@ body {
   flex-grow: 1;
   flex-direction: column;
   justify-content: space-between;
-  min-height: 112px;
+  gap: var(--aa-spacing-half);
 }
 
 .aa-ProductItem .aa-ItemPicture--blurred {
@@ -179,9 +205,9 @@ body {
   width: 100%;
   height: 100%;
   background: rgba(var(--aa-muted-color-rgb), 0.2);
+  animation-name: loading;
   animation-duration: 1.5s;
   animation-iteration-count: infinite;
-  animation-name: loading;
   animation-timing-function: linear;
 }
 
@@ -197,12 +223,26 @@ body {
   font-size: 0.7em;
   text-transform: uppercase;
   color: rgb(var(--aa-muted-color-rgb));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.aa-ProductItem .aa-ItemContentBrand mark {
+  font-weight: normal;
+}
+
+.aa-ProductItem .aa-ItemContentTitleWrapper {
+  height: calc(var(--aa-spacing) * 2.5);
 }
 
 .aa-ProductItem .aa-ItemContentTitle {
-  white-space: normal;
   font-size: 0.9em;
   margin: 0;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  white-space: normal;
 }
 
 .aa-ProductItem .aa-ItemContentPriceCurrent {
@@ -251,10 +291,10 @@ body {
 .aa-ProductItem .aa-ItemFavorite {
   z-index: 5;
   position: absolute;
-  right: 4px;
-  top: 4px;
+  right: var(--aa-spacing-half);
+  top: var(--aa-spacing-half);
   background-color: #fff;
-  border-radius: 3px;
+  border-radius: calc(var(--aa-spacing-half) / 2);
   box-shadow: 0px 4px 8px rgba(35, 38, 59, 0.15);
   cursor: pointer;
   opacity: 0;
@@ -262,7 +302,6 @@ body {
 }
 
 .aa-ProductItem .aa-FavoriteIcon {
-  --aa-icon-size: 18px;
   color: rgb(var(--aa-primary-color-rgb));
   stroke-width: 2;
   stroke: currentColor;
@@ -271,6 +310,37 @@ body {
 
 .aa-ProductItem .aa-FavoriteIcon--outlined {
   fill: none;
+}
+
+/* Blurhash */
+.aa-BlurhashCanvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/* See all */
+.aa-SeeAllBtn,
+.aa-SeeAllLink {
+  display: inline-block;
+  text-decoration: none;
+  margin: var(--aa-spacing) auto 0 auto;
+  font-size: 0.9em;
+  font-weight: 600;
+}
+
+.aa-SeeAllBtn {
+  background-color: rgba(var(--aa-primary-color-rgb), 0.8);
+  transition: background 0.2s ease-out;
+  color: #fff;
+  padding: calc(var(--aa-spacing-half) * 1.5) var(--aa-spacing);
+  border-radius: calc(var(--aa-spacing-half) / 2);
+}
+
+.aa-SeeAllLink {
+  color: rgb(var(--aa-primary-color-rgb));
+  transition: opacity 0.2s ease-out;
 }
 
 /* Articles */
@@ -284,12 +354,14 @@ body {
 
 .aa-PanelSection--articles .aa-Item {
   width: 50%;
+  padding: 0;
+  margin: calc(var(--aa-spacing-half) / 2);
 }
 
 .aa-ArticleItem {
   box-shadow: inset 0 0 0 1px
     rgba(var(--aa-panel-border-color-rgb), var(--aa-panel-border-color-alpha));
-  border-radius: 3px;
+  border-radius: calc(var(--aa-spacing-half) / 2);
   padding: var(--aa-spacing-half);
   height: 100%;
 }
@@ -357,7 +429,7 @@ body {
 
 .aa-PanelSection--quickAccess .aa-QuickAccessItem {
   display: flex;
-  border-radius: 3px;
+  border-radius: calc(var(--aa-spacing-half) / 2);
   overflow: hidden;
   height: 100%;
 }
@@ -417,7 +489,7 @@ body {
 
 .aa-QuickAccessItem--sales-code .aa-ItemContentTitle {
   font-size: 1.2em;
-  line-height: 1.3em;
+  line-height: 1.3;
   font-weight: bold;
 }
 
@@ -448,7 +520,7 @@ body {
   text-transform: uppercase;
   font-size: 1.2em;
   font-weight: bold;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 
 .aa-QuickAccessItem--help ul {
@@ -466,18 +538,123 @@ body {
   transition: opacity 0.2s ease-out;
 }
 
-.aa-QuickAccessItem--help a:hover {
-  opacity: 0.6;
+/* Faq preview */
+.aa-FaqPreview,
+.aa-FaqPreview .aa-ItemContent {
+  cursor: initial;
+}
+
+.aa-FaqPreview p {
+  margin-right: var(--aa-spacing);
+}
+
+.aa-FaqPreview a {
+  color: #000;
+  font-size: 0.9em;
+}
+
+.aa-FaqPreview h4,
+.aa-FaqPreview h3 {
+  margin: 0;
+}
+
+.aa-FaqPreview h3 {
+  margin-top: var(--aa-spacing-half);
+}
+
+/* Popular categories */
+.aa-PanelSection--popularCategories .aa-List {
+  display: grid;
+  grid-auto-flow: column;
+  grid-gap: var(--aa-spacing);
+  font-size: 0.9em;
+}
+
+.aa-PanelSection--popularCategories .aa-Item {
+  padding: 0;
+}
+
+.aa-PanelSection--popularCategories .aa-SourceHeader {
+  margin-top: 0;
+}
+
+.aa-PopularCategoryItem.aa-ItemWrapper {
+  justify-content: stretch;
+}
+
+.aa-PopularCategoryItem .aa-ItemContent {
+  grid-auto-flow: row;
+}
+
+.aa-PopularCategoryItem .aa-ItemContentTitle {
+  margin-right: 0;
+}
+
+.aa-PopularCategoryItem .aa-ItemContentTitle span {
+  font-size: 0.8em;
+  color: rgb(var(--aa-muted-color-rgb));
+}
+
+/* No results */
+.aa-NoResultsQuery {
+  font-size: 1.15em;
+  line-height: 1.3;
+  font-weight: bold;
+  margin-bottom: var(--aa-spacing);
+}
+
+.aa-NoResultsAdvicesList {
+  font-size: 0.9em;
+  line-height: 1.3;
+  padding: 0;
+  margin-top: 0;
+  margin-left: calc(var(--aa-spacing) * 1.5);
+  margin-bottom: 0;
+  display: flex;
+  flex-direction: column;
+  row-gap: calc(var(--aa-spacing-half) * 0.5);
 }
 
 /* Media queries */
+@media (hover: hover) {
+  /* Item */
+  .aa-Item:hover .aa-ItemPicture img {
+    transform: scale(1.1);
+  }
+
+  /* Products */
+  .aa-PanelSection--products .aa-Item:hover .aa-ItemFavorite {
+    opacity: 1;
+  }
+
+  /* See all */
+  .aa-SeeAllBtn:hover {
+    background-color: rgba(var(--aa-primary-color-rgb), 1);
+  }
+
+  .aa-SeeAllLink:hover {
+    opacity: 0.8;
+  }
+
+  /* Quick access */
+  .aa-QuickAccessItem--help a:hover {
+    opacity: 0.6;
+  }
+}
+
 @media screen and (prefers-reduced-motion: reduce) {
   .aa-Item,
   .aa-PanelSection--products,
-  .aa-ProductItem .aa-ItemPictureBlurred,
   .aa-ProductItem .aa-ItemFavorite,
-  .aa-QuickAccessItem--help a {
+  .aa-SeeAllBtn,
+  .aa-SeeAllLink,
+  .aa-QuickAccessItem--help a,
+  .aa-ItemPicture img {
     transition: none;
+  }
+
+  .aa-ProductItem .aa-ItemPicture--blurred {
+    animation: none;
   }
 }
 
@@ -499,10 +676,25 @@ body {
   }
 }
 
+@media screen and (max-width: 960px) {
+  .aa-PanelSection--articles .aa-List {
+    flex-wrap: wrap;
+  }
+
+  .aa-PanelSection--articles .aa-Item {
+    width: 100%;
+  }
+}
+
 @media screen and (max-width: 680px) {
-  /* Common */
+  /* Source */
   .aa-SourceHeader {
     display: none;
+  }
+
+  .aa-PanelSection--quickAccess .aa-SourceHeader,
+  .aa-PanelSection--popular .aa-SourceHeader {
+    display: block;
   }
 
   /* Panel section */
@@ -516,6 +708,14 @@ body {
     width: 100%;
   }
 
+  .aa-PanelSection--left .aa-ItemWrapper {
+    padding: calc(var(--aa-spacing-half) / 1.5);
+  }
+
+  .aa-PanelSectionSources {
+    row-gap: 0;
+  }
+
   /* Products */
   .aa-PanelSection--products .aa-List {
     display: flex;
@@ -525,6 +725,10 @@ body {
 
   .aa-PanelSection--products .aa-Item {
     width: calc(50% - var(--aa-spacing-half) / 2);
+  }
+
+  .aa-ProductItem {
+    min-height: 100%;
   }
 
   .aa-ProductItem .aa-ItemFavorite {
@@ -556,6 +760,17 @@ body {
   .aa-PanelSection--quickAccess .aa-Item:nth-child(3) {
     display: block;
   }
+
+  /* Popular categories */
+  .aa-PanelSection--popularCategories .aa-List {
+    grid-template-columns: repeat(3, 1fr);
+    grid-auto-flow: row;
+    grid-gap: var(--aa-spacing-half);
+  }
+
+  .aa-PanelSection--popularCategories .aa-ItemContentTitle span {
+    display: block;
+  }
 }
 
 /* Keyframes */
@@ -565,7 +780,7 @@ body {
   }
 
   50% {
-    opacity: 0;
+    opacity: 0.4;
   }
 
   100% {


### PR DESCRIPTION
This PR adds reshape functions and the quick access plugin to the Autocomplete two columns layout example.

Main PR: #908