### PR TITLE
docs(two-column-layout-example): add no results state and popular categories plugin

### DIFF
--- a/examples/two-column-layout/src/app.tsx
+++ b/examples/two-column-layout/src/app.tsx
@@ -125,7 +125,7 @@ autocomplete({
         <div className="aa-PanelSections">
           <div className="aa-PanelSection--left">
             {hasResults ? (
-              (!state.query && (
+              (!state.query && recentSearches && (
                 <Fragment>
                   <div className="aa-SourceHeader">
                     <span className="aa-SourceHeaderTitle">

--- a/examples/two-column-layout/src/app.tsx
+++ b/examples/two-column-layout/src/app.tsx
@@ -125,13 +125,13 @@ autocomplete({
         <div className="aa-PanelSections">
           <div className="aa-PanelSection--left">
             {hasResults ? (
-              <div>
+              <Fragment>
                 {recentSearches}
                 {querySuggestions}
                 {categories}
                 {brands}
                 {faq}
-              </div>
+              </Fragment>
             ) : (
               <div className="aa-NoResultsAdvices">
                 <div className="aa-NoResultsAdvicesTitle">

--- a/examples/two-column-layout/src/app.tsx
+++ b/examples/two-column-layout/src/app.tsx
@@ -9,6 +9,7 @@ import { articlesPlugin } from './plugins/articlesPlugin';
 import { brandsPlugin } from './plugins/brandsPlugin';
 import { categoriesPlugin } from './plugins/categoriesPlugin';
 import { faqPlugin } from './plugins/faqPlugin';
+import { popularCategoriesPlugin } from './plugins/popularCategoriesPlugin';
 import { popularPlugin } from './plugins/popularPlugin';
 import { productsPlugin } from './plugins/productsPlugin';
 import { querySuggestionsPlugin } from './plugins/querySuggestionsPlugin';
@@ -53,6 +54,7 @@ autocomplete({
     articlesPlugin,
     popularPlugin,
     quickAccessPlugin,
+    popularCategoriesPlugin,
   ],
   getInputProps({ props, setContext }) {
     return {
@@ -89,11 +91,16 @@ autocomplete({
       articlesPlugin: articles,
       popularPlugin: popular,
       quickAccessPlugin: quickAccess,
+      popularCategoriesPlugin: popularCategories,
     } = elements;
 
     const hasResults =
       state.collections
-        .filter(({ source }) => source.sourceId !== 'popularPlugin')
+        .filter(
+          ({ source }) =>
+            source.sourceId !== 'popularPlugin' &&
+            source.sourceId !== 'popularCategoriesPlugin'
+        )
         .reduce((prev, curr) => prev + curr.items.length, 0) > 0;
 
     const previewContext = state.context.preview;
@@ -109,15 +116,34 @@ autocomplete({
           refresh();
         }}
       >
+        {!hasResults && (
+          <div className="aa-NoResultsQuery">
+            Sorry, we didn't find any matches for "{state.query}"
+          </div>
+        )}
+
         <div className="aa-PanelSections">
           <div className="aa-PanelSection--left">
-            {hasResults && (
+            {hasResults ? (
               <div>
                 {recentSearches}
                 {querySuggestions}
                 {categories}
                 {brands}
                 {faq}
+              </div>
+            ) : (
+              <div className="aa-NoResultsAdvices">
+                <div className="aa-NoResultsAdvicesTitle">
+                  Try the following:
+                </div>
+                <ul className="aa-NoResultsAdvicesList">
+                  <li>Double check your spelling</li>
+                  <li>Use fewer keywords</li>
+                  <li>
+                    Search fo an item that is less specific and refine results
+                  </li>
+                </ul>
               </div>
             )}
 
@@ -153,6 +179,12 @@ autocomplete({
 
             {quickAccess && (
               <div className="aa-PanelSection--quickAccess">{quickAccess}</div>
+            )}
+
+            {!hasResults && (
+              <div className="aa-PanelSection--popularCategories">
+                {popularCategories}
+              </div>
             )}
           </div>
         </div>

--- a/examples/two-column-layout/src/app.tsx
+++ b/examples/two-column-layout/src/app.tsx
@@ -125,13 +125,16 @@ autocomplete({
         <div className="aa-PanelSections">
           <div className="aa-PanelSection--left">
             {hasResults ? (
-              <Fragment>
-                {recentSearches}
-                {querySuggestions}
-                {categories}
-                {brands}
-                {faq}
-              </Fragment>
+              (!state.query && recentSearches) ||
+              (state.query && (
+                <div>
+                  {recentSearches}
+                  {querySuggestions}
+                  {categories}
+                  {brands}
+                  {faq}
+                </div>
+              ))
             ) : (
               <div className="aa-NoResultsAdvices">
                 <div className="aa-NoResultsAdvicesTitle">

--- a/examples/two-column-layout/src/app.tsx
+++ b/examples/two-column-layout/src/app.tsx
@@ -34,7 +34,7 @@ const removeDuplicates = uniqBy(({ source, item }) => {
 
 const fillWith = populate({
   mainSourceId: 'querySuggestionsPlugin',
-  limit: 8,
+  limit: 10,
 });
 
 const combine = pipe(removeDuplicates, fillWith);
@@ -118,30 +118,44 @@ autocomplete({
       >
         {!hasResults && (
           <div className="aa-NoResultsQuery">
-            Sorry, we didn't find any matches for "{state.query}".
+            No results for "{state.query}".
           </div>
         )}
 
         <div className="aa-PanelSections">
           <div className="aa-PanelSection--left">
             {hasResults ? (
-              (!state.query && recentSearches) ||
-              (state.query && (
-                <div>
+              (!state.query && (
+                <Fragment>
+                  <div className="aa-SourceHeader">
+                    <span className="aa-SourceHeaderTitle">
+                      Recent searches
+                    </span>
+                    <div className="aa-SourceHeaderLine" />
+                  </div>
                   {recentSearches}
-                  {querySuggestions}
-                  {categories}
-                  {brands}
-                  {faq}
-                </div>
+                </Fragment>
+              )) ||
+              (state.query && (
+                <Fragment>
+                  <div className="aa-SourceHeader">
+                    <span className="aa-SourceHeaderTitle">Suggestions</span>
+                    <div className="aa-SourceHeaderLine" />
+                  </div>
+
+                  <div className="aa-PanelSectionSources">
+                    {recentSearches}
+                    {querySuggestions}
+                    {categories}
+                    {brands}
+                    {faq}
+                  </div>
+                </Fragment>
               ))
             ) : (
               <div className="aa-NoResultsAdvices">
-                <div className="aa-NoResultsAdvicesTitle">
-                  Try the following:
-                </div>
                 <ul className="aa-NoResultsAdvicesList">
-                  <li>Double check your spelling</li>
+                  <li>Double-check your spelling</li>
                   <li>Use fewer keywords</li>
                   <li>Search for a less specific item</li>
                 </ul>
@@ -168,6 +182,19 @@ autocomplete({
                     )}
                   >
                     <div className="aa-PanelSectionSource">{products}</div>
+                    {state.context.nbHits > 4 && (
+                      <div style={{ textAlign: 'center' }}>
+                        <a
+                          href="https://example.org/"
+                          target="_blank"
+                          rel="noreferrer noopener"
+                          className="aa-SeeAll"
+                        >
+                          See All Products{' '}
+                          {state.context.nbHits && `(${state.context.nbHits})`}
+                        </a>
+                      </div>
+                    )}
                   </div>
                 )}
                 {articles && (

--- a/examples/two-column-layout/src/app.tsx
+++ b/examples/two-column-layout/src/app.tsx
@@ -118,7 +118,7 @@ autocomplete({
       >
         {!hasResults && (
           <div className="aa-NoResultsQuery">
-            Sorry, we didn't find any matches for "{state.query}"
+            Sorry, we didn't find any matches for "{state.query}".
           </div>
         )}
 
@@ -143,9 +143,7 @@ autocomplete({
                 <ul className="aa-NoResultsAdvicesList">
                   <li>Double check your spelling</li>
                   <li>Use fewer keywords</li>
-                  <li>
-                    Search fo an item that is less specific and refine results
-                  </li>
+                  <li>Search for a less specific item</li>
                 </ul>
               </div>
             )}

--- a/examples/two-column-layout/src/app.tsx
+++ b/examples/two-column-layout/src/app.tsx
@@ -16,7 +16,7 @@ import { querySuggestionsPlugin } from './plugins/querySuggestionsPlugin';
 import { quickAccessPlugin } from './plugins/quickAccessPlugin';
 import { recentSearchesPlugin } from './plugins/recentSearchesPlugin';
 import { FaqHit } from './types';
-import { cx } from './utils';
+import { cx, isDetached } from './utils';
 
 import '@algolia/autocomplete-theme-classic';
 
@@ -34,7 +34,7 @@ const removeDuplicates = uniqBy(({ source, item }) => {
 
 const fillWith = populate({
   mainSourceId: 'querySuggestionsPlugin',
-  limit: 10,
+  limit: isDetached() ? 6 : 10,
 });
 
 const combine = pipe(removeDuplicates, fillWith);
@@ -124,7 +124,7 @@ autocomplete({
             {hasResults ? (
               (!state.query && recentSearches && (
                 <Fragment>
-                  <div className="aa-SourceHeader">
+                  <div className="aa-SourceHeader aa-SourceHeader--recentSearches">
                     <span className="aa-SourceHeaderTitle">
                       Recent searches
                     </span>
@@ -159,7 +159,7 @@ autocomplete({
               </div>
             )}
 
-            {(!hasResults || !state.query) && (
+            {!state.query && (
               <div className="aa-PanelSection--popular">{popular}</div>
             )}
           </div>
@@ -179,19 +179,6 @@ autocomplete({
                     )}
                   >
                     <div className="aa-PanelSectionSource">{products}</div>
-                    {state.context.nbHits > 4 && (
-                      <div style={{ textAlign: 'center' }}>
-                        <a
-                          href="https://example.org/"
-                          target="_blank"
-                          rel="noreferrer noopener"
-                          className="aa-SeeAll"
-                        >
-                          See All Products{' '}
-                          {state.context.nbHits && `(${state.context.nbHits})`}
-                        </a>
-                      </div>
-                    )}
                   </div>
                 )}
                 {articles && (

--- a/examples/two-column-layout/src/app.tsx
+++ b/examples/two-column-layout/src/app.tsx
@@ -109,10 +109,7 @@ autocomplete({
       <div
         className="aa-PanelLayout aa-Panel--scrollable"
         onMouseLeave={() => {
-          const el = document.querySelector('[data-active=true]');
-          el?.removeAttribute('data-active');
-
-          setContext({ preview: null });
+          setContext({ preview: null, lastActiveItemId: -1 });
           refresh();
         }}
       >

--- a/examples/two-column-layout/src/app.tsx
+++ b/examples/two-column-layout/src/app.tsx
@@ -124,7 +124,7 @@ autocomplete({
             {hasResults ? (
               (!state.query && recentSearches && (
                 <Fragment>
-                  <div className="aa-SourceHeader aa-SourceHeader--recentSearches">
+                  <div className="aa-SourceHeader">
                     <span className="aa-SourceHeaderTitle">
                       Recent searches
                     </span>

--- a/examples/two-column-layout/src/app.tsx
+++ b/examples/two-column-layout/src/app.tsx
@@ -155,6 +155,7 @@ autocomplete({
                   <li>Double-check your spelling</li>
                   <li>Use fewer keywords</li>
                   <li>Search for a less specific item</li>
+                  <li>Try navigate using on the of the popular categories</li>
                 </ul>
               </div>
             )}

--- a/examples/two-column-layout/src/components/Blurhash.tsx
+++ b/examples/two-column-layout/src/components/Blurhash.tsx
@@ -10,12 +10,12 @@ export interface BlurhashProps {
   punch?: number;
 }
 
-export const Blurhash = ({
+export function Blurhash({
   hash,
   width = 128,
   height = 128,
   punch = 1,
-}: BlurhashProps) => {
+}: BlurhashProps) {
   const ref = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
@@ -32,11 +32,13 @@ export const Blurhash = ({
   }, [hash, width, height, punch]);
 
   return (
-    <canvas
-      ref={ref}
-      height={height}
-      width={width}
-      className="aa-BlurhashCanvas"
-    />
+    hash && (
+      <canvas
+        ref={ref}
+        height={height}
+        width={width}
+        className="aa-BlurhashCanvas"
+      />
+    )
   );
-};
+}

--- a/examples/two-column-layout/src/components/Breadcrumb.tsx
+++ b/examples/two-column-layout/src/components/Breadcrumb.tsx
@@ -9,7 +9,7 @@ type BreadcrumbProps = {
   items: string[];
 };
 
-export const Breadcrumb = ({ items }: BreadcrumbProps) => {
+export function Breadcrumb({ items }: BreadcrumbProps) {
   return (
     <div className="aa-Breadcrumb">
       {intersperse(
@@ -20,4 +20,4 @@ export const Breadcrumb = ({ items }: BreadcrumbProps) => {
       )}
     </div>
   );
-};
+}

--- a/examples/two-column-layout/src/components/Breadcrumb.tsx
+++ b/examples/two-column-layout/src/components/Breadcrumb.tsx
@@ -6,7 +6,7 @@ import { intersperse } from '../utils';
 import { ChevronRightIcon } from './Icons';
 
 type BreadcrumbProps = {
-  items: string[];
+  items: string[] | JSX.Element[];
 };
 
 export function Breadcrumb({ items }: BreadcrumbProps) {

--- a/examples/two-column-layout/src/components/FaqPreview.tsx
+++ b/examples/two-column-layout/src/components/FaqPreview.tsx
@@ -11,7 +11,7 @@ type FaqPreviewProps = {
   components: AutocompleteComponents;
 };
 
-export const FaqPreview = ({ hit, components }: FaqPreviewProps) => {
+export function FaqPreview({ hit, components }: FaqPreviewProps) {
   return (
     <div className="aa-FaqPreview aa-Item">
       <div className="aa-ItemContent">
@@ -29,4 +29,4 @@ export const FaqPreview = ({ hit, components }: FaqPreviewProps) => {
       </div>
     </div>
   );
-};
+}

--- a/examples/two-column-layout/src/functions/index.ts
+++ b/examples/two-column-layout/src/functions/index.ts
@@ -1,3 +1,2 @@
 export * from './uniqBy';
 export * from './populate';
-export * from './smartPreview';

--- a/examples/two-column-layout/src/functions/populate.ts
+++ b/examples/two-column-layout/src/functions/populate.ts
@@ -37,6 +37,7 @@ export const populate: AutocompleteReshapeFunction<PopulateOptions> = ({
           },
         };
       }
+
       return transformedSource;
     });
   };

--- a/examples/two-column-layout/src/plugins/articlesPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/articlesPlugin.tsx
@@ -57,7 +57,7 @@ type ArticleItemProps = {
   hit: ArticleHit;
 };
 
-const ArticleItem = ({ hit }: ArticleItemProps) => {
+function ArticleItem({ hit }: ArticleItemProps) {
   const articleDate = new Date(hit.date);
   const articleMonth = articleDate.toLocaleDateString('en-US', {
     month: 'long',
@@ -80,4 +80,4 @@ const ArticleItem = ({ hit }: ArticleItemProps) => {
       </div>
     </a>
   );
-};
+}

--- a/examples/two-column-layout/src/plugins/articlesPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/articlesPlugin.tsx
@@ -3,6 +3,7 @@ import {
   AutocompletePlugin,
   getAlgoliaResults,
 } from '@algolia/autocomplete-js';
+import { SearchResponse } from '@algolia/client-search';
 import { h } from 'preact';
 
 import { ALGOLIA_ARTICLES_INDEX_NAME } from '../constants';
@@ -10,7 +11,7 @@ import { searchClient } from '../searchClient';
 import { ArticleHit } from '../types';
 
 export const articlesPlugin: AutocompletePlugin<ArticleHit, {}> = {
-  getSources({ query }) {
+  getSources({ query, setContext }) {
     if (!query) {
       return [];
     }
@@ -30,6 +31,13 @@ export const articlesPlugin: AutocompletePlugin<ArticleHit, {}> = {
                 },
               },
             ],
+            transformResponse({ hits, results }) {
+              setContext({
+                nbArticles: (results[0] as SearchResponse<ArticleHit>).nbHits,
+              });
+
+              return hits;
+            },
           });
         },
         onSelect({ setIsOpen }) {
@@ -46,6 +54,24 @@ export const articlesPlugin: AutocompletePlugin<ArticleHit, {}> = {
           },
           item({ item }) {
             return <ArticleItem hit={item} />;
+          },
+          footer({ state }) {
+            return (
+              state.context.nbArticles > 2 && (
+                <div style={{ textAlign: 'center' }}>
+                  <a
+                    href="https://example.org/"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="aa-SeeAllLink"
+                  >
+                    See All Articles{' '}
+                    {state.context.nbArticles &&
+                      `(${state.context.nbArticles})`}
+                  </a>
+                </div>
+              )
+            );
           },
         },
       },

--- a/examples/two-column-layout/src/plugins/brandsPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/brandsPlugin.tsx
@@ -8,8 +8,8 @@ import { h } from 'preact';
 
 import { TagIcon } from '../components';
 import { ALGOLIA_PRODUCTS_INDEX_NAME } from '../constants';
-import { setSmartPreview } from '../functions';
 import { searchClient } from '../searchClient';
+import { setSmartPreview } from '../setSmartPreview';
 import { BrandHit } from '../types';
 
 export const brandsPlugin: AutocompletePlugin<BrandHit, {}> = {
@@ -63,7 +63,7 @@ type BrandItemProps = {
   components: AutocompleteComponents;
 };
 
-const BrandItem = ({ hit, components }: BrandItemProps) => {
+function BrandItem({ hit, components }: BrandItemProps) {
   return (
     <div className="aa-ItemWrapper">
       <div className="aa-ItemContent">
@@ -78,4 +78,4 @@ const BrandItem = ({ hit, components }: BrandItemProps) => {
       </div>
     </div>
   );
-};
+}

--- a/examples/two-column-layout/src/plugins/brandsPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/brandsPlugin.tsx
@@ -49,8 +49,16 @@ export const brandsPlugin: AutocompletePlugin<BrandHit, {}> = {
           });
         },
         templates: {
-          item({ item, components }) {
-            return <BrandItem hit={item} components={components} />;
+          item({ item, components, state }) {
+            return (
+              <BrandItem
+                hit={item}
+                components={components}
+                active={
+                  state.context.lastActiveItemId === item.__autocomplete_id
+                }
+              />
+            );
           },
         },
       },
@@ -61,11 +69,12 @@ export const brandsPlugin: AutocompletePlugin<BrandHit, {}> = {
 type BrandItemProps = {
   hit: BrandHit;
   components: AutocompleteComponents;
+  active: boolean;
 };
 
-function BrandItem({ hit, components }: BrandItemProps) {
+function BrandItem({ hit, components, active }: BrandItemProps) {
   return (
-    <div className="aa-ItemWrapper">
+    <div className="aa-ItemWrapper" data-active={active}>
       <div className="aa-ItemContent">
         <div className="aa-ItemIcon aa-ItemIcon--noBorder">
           <TagIcon />

--- a/examples/two-column-layout/src/plugins/categoriesPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/categoriesPlugin.tsx
@@ -7,8 +7,8 @@ import { h } from 'preact';
 
 import { Breadcrumb, GridIcon } from '../components';
 import { ALGOLIA_PRODUCTS_INDEX_NAME } from '../constants';
-import { setSmartPreview } from '../functions';
 import { searchClient } from '../searchClient';
+import { setSmartPreview } from '../setSmartPreview';
 import { CategoryHit } from '../types';
 
 export const categoriesPlugin: AutocompletePlugin<CategoryHit, {}> = {
@@ -60,7 +60,7 @@ type CategoryItemProps = {
   hit: CategoryHit;
 };
 
-const CategoryItem = ({ hit }: CategoryItemProps) => {
+function CategoryItem({ hit }: CategoryItemProps) {
   const breadcrumbCategories = hit.list_categories.slice(0, -1);
   const category = hit.list_categories[hit.list_categories.length - 1];
 
@@ -77,4 +77,4 @@ const CategoryItem = ({ hit }: CategoryItemProps) => {
       <Breadcrumb items={breadcrumbCategories} />
     </div>
   );
-};
+}

--- a/examples/two-column-layout/src/plugins/categoriesPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/categoriesPlugin.tsx
@@ -10,6 +10,7 @@ import { ALGOLIA_PRODUCTS_INDEX_NAME } from '../constants';
 import { searchClient } from '../searchClient';
 import { setSmartPreview } from '../setSmartPreview';
 import { CategoryHit } from '../types';
+import { cx } from '../utils';
 
 export const categoriesPlugin: AutocompletePlugin<CategoryHit, {}> = {
   getSources({ query }) {
@@ -47,8 +48,15 @@ export const categoriesPlugin: AutocompletePlugin<CategoryHit, {}> = {
           });
         },
         templates: {
-          item({ item }) {
-            return <CategoryItem hit={item} />;
+          item({ item, state }) {
+            return (
+              <CategoryItem
+                hit={item}
+                active={
+                  state.context.lastActiveItemId === item.__autocomplete_id
+                }
+              />
+            );
           },
         },
       },
@@ -58,14 +66,15 @@ export const categoriesPlugin: AutocompletePlugin<CategoryHit, {}> = {
 
 type CategoryItemProps = {
   hit: CategoryHit;
+  active: boolean;
 };
 
-function CategoryItem({ hit }: CategoryItemProps) {
+function CategoryItem({ hit, active }: CategoryItemProps) {
   const breadcrumbCategories = hit.list_categories.slice(0, -1);
   const category = hit.list_categories[hit.list_categories.length - 1];
 
   return (
-    <div className="aa-ItemWrapper aa-CategoryItem">
+    <div className={cx('aa-ItemWrapper aa-CategoryItem')} data-active={active}>
       <div className="aa-ItemContent">
         <div className="aa-ItemIcon aa-ItemIcon--noBorder">
           <GridIcon />

--- a/examples/two-column-layout/src/plugins/categoriesPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/categoriesPlugin.tsx
@@ -1,5 +1,6 @@
 /** @jsx h */
 import {
+  AutocompleteComponents,
   AutocompletePlugin,
   getAlgoliaResults,
 } from '@algolia/autocomplete-js';
@@ -48,10 +49,11 @@ export const categoriesPlugin: AutocompletePlugin<CategoryHit, {}> = {
           });
         },
         templates: {
-          item({ item, state }) {
+          item({ item, components, state }) {
             return (
               <CategoryItem
                 hit={item}
+                components={components}
                 active={
                   state.context.lastActiveItemId === item.__autocomplete_id
                 }
@@ -66,13 +68,11 @@ export const categoriesPlugin: AutocompletePlugin<CategoryHit, {}> = {
 
 type CategoryItemProps = {
   hit: CategoryHit;
+  components: AutocompleteComponents;
   active: boolean;
 };
 
-function CategoryItem({ hit, active }: CategoryItemProps) {
-  const breadcrumbCategories = hit.list_categories.slice(0, -1);
-  const category = hit.list_categories[hit.list_categories.length - 1];
-
+function CategoryItem({ hit, components, active }: CategoryItemProps) {
   return (
     <div className={cx('aa-ItemWrapper aa-CategoryItem')} data-active={active}>
       <div className="aa-ItemContent">
@@ -80,10 +80,26 @@ function CategoryItem({ hit, active }: CategoryItemProps) {
           <GridIcon />
         </div>
         <div className="aa-ItemContentBody">
-          <div className="aa-ItemContentTitle">{category}</div>
+          <div className="aa-ItemContentTitle">
+            <components.ReverseHighlight
+              hit={hit}
+              attribute={[
+                'list_categories',
+                `${hit.list_categories.length - 1}`,
+              ]}
+            />
+          </div>
         </div>
       </div>
-      <Breadcrumb items={breadcrumbCategories} />
+      <Breadcrumb
+        items={hit.list_categories.slice(0, -1).map((_, index) => (
+          <components.ReverseHighlight
+            key={index}
+            hit={hit}
+            attribute={['list_categories', `${index}`]}
+          />
+        ))}
+      />
     </div>
   );
 }

--- a/examples/two-column-layout/src/plugins/faqPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/faqPlugin.tsx
@@ -8,8 +8,8 @@ import { h } from 'preact';
 
 import { Breadcrumb, InfoIcon } from '../components';
 import { ALGOLIA_FAQ_INDEX_NAME } from '../constants';
-import { setSmartPreview } from '../functions';
 import { searchClient } from '../searchClient';
+import { setSmartPreview } from '../setSmartPreview';
 import { FaqHit } from '../types';
 
 export const faqPlugin: AutocompletePlugin<FaqHit, {}> = {
@@ -56,7 +56,7 @@ type FaqItemProps = {
   components: AutocompleteComponents;
 };
 
-const FaqItem = ({ hit, components }: FaqItemProps) => {
+function FaqItem({ hit, components }: FaqItemProps) {
   const breadcrumbItems = hit.list_categories;
 
   return (
@@ -74,4 +74,4 @@ const FaqItem = ({ hit, components }: FaqItemProps) => {
       <Breadcrumb items={breadcrumbItems} />
     </div>
   );
-};
+}

--- a/examples/two-column-layout/src/plugins/faqPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/faqPlugin.tsx
@@ -66,8 +66,6 @@ type FaqItemProps = {
 };
 
 function FaqItem({ hit, components, active }: FaqItemProps) {
-  const breadcrumbItems = hit.list_categories;
-
   return (
     <div className="aa-ItemWrapper aa-FaqItem" data-active={active}>
       <div className="aa-ItemContent">
@@ -80,7 +78,15 @@ function FaqItem({ hit, components, active }: FaqItemProps) {
           </div>
         </div>
       </div>
-      <Breadcrumb items={breadcrumbItems} />
+      <Breadcrumb
+        items={hit.list_categories.map((_, index) => (
+          <components.ReverseHighlight
+            key={index}
+            hit={hit}
+            attribute={['list_categories', `${index}`]}
+          />
+        ))}
+      />
     </div>
   );
 }

--- a/examples/two-column-layout/src/plugins/faqPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/faqPlugin.tsx
@@ -42,8 +42,16 @@ export const faqPlugin: AutocompletePlugin<FaqHit, {}> = {
           });
         },
         templates: {
-          item({ item, components }) {
-            return <FaqItem hit={item} components={components} />;
+          item({ item, components, state }) {
+            return (
+              <FaqItem
+                hit={item}
+                components={components}
+                active={
+                  state.context.lastActiveItemId === item.__autocomplete_id
+                }
+              />
+            );
           },
         },
       },
@@ -54,13 +62,14 @@ export const faqPlugin: AutocompletePlugin<FaqHit, {}> = {
 type FaqItemProps = {
   hit: FaqHit;
   components: AutocompleteComponents;
+  active: boolean;
 };
 
-function FaqItem({ hit, components }: FaqItemProps) {
+function FaqItem({ hit, components, active }: FaqItemProps) {
   const breadcrumbItems = hit.list_categories;
 
   return (
-    <div className="aa-ItemWrapper aa-FaqItem">
+    <div className="aa-ItemWrapper aa-FaqItem" data-active={active}>
       <div className="aa-ItemContent">
         <div className="aa-ItemIcon aa-ItemIcon--noBorder">
           <InfoIcon />

--- a/examples/two-column-layout/src/plugins/popularCategoriesPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/popularCategoriesPlugin.tsx
@@ -11,17 +11,17 @@ import { searchClient } from '../searchClient';
 import { PopularCategoryHit } from '../types';
 
 const images = {
-  women:
+  Women:
     'https://res.cloudinary.com/hilnmyskv/image/upload/v1646067858/women_category_vwzkln.jpg',
-  bags:
+  Bags:
     'https://res.cloudinary.com/hilnmyskv/image/upload/v1646067858/bags_category_qd7ssj.jpg',
-  clothing:
+  Clothing:
     'https://res.cloudinary.com/hilnmyskv/image/upload/v1646067858/clothing_category_xhiz1s.jpg',
-  men:
+  Men:
     'https://res.cloudinary.com/hilnmyskv/image/upload/v1646067858/men_category_wfcley.jpg',
-  't-shirts':
+  'T-shirts':
     'https://res.cloudinary.com/hilnmyskv/image/upload/v1646067858/t-shirts_category_gzqcvd.jpg',
-  shoes:
+  Shoes:
     'https://res.cloudinary.com/hilnmyskv/image/upload/v1646068349/shoes_category_u4fi0q.jpg',
 };
 
@@ -82,7 +82,7 @@ const CategoryItem = ({ hit }: CategoryItemProps) => {
     <div className="aa-ItemWrapper aa-PopularCategoryItem">
       <div className="aa-ItemContent">
         <div className="aa-ItemPicture">
-          <img src={images[hit.label.toLowerCase()]} alt={hit.label} />
+          <img src={images[hit.label]} alt={hit.label} />
         </div>
         <div className="aa-ItemContentBody">
           <div className="aa-ItemContentTitle">

--- a/examples/two-column-layout/src/plugins/popularCategoriesPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/popularCategoriesPlugin.tsx
@@ -10,19 +10,14 @@ import { ALGOLIA_PRODUCTS_INDEX_NAME } from '../constants';
 import { searchClient } from '../searchClient';
 import { PopularCategoryHit } from '../types';
 
+const baseUrl = 'https://res.cloudinary.com/hilnmyskv/image/upload/v1646067858';
 const images = {
-  Women:
-    'https://res.cloudinary.com/hilnmyskv/image/upload/v1646067858/women_category_vwzkln.jpg',
-  Bags:
-    'https://res.cloudinary.com/hilnmyskv/image/upload/v1646067858/bags_category_qd7ssj.jpg',
-  Clothing:
-    'https://res.cloudinary.com/hilnmyskv/image/upload/v1646067858/clothing_category_xhiz1s.jpg',
-  Men:
-    'https://res.cloudinary.com/hilnmyskv/image/upload/v1646067858/men_category_wfcley.jpg',
-  'T-shirts':
-    'https://res.cloudinary.com/hilnmyskv/image/upload/v1646067858/t-shirts_category_gzqcvd.jpg',
-  Shoes:
-    'https://res.cloudinary.com/hilnmyskv/image/upload/v1646068349/shoes_category_u4fi0q.jpg',
+  Women: `${baseUrl}/women_category_vwzkln.jpg`,
+  Bags: `${baseUrl}/bags_category_qd7ssj.jpg`,
+  Clothing: `${baseUrl}/clothing_category_xhiz1s.jpg`,
+  Men: `${baseUrl}/men_category_wfcley.jpg`,
+  'T-shirts': `${baseUrl}/t-shirts_category_gzqcvd.jpg`,
+  Shoes: `${baseUrl}/shoes_category_u4fi0q.jpg`,
 };
 
 export const popularCategoriesPlugin: AutocompletePlugin<

--- a/examples/two-column-layout/src/plugins/popularCategoriesPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/popularCategoriesPlugin.tsx
@@ -72,7 +72,7 @@ type CategoryItemProps = {
   components: AutocompleteComponents;
 };
 
-const CategoryItem = ({ hit }: CategoryItemProps) => {
+function CategoryItem({ hit }: CategoryItemProps) {
   return (
     <div className="aa-ItemWrapper aa-PopularCategoryItem">
       <div className="aa-ItemContent">
@@ -87,4 +87,4 @@ const CategoryItem = ({ hit }: CategoryItemProps) => {
       </div>
     </div>
   );
-};
+}

--- a/examples/two-column-layout/src/plugins/popularCategoriesPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/popularCategoriesPlugin.tsx
@@ -1,0 +1,95 @@
+/** @jsx h */
+import {
+  AutocompleteComponents,
+  AutocompletePlugin,
+  getAlgoliaFacets,
+} from '@algolia/autocomplete-js';
+import { h } from 'preact';
+
+import { ALGOLIA_PRODUCTS_INDEX_NAME } from '../constants';
+import { searchClient } from '../searchClient';
+import { PopularCategoryHit } from '../types';
+
+const images = {
+  women:
+    'https://res.cloudinary.com/hilnmyskv/image/upload/v1646067858/women_category_vwzkln.jpg',
+  bags:
+    'https://res.cloudinary.com/hilnmyskv/image/upload/v1646067858/bags_category_qd7ssj.jpg',
+  clothing:
+    'https://res.cloudinary.com/hilnmyskv/image/upload/v1646067858/clothing_category_xhiz1s.jpg',
+  men:
+    'https://res.cloudinary.com/hilnmyskv/image/upload/v1646067858/men_category_wfcley.jpg',
+  't-shirts':
+    'https://res.cloudinary.com/hilnmyskv/image/upload/v1646067858/t-shirts_category_gzqcvd.jpg',
+  shoes:
+    'https://res.cloudinary.com/hilnmyskv/image/upload/v1646068349/shoes_category_u4fi0q.jpg',
+};
+
+export const popularCategoriesPlugin: AutocompletePlugin<
+  PopularCategoryHit,
+  {}
+> = {
+  getSources() {
+    return [
+      {
+        sourceId: 'popularCategoriesPlugin',
+        getItems() {
+          return getAlgoliaFacets({
+            searchClient,
+            queries: [
+              {
+                indexName: ALGOLIA_PRODUCTS_INDEX_NAME,
+                facet: 'list_categories',
+                params: {
+                  facetQuery: '',
+                  maxFacetHits: 6,
+                },
+              },
+            ],
+          });
+        },
+        getItemInputValue({ item }) {
+          return item.label;
+        },
+        onSelect({ setIsOpen }) {
+          setIsOpen(true);
+        },
+        templates: {
+          header({ Fragment }) {
+            return (
+              <Fragment>
+                <span className="aa-SourceHeaderTitle">Popular categories</span>
+                <div className="aa-SourceHeaderLine" />
+              </Fragment>
+            );
+          },
+          item({ item, components }) {
+            return <CategoryItem hit={item} components={components} />;
+          },
+        },
+      },
+    ];
+  },
+};
+
+type CategoryItemProps = {
+  hit: PopularCategoryHit;
+  components: AutocompleteComponents;
+};
+
+const CategoryItem = ({ hit }: CategoryItemProps) => {
+  return (
+    <div className="aa-ItemWrapper aa-PopularCategoryItem">
+      <div className="aa-ItemContent">
+        <div className="aa-ItemPicture">
+          <img src={images[hit.label.toLowerCase()]} alt={hit.label} />
+        </div>
+        <div className="aa-ItemContentBody">
+          <div className="aa-ItemContentTitle">
+            {hit.label} <span>({hit.count})</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/examples/two-column-layout/src/plugins/popularPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/popularPlugin.tsx
@@ -13,7 +13,7 @@ export const popularPlugin = createQuerySuggestionsPlugin({
   getSearchParams() {
     return {
       query: '',
-      hitsPerPage: 8,
+      hitsPerPage: 6,
     };
   },
   transformSource({ source }) {
@@ -47,7 +47,7 @@ type PopularItemProps = {
   hit: PopularHit;
 };
 
-const PopularItem = ({ hit }: PopularItemProps) => {
+function PopularItem({ hit }: PopularItemProps) {
   return (
     <div className="aa-ItemWrapper">
       <div className="aa-ItemIcon aa-ItemIcon--noBorder">
@@ -60,4 +60,4 @@ const PopularItem = ({ hit }: PopularItemProps) => {
       </div>
     </div>
   );
-};
+}

--- a/examples/two-column-layout/src/plugins/popularPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/popularPlugin.tsx
@@ -13,7 +13,7 @@ export const popularPlugin = createQuerySuggestionsPlugin({
   getSearchParams() {
     return {
       query: '',
-      hitsPerPage: 7,
+      hitsPerPage: 8,
     };
   },
   transformSource({ source }) {

--- a/examples/two-column-layout/src/plugins/productsPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/productsPlugin.tsx
@@ -1,8 +1,10 @@
 /** @jsx h */
 import {
+  AutocompleteComponents,
   AutocompletePlugin,
   getAlgoliaResults,
 } from '@algolia/autocomplete-js';
+import { SearchResponse } from '@algolia/client-search';
 import { h } from 'preact';
 import { useState } from 'preact/hooks';
 
@@ -27,7 +29,7 @@ export const productsPlugin: AutocompletePlugin<ProductHit, {}> = {
     return [
       {
         sourceId: 'productsPlugin',
-        getItems({ state }) {
+        getItems({ state, setContext }) {
           const preview = state.context.preview as ProductsPluginContext;
 
           const facetFilters = [];
@@ -41,34 +43,44 @@ export const productsPlugin: AutocompletePlugin<ProductHit, {}> = {
             queries: [
               {
                 indexName: ALGOLIA_PRODUCTS_INDEX_NAME,
-                query: preview?.query ?? query,
+                query: preview?.query || query,
                 params: {
                   hitsPerPage: 4,
                   facetFilters,
                 },
               },
             ],
+            transformResponse({ hits, results }) {
+              setContext({
+                nbHits: (results[0] as SearchResponse<ProductHit>).nbHits,
+              });
+
+              return hits;
+            },
           });
         },
         onSelect({ setIsOpen }) {
           setIsOpen(true);
         },
         templates: {
-          header({ state }) {
+          header({ state, Fragment }) {
             const preview = state.context.preview as ProductsPluginContext;
 
             return (
-              <div className="aa-SourceHeaderTitle">
-                Products {preview?.facetValue ? 'in' : 'for'} "
-                {preview?.query || preview?.facetValue || state.query}"{' '}
-                {preview?.facetName === 'list_categories'
-                  ? 'category'
-                  : preview?.facetName}
-              </div>
+              <Fragment>
+                <div className="aa-SourceHeaderTitle">
+                  Products {preview?.facetValue ? 'in' : 'for'} "
+                  {preview?.query || preview?.facetValue || state.query}"{' '}
+                  {preview?.facetName === 'list_categories'
+                    ? 'category'
+                    : preview?.facetName}
+                </div>
+                <div className="aa-SourceHeaderLine" />
+              </Fragment>
             );
           },
-          item({ item }) {
-            return <ProductItem hit={item} />;
+          item({ item, components }) {
+            return <ProductItem hit={item} components={components} />;
           },
         },
       },
@@ -82,14 +94,20 @@ function formatPrice(value: number, currency = 'EUR') {
 
 type ProductItemProps = {
   hit: ProductHit;
+  components: AutocompleteComponents;
 };
 
-function ProductItem({ hit }: ProductItemProps) {
+function ProductItem({ hit, components }: ProductItemProps) {
   const [loaded, setLoaded] = useState(false);
   const [favorite, setFavorite] = useState(false);
 
   return (
-    <a href="#" className="aa-ItemLink aa-ProductItem">
+    <a
+      href="https://example.org/"
+      target="_blank"
+      rel="noreferrer noopener"
+      className="aa-ItemLink aa-ProductItem"
+    >
       <div className="aa-ItemContent">
         <div
           className={cx('aa-ItemPicture', loaded && 'aa-ItemPicture--loaded')}
@@ -114,7 +132,11 @@ function ProductItem({ hit }: ProductItemProps) {
             {hit.brand && (
               <div className="aa-ItemContentBrand">{hit.brand}</div>
             )}
-            <div className="aa-ItemContentTitle">{hit.name}</div>
+            <div className="aa-ItemContentTitleWrapper">
+              <div className="aa-ItemContentTitle">
+                <components.Highlight hit={hit} attribute="name" />
+              </div>
+            </div>
           </div>
           <div>
             <div className="aa-ItemContentPrice">

--- a/examples/two-column-layout/src/plugins/productsPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/productsPlugin.tsx
@@ -52,7 +52,7 @@ export const productsPlugin: AutocompletePlugin<ProductHit, {}> = {
             ],
             transformResponse({ hits, results }) {
               setContext({
-                nbHits: (results[0] as SearchResponse<ProductHit>).nbHits,
+                nbProducts: (results[0] as SearchResponse<ProductHit>).nbHits,
               });
 
               return hits;
@@ -81,6 +81,24 @@ export const productsPlugin: AutocompletePlugin<ProductHit, {}> = {
           },
           item({ item, components }) {
             return <ProductItem hit={item} components={components} />;
+          },
+          footer({ state }) {
+            return (
+              state.context.nbProducts > 4 && (
+                <div style={{ textAlign: 'center' }}>
+                  <a
+                    href="https://example.org/"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="aa-SeeAllBtn"
+                  >
+                    See All Products{' '}
+                    {state.context.nbProducts &&
+                      `(${state.context.nbProducts})`}
+                  </a>
+                </div>
+              )
+            );
           },
         },
       },
@@ -130,7 +148,9 @@ function ProductItem({ hit, components }: ProductItemProps) {
         <div className="aa-ItemContentBody">
           <div>
             {hit.brand && (
-              <div className="aa-ItemContentBrand">{hit.brand}</div>
+              <div className="aa-ItemContentBrand">
+                <components.Highlight hit={hit} attribute="brand" />
+              </div>
             )}
             <div className="aa-ItemContentTitleWrapper">
               <div className="aa-ItemContentTitle">

--- a/examples/two-column-layout/src/plugins/querySuggestionsPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/querySuggestionsPlugin.tsx
@@ -2,15 +2,15 @@
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
 
 import { ALGOLIA_PRODUCTS_QUERY_SUGGESTIONS_INDEX_NAME } from '../constants';
-import { setSmartPreview } from '../functions';
 import { searchClient } from '../searchClient';
+import { setSmartPreview } from '../setSmartPreview';
 
 export const querySuggestionsPlugin = createQuerySuggestionsPlugin({
   searchClient,
   indexName: ALGOLIA_PRODUCTS_QUERY_SUGGESTIONS_INDEX_NAME,
   getSearchParams({ state }) {
     return {
-      hitsPerPage: !state.query ? 0 : 8,
+      hitsPerPage: !state.query ? 0 : 20,
     };
   },
   transformSource({ source }) {

--- a/examples/two-column-layout/src/plugins/querySuggestionsPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/querySuggestionsPlugin.tsx
@@ -1,9 +1,11 @@
 /** @jsx h */
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
+import { h } from 'preact';
 
 import { ALGOLIA_PRODUCTS_QUERY_SUGGESTIONS_INDEX_NAME } from '../constants';
 import { searchClient } from '../searchClient';
 import { setSmartPreview } from '../setSmartPreview';
+import { QuerySuggestionsHit } from '../types';
 
 export const querySuggestionsPlugin = createQuerySuggestionsPlugin({
   searchClient,
@@ -13,7 +15,7 @@ export const querySuggestionsPlugin = createQuerySuggestionsPlugin({
       hitsPerPage: !state.query ? 0 : 20,
     };
   },
-  transformSource({ source }) {
+  transformSource({ source, onTapAhead }) {
     return {
       ...source,
       onActive(params) {
@@ -23,6 +25,72 @@ export const querySuggestionsPlugin = createQuerySuggestionsPlugin({
           },
           ...params,
         });
+      },
+      templates: {
+        ...source.templates,
+        item({ item, components, state }) {
+          if (item.__autocomplete_qsCategory) {
+            return (
+              <div
+                className="aa-ItemWrapper"
+                data-active={
+                  state.context.lastActiveItemId ===
+                  (item as QuerySuggestionsHit).__autocomplete_id
+                }
+              >
+                <div className="aa-ItemContent aa-ItemContent--indented">
+                  <div className="aa-ItemContentSubtitle aa-ItemContentSubtitle--standalone">
+                    <span className="aa-ItemContentSubtitleIcon" />
+                    <span>
+                      in{' '}
+                      <span className="aa-ItemContentSubtitleCategory">
+                        {item.__autocomplete_qsCategory}
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            );
+          }
+
+          return (
+            <div
+              className="aa-ItemWrapper"
+              data-active={
+                state.context.lastActiveItemId ===
+                (item as QuerySuggestionsHit).__autocomplete_id
+              }
+            >
+              <div className="aa-ItemContent">
+                <div className="aa-ItemIcon aa-ItemIcon--noBorder">
+                  <svg viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M16.041 15.856c-0.034 0.026-0.067 0.055-0.099 0.087s-0.060 0.064-0.087 0.099c-1.258 1.213-2.969 1.958-4.855 1.958-1.933 0-3.682-0.782-4.95-2.050s-2.050-3.017-2.050-4.95 0.782-3.682 2.050-4.95 3.017-2.050 4.95-2.050 3.682 0.782 4.95 2.050 2.050 3.017 2.050 4.95c0 1.886-0.745 3.597-1.959 4.856zM21.707 20.293l-3.675-3.675c1.231-1.54 1.968-3.493 1.968-5.618 0-2.485-1.008-4.736-2.636-6.364s-3.879-2.636-6.364-2.636-4.736 1.008-6.364 2.636-2.636 3.879-2.636 6.364 1.008 4.736 2.636 6.364 3.879 2.636 6.364 2.636c2.125 0 4.078-0.737 5.618-1.968l3.675 3.675c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414z" />
+                  </svg>
+                </div>
+                <div className="aa-ItemContentBody">
+                  <div className="aa-ItemContentTitle">
+                    <components.ReverseHighlight hit={item} attribute="query" />
+                  </div>
+                </div>
+              </div>
+              <div className="aa-ItemActions">
+                <button
+                  className="aa-ItemActionButton"
+                  title={`Fill query with "${item.query}"`}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onTapAhead(item);
+                  }}
+                >
+                  <svg viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M8 17v-7.586l8.293 8.293c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-8.293-8.293h7.586c0.552 0 1-0.448 1-1s-0.448-1-1-1h-10c-0.552 0-1 0.448-1 1v10c0 0.552 0.448 1 1 1s1-0.448 1-1z" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          );
+        },
       },
     };
   },

--- a/examples/two-column-layout/src/plugins/quickAccessPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/quickAccessPlugin.tsx
@@ -62,7 +62,7 @@ type QuickAccessItemProps = {
   hit: QuickAccessHit;
 };
 
-const QuickAccessItem = ({ hit }: QuickAccessItemProps) => {
+function QuickAccessItem({ hit }: QuickAccessItemProps) {
   return (
     <a
       href={hit.href}
@@ -102,4 +102,4 @@ const QuickAccessItem = ({ hit }: QuickAccessItemProps) => {
       </div>
     </a>
   );
-};
+}

--- a/examples/two-column-layout/src/plugins/recentSearchesPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/recentSearchesPlugin.tsx
@@ -3,7 +3,6 @@ import {
   createLocalStorageRecentSearchesPlugin,
   search,
 } from '@algolia/autocomplete-plugin-recent-searches';
-import { h } from 'preact';
 
 import { setSmartPreview } from '../setSmartPreview';
 

--- a/examples/two-column-layout/src/plugins/recentSearchesPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/recentSearchesPlugin.tsx
@@ -5,7 +5,7 @@ import {
 } from '@algolia/autocomplete-plugin-recent-searches';
 import { h } from 'preact';
 
-import { setSmartPreview } from '../functions';
+import { setSmartPreview } from '../setSmartPreview';
 
 export const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
   key: 'autocomplete-two-column-layout-example',
@@ -27,19 +27,6 @@ export const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
           },
           ...params,
         });
-      },
-      templates: {
-        ...source.templates,
-        header({ state, Fragment }) {
-          return (
-            <Fragment>
-              <span className="aa-SourceHeaderTitle">
-                {state.query ? 'Suggestions' : 'Recent searches'}
-              </span>
-              <div className="aa-SourceHeaderLine" />
-            </Fragment>
-          );
-        },
       },
     };
   },

--- a/examples/two-column-layout/src/plugins/recentSearchesPlugin.tsx
+++ b/examples/two-column-layout/src/plugins/recentSearchesPlugin.tsx
@@ -3,8 +3,10 @@ import {
   createLocalStorageRecentSearchesPlugin,
   search,
 } from '@algolia/autocomplete-plugin-recent-searches';
+import { h } from 'preact';
 
 import { setSmartPreview } from '../setSmartPreview';
+import { RecentSearchesHit } from '../types';
 
 export const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
   key: 'autocomplete-two-column-layout-example',
@@ -12,7 +14,7 @@ export const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
     const limit = params.query ? 1 : 4;
     return search({ ...params, limit });
   },
-  transformSource({ source }) {
+  transformSource({ source, onRemove, onTapAhead }) {
     return {
       ...source,
       onActive(params) {
@@ -26,6 +28,69 @@ export const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
           },
           ...params,
         });
+      },
+      templates: {
+        ...source.templates,
+        item({ item, components, state }) {
+          return (
+            <div
+              className="aa-ItemWrapper"
+              data-active={
+                state.context.lastActiveItemId ===
+                (item as RecentSearchesHit).__autocomplete_id
+              }
+            >
+              <div className="aa-ItemContent">
+                <div className="aa-ItemIcon aa-ItemIcon--noBorder">
+                  <svg viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M12.516 6.984v5.25l4.5 2.672-0.75 1.266-5.25-3.188v-6h1.5zM12 20.016q3.281 0 5.648-2.367t2.367-5.648-2.367-5.648-5.648-2.367-5.648 2.367-2.367 5.648 2.367 5.648 5.648 2.367zM12 2.016q4.125 0 7.055 2.93t2.93 7.055-2.93 7.055-7.055 2.93-7.055-2.93-2.93-7.055 2.93-7.055 7.055-2.93z" />
+                  </svg>
+                </div>
+                <div className="aa-ItemContentBody">
+                  <div className="aa-ItemContentTitle">
+                    <components.ReverseHighlight hit={item} attribute="label" />
+                    {item.category && (
+                      <span className="aa-ItemContentSubtitle aa-ItemContentSubtitle--inline">
+                        <span className="aa-ItemContentSubtitleIcon" /> in{' '}
+                        <span className="aa-ItemContentSubtitleCategory">
+                          {item.category}
+                        </span>
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+              <div className="aa-ItemActions">
+                <button
+                  className="aa-ItemActionButton"
+                  title="Remove this search"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onRemove(item.id);
+                  }}
+                >
+                  <svg viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M18 7v13c0 0.276-0.111 0.525-0.293 0.707s-0.431 0.293-0.707 0.293h-10c-0.276 0-0.525-0.111-0.707-0.293s-0.293-0.431-0.293-0.707v-13zM17 5v-1c0-0.828-0.337-1.58-0.879-2.121s-1.293-0.879-2.121-0.879h-4c-0.828 0-1.58 0.337-2.121 0.879s-0.879 1.293-0.879 2.121v1h-4c-0.552 0-1 0.448-1 1s0.448 1 1 1h1v13c0 0.828 0.337 1.58 0.879 2.121s1.293 0.879 2.121 0.879h10c0.828 0 1.58-0.337 2.121-0.879s0.879-1.293 0.879-2.121v-13h1c0.552 0 1-0.448 1-1s-0.448-1-1-1zM9 5v-1c0-0.276 0.111-0.525 0.293-0.707s0.431-0.293 0.707-0.293h4c0.276 0 0.525 0.111 0.707 0.293s0.293 0.431 0.293 0.707v1zM9 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1zM13 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1z" />
+                  </svg>
+                </button>
+                <button
+                  className="aa-ItemActionButton"
+                  title={`Fill query with "${item.label}"`}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onTapAhead(item);
+                  }}
+                >
+                  <svg viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M8 17v-7.586l8.293 8.293c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-8.293-8.293h7.586c0.552 0 1-0.448 1-1s-0.448-1-1-1h-10c-0.552 0-1 0.448-1 1v10c0 0.552 0.448 1 1 1s1-0.448 1-1z" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          );
+        },
       },
     };
   },

--- a/examples/two-column-layout/src/setSmartPreview.ts
+++ b/examples/two-column-layout/src/setSmartPreview.ts
@@ -5,7 +5,7 @@ import {
 } from '@algolia/autocomplete-core';
 import { dequal } from 'dequal/lite';
 
-import { isTouchDevice } from '../utils';
+import { isTouchDevice } from './utils';
 
 type smartPreviewParams<
   TItem extends BaseItem
@@ -16,7 +16,7 @@ type smartPreviewParams<
   };
 };
 
-export const updateActiveItem = (activeItemId: number) => {
+export function updateActiveItem(activeItemId: number) {
   const currentActiveEl = document.querySelector('[data-active=true]');
   currentActiveEl?.removeAttribute('data-active');
 
@@ -24,15 +24,15 @@ export const updateActiveItem = (activeItemId: number) => {
     `#autocomplete-0-item-${activeItemId}`
   );
   selectedEl?.setAttribute('data-active', 'true');
-};
+}
 
-export const setSmartPreview = <TItem extends BaseItem>({
+export function setSmartPreview<TItem extends BaseItem>({
   state,
   setContext,
   refresh,
   preview,
   setActiveItemId,
-}: smartPreviewParams<TItem>) => {
+}: smartPreviewParams<TItem>) {
   if (!dequal(state.context.preview, preview) && !isTouchDevice()) {
     setContext({ preview });
 
@@ -40,4 +40,4 @@ export const setSmartPreview = <TItem extends BaseItem>({
     setActiveItemId(state.activeItemId);
     updateActiveItem(state.activeItemId);
   }
-};
+}

--- a/examples/two-column-layout/src/setSmartPreview.ts
+++ b/examples/two-column-layout/src/setSmartPreview.ts
@@ -16,28 +16,14 @@ type smartPreviewParams<
   };
 };
 
-export function updateActiveItem(activeItemId: number) {
-  const currentActiveEl = document.querySelector('[data-active=true]');
-  currentActiveEl?.removeAttribute('data-active');
-
-  const selectedEl = document.querySelector(
-    `#autocomplete-0-item-${activeItemId}`
-  );
-  selectedEl?.setAttribute('data-active', 'true');
-}
-
 export function setSmartPreview<TItem extends BaseItem>({
   state,
   setContext,
   refresh,
   preview,
-  setActiveItemId,
 }: smartPreviewParams<TItem>) {
   if (!dequal(state.context.preview, preview) && !isTouchDevice()) {
-    setContext({ preview });
-
+    setContext({ preview, lastActiveItemId: state.activeItemId });
     refresh();
-    setActiveItemId(state.activeItemId);
-    updateActiveItem(state.activeItemId);
   }
 }

--- a/examples/two-column-layout/src/types/AutocompleteHit.ts
+++ b/examples/two-column-layout/src/types/AutocompleteHit.ts
@@ -1,0 +1,7 @@
+import { Hit } from '@algolia/client-search';
+
+export type AutocompleteHit<THit> = Hit<
+  THit & {
+    __autocomplete_id: number;
+  }
+>;

--- a/examples/two-column-layout/src/types/BrandHit.ts
+++ b/examples/two-column-layout/src/types/BrandHit.ts
@@ -1,8 +1,8 @@
-import { Hit } from '@algolia/client-search';
+import { AutocompleteHit } from './AutocompleteHit';
 
 type BrandRecord = {
   label: string;
   count: number;
 };
 
-export type BrandHit = Hit<BrandRecord>;
+export type BrandHit = AutocompleteHit<BrandRecord>;

--- a/examples/two-column-layout/src/types/CategoryHit.ts
+++ b/examples/two-column-layout/src/types/CategoryHit.ts
@@ -1,7 +1,7 @@
-import { Hit } from '@algolia/client-search';
+import { AutocompleteHit } from './AutocompleteHit';
 
 type CategoryRecord = {
   list_categories: string[];
 };
 
-export type CategoryHit = Hit<CategoryRecord>;
+export type CategoryHit = AutocompleteHit<CategoryRecord>;

--- a/examples/two-column-layout/src/types/FaqHit.ts
+++ b/examples/two-column-layout/src/types/FaqHit.ts
@@ -1,4 +1,4 @@
-import { Hit } from '@algolia/client-search';
+import { AutocompleteHit } from './AutocompleteHit';
 
 type FaqRecord = {
   list_categories: string[];
@@ -6,4 +6,4 @@ type FaqRecord = {
   description: string;
 };
 
-export type FaqHit = Hit<FaqRecord>;
+export type FaqHit = AutocompleteHit<FaqRecord>;

--- a/examples/two-column-layout/src/types/PopularCategoryHit.ts
+++ b/examples/two-column-layout/src/types/PopularCategoryHit.ts
@@ -1,0 +1,8 @@
+import { Hit } from '@algolia/client-search';
+
+type PopularCategoryRecord = {
+  label: string;
+  count: number;
+};
+
+export type PopularCategoryHit = Hit<PopularCategoryRecord>;

--- a/examples/two-column-layout/src/types/QuerySuggestionsHit.ts
+++ b/examples/two-column-layout/src/types/QuerySuggestionsHit.ts
@@ -1,0 +1,5 @@
+import { AutocompleteQuerySuggestionsHit } from '@algolia/autocomplete-plugin-query-suggestions/dist/esm/types';
+
+import { AutocompleteHit } from './AutocompleteHit';
+
+export type QuerySuggestionsHit = AutocompleteHit<AutocompleteQuerySuggestionsHit>;

--- a/examples/two-column-layout/src/types/RecentSearchesHit.ts
+++ b/examples/two-column-layout/src/types/RecentSearchesHit.ts
@@ -1,0 +1,5 @@
+import { RecentSearchesItem } from '@algolia/autocomplete-plugin-recent-searches/dist/esm/types';
+
+import { AutocompleteHit } from './AutocompleteHit';
+
+export type RecentSearchesHit = AutocompleteHit<RecentSearchesItem>;

--- a/examples/two-column-layout/src/types/index.ts
+++ b/examples/two-column-layout/src/types/index.ts
@@ -5,3 +5,4 @@ export * from './FaqHit';
 export * from './ArticleHit';
 export * from './PopularHit';
 export * from './QuickAccessHit';
+export * from './PopularCategoryHit';

--- a/examples/two-column-layout/src/types/index.ts
+++ b/examples/two-column-layout/src/types/index.ts
@@ -6,3 +6,5 @@ export * from './ArticleHit';
 export * from './PopularHit';
 export * from './QuickAccessHit';
 export * from './PopularCategoryHit';
+export * from './RecentSearchesHit';
+export * from './QuerySuggestionsHit';

--- a/examples/two-column-layout/src/utils/index.ts
+++ b/examples/two-column-layout/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './cx';
 export * from './intersperse';
 export * from './isTouchDevice';
+export * from './isDetached';

--- a/examples/two-column-layout/src/utils/isDetached.ts
+++ b/examples/two-column-layout/src/utils/isDetached.ts
@@ -1,0 +1,7 @@
+export function isDetached() {
+  return window.matchMedia(
+    getComputedStyle(document.documentElement).getPropertyValue(
+      '--aa-detached-media-query'
+    )
+  ).matches;
+}

--- a/examples/two-column-layout/style.css
+++ b/examples/two-column-layout/style.css
@@ -515,6 +515,52 @@ body {
   margin-top: var(--aa-spacing-half);
 }
 
+/* Popular categories */
+.aa-PanelSection--popularCategories .aa-List {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: var(--aa-spacing-half);
+  font-size: 0.9em;
+}
+
+.aa-PanelSection--popularCategories .aa-SourceHeader {
+  margin-top: 0;
+}
+
+.aa-PopularCategoryItem .aa-ItemPicture {
+  width: 72px;
+}
+
+.aa-PopularCategoryItem .aa-ItemContentTitle {
+  margin-right: 0;
+}
+
+.aa-PopularCategoryItem .aa-ItemContentTitle span {
+  font-size: 0.8em;
+  color: rgb(var(--aa-muted-color-rgb));
+}
+
+/* No results */
+.aa-NoResultsQuery {
+  font-size: 1.15em;
+  font-weight: bold;
+  margin: var(--aa-spacing) 0 calc(var(--aa-spacing) * 2) 0;
+}
+
+.aa-NoResultsAdvicesTitle {
+  font-weight: bold;
+}
+
+.aa-NoResultsAdvicesList {
+  font-size: 0.9em;
+  padding: 0;
+  margin-left: calc(var(--aa-spacing) * 1.5);
+  margin-bottom: 0;
+  display: flex;
+  flex-direction: column;
+  row-gap: calc(var(--aa-spacing-half) * 0.5);
+}
+
 /* Media queries */
 @media screen and (prefers-reduced-motion: reduce) {
   .aa-Item,
@@ -600,6 +646,22 @@ body {
 
   .aa-PanelSection--quickAccess .aa-Item:nth-child(3) {
     display: block;
+  }
+
+  /* Popular categories */
+  .aa-PanelSection--popularCategories .aa-List {
+    display: flex;
+    overflow: auto;
+    scroll-snap-type: x;
+  }
+
+  .aa-PanelSection--popularCategories .aa-Item {
+    scroll-snap-align: start;
+  }
+
+  .aa-PanelSection--popularCategories .aa-ItemContent,
+  .aa-PanelSection--popularCategories .aa-ItemContentTitle {
+    overflow: visible;
   }
 }
 

--- a/examples/two-column-layout/style.css
+++ b/examples/two-column-layout/style.css
@@ -15,28 +15,28 @@ body {
 
 .container {
   margin: 0 auto;
-  max-width: 1280px;
+  max-width: 1024px;
   width: 100%;
 }
 
-/* Blurhash */
-.aa-BlurhashCanvas {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
+/* Panel */
+.aa-Panel--scrollable {
+  --aa-panel-max-height: 660px;
+}
+
+.aa-Panel .aa-SourceHeader {
+  margin: var(--aa-spacing-half) 0 var(--aa-spacing-half) 0;
 }
 
 /* Panel section */
 .aa-PanelSections {
-  column-gap: var(--aa-spacing-half);
+  column-gap: var(--aa-spacing);
   display: flex;
 }
 
 .aa-PanelSection--left {
   display: flex;
   flex-direction: column;
-  row-gap: var(--aa-spacing);
   width: 30%;
 }
 
@@ -46,7 +46,6 @@ body {
 
 .aa-PanelSection--left .aa-ItemWrapper {
   height: 100%;
-  padding: calc(var(--aa-spacing-half) / 2);
 }
 
 .aa-PanelSection--right {
@@ -56,9 +55,9 @@ body {
   width: 70%;
 }
 
-/* Add padding on each source for the smart preview background color on products */
-.aa-PanelSection--right > * {
-  padding: 0 var(--aa-spacing-half);
+.aa-PanelSectionSources {
+  display: grid;
+  row-gap: var(--aa-spacing);
 }
 
 /* Item */
@@ -79,7 +78,7 @@ body {
 
 .aa-ItemPicture {
   width: 100%;
-  border-radius: 3px;
+  border-radius: calc(var(--aa-spacing-half) / 2);
   overflow: hidden;
 }
 
@@ -126,36 +125,32 @@ body {
 }
 
 /* Products */
-.aa-PanelSection--products,
-.aa-PanelSection--products .aa-SourceHeaderTitle {
+.aa-PanelSection--products {
   transition: background 0.2s ease-out;
 }
 
-.aa-PanelSection--products {
-  padding-bottom: var(--aa-spacing-half);
-}
-
-.aa-PanelSection--products-preview {
+.aa-PanelSection--products-preview .aa-List {
   background: rgba(
     var(--aa-selected-color-rgb),
     var(--aa-selected-color-alpha)
   );
-  border-radius: 3px;
+  border-radius: calc(var(--aa-spacing-half) / 2);
 }
 
-.aa-PanelSection--products-preview .aa-SourceHeaderTitle {
-  background: #efeef6;
+.aa-PanelSection--products-preview .aa-Item[aria-selected='true'] {
+  background: none;
 }
 
 .aa-PanelSection--products .aa-List {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: var(--aa-spacing);
+  padding: var(--aa-spacing-half);
 }
 
 .aa-PanelSection--products .aa-Item {
   align-items: flex-start;
   width: 100%;
+  padding: var(--aa-spacing-half);
 }
 
 .aa-PanelSection--products .aa-Item:hover .aa-ItemFavorite {
@@ -191,7 +186,7 @@ body {
   flex-grow: 1;
   flex-direction: column;
   justify-content: space-between;
-  min-height: 112px;
+  gap: var(--aa-spacing-half);
 }
 
 .aa-ProductItem .aa-ItemPicture--blurred {
@@ -218,12 +213,22 @@ body {
   font-size: 0.7em;
   text-transform: uppercase;
   color: rgb(var(--aa-muted-color-rgb));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.aa-ProductItem .aa-ItemContentTitleWrapper {
+  height: calc(var(--aa-spacing) * 2.5);
 }
 
 .aa-ProductItem .aa-ItemContentTitle {
-  white-space: normal;
   font-size: 0.9em;
   margin: 0;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  white-space: normal;
 }
 
 .aa-ProductItem .aa-ItemContentPriceCurrent {
@@ -272,10 +277,10 @@ body {
 .aa-ProductItem .aa-ItemFavorite {
   z-index: 5;
   position: absolute;
-  right: 4px;
-  top: 4px;
+  right: var(--aa-spacing-half);
+  top: var(--aa-spacing-half);
   background-color: #fff;
-  border-radius: 3px;
+  border-radius: calc(var(--aa-spacing-half) / 2);
   box-shadow: 0px 4px 8px rgba(35, 38, 59, 0.15);
   cursor: pointer;
   opacity: 0;
@@ -294,6 +299,33 @@ body {
   fill: none;
 }
 
+/* Blurhash */
+.aa-BlurhashCanvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/* See all */
+.aa-SeeAll {
+  display: inline-block;
+  background-color: rgba(var(--aa-primary-color-rgb), 0.8);
+  transition: background 0.2s ease-out;
+  color: #fff;
+  font-size: 0.9em;
+  font-weight: 600;
+  padding: calc(var(--aa-spacing-half) * 1.5) var(--aa-spacing);
+  border-radius: calc(var(--aa-spacing-half) / 2);
+  margin: var(--aa-spacing) auto 0 auto;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.aa-SeeAll:hover {
+  background-color: rgba(var(--aa-primary-color-rgb), 1);
+}
+
 /* Articles */
 .aa-PanelSection--articles .aa-List {
   display: flex;
@@ -305,12 +337,14 @@ body {
 
 .aa-PanelSection--articles .aa-Item {
   width: 50%;
+  padding: 0;
+  margin: calc(var(--aa-spacing-half) / 2);
 }
 
 .aa-ArticleItem {
   box-shadow: inset 0 0 0 1px
     rgba(var(--aa-panel-border-color-rgb), var(--aa-panel-border-color-alpha));
-  border-radius: 3px;
+  border-radius: calc(var(--aa-spacing-half) / 2);
   padding: var(--aa-spacing-half);
   height: 100%;
 }
@@ -378,7 +412,7 @@ body {
 
 .aa-PanelSection--quickAccess .aa-QuickAccessItem {
   display: flex;
-  border-radius: 3px;
+  border-radius: calc(var(--aa-spacing-half) / 2);
   overflow: hidden;
   height: 100%;
 }
@@ -519,8 +553,12 @@ body {
 .aa-PanelSection--popularCategories .aa-List {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  grid-gap: var(--aa-spacing-half);
+  grid-gap: var(--aa-spacing);
   font-size: 0.9em;
+}
+
+.aa-PanelSection--popularCategories .aa-Item {
+  padding: 0;
 }
 
 .aa-PanelSection--popularCategories .aa-SourceHeader {
@@ -543,19 +581,17 @@ body {
 /* No results */
 .aa-NoResultsQuery {
   font-size: 1.15em;
+  line-height: 1.3;
   font-weight: bold;
-  margin: var(--aa-spacing) 0 calc(var(--aa-spacing) * 2) 0;
-}
-
-.aa-NoResultsAdvicesTitle {
-  font-weight: bold;
+  margin-bottom: var(--aa-spacing);
 }
 
 .aa-NoResultsAdvicesList {
   font-size: 0.9em;
   padding: 0;
+  margin-top: 0;
   margin-left: calc(var(--aa-spacing) * 1.5);
-  margin-bottom: 0;
+  margin-bottom: var(--aa-spacing);
   display: flex;
   flex-direction: column;
   row-gap: calc(var(--aa-spacing-half) * 0.5);
@@ -590,8 +626,18 @@ body {
   }
 }
 
+@media screen and (max-width: 960px) {
+  .aa-PanelSection--articles .aa-List {
+    flex-wrap: wrap;
+  }
+
+  .aa-PanelSection--articles .aa-Item {
+    width: 100%;
+  }
+}
+
 @media screen and (max-width: 680px) {
-  /* Common */
+  /* Source */
   .aa-SourceHeader {
     display: none;
   }
@@ -605,6 +651,14 @@ body {
   .aa-PanelSection--left,
   .aa-PanelSection--right {
     width: 100%;
+  }
+
+  .aa-PanelSection--left .aa-ItemWrapper {
+    padding: calc(var(--aa-spacing-half) / 1.5);
+  }
+
+  .aa-PanelSectionSources {
+    row-gap: 0;
   }
 
   /* Products */
@@ -650,18 +704,12 @@ body {
 
   /* Popular categories */
   .aa-PanelSection--popularCategories .aa-List {
-    display: flex;
-    overflow: auto;
-    scroll-snap-type: x;
+    grid-template-columns: repeat(2, 1fr);
+    grid-gap: var(--aa-spacing-half);
   }
 
-  .aa-PanelSection--popularCategories .aa-Item {
-    scroll-snap-align: start;
-  }
-
-  .aa-PanelSection--popularCategories .aa-ItemContent,
-  .aa-PanelSection--popularCategories .aa-ItemContentTitle {
-    overflow: visible;
+  .aa-PanelSection--popularCategories .aa-ItemContentTitle span {
+    display: block;
   }
 }
 
@@ -672,7 +720,7 @@ body {
   }
 
   50% {
-    opacity: 0;
+    opacity: 0.4;
   }
 
   100% {

--- a/examples/two-column-layout/style.css
+++ b/examples/two-column-layout/style.css
@@ -69,10 +69,6 @@ body {
   transition: background 0.2s ease-out;
 }
 
-.aa-Item:hover .aa-ItemPicture img {
-  transform: scale(1.1);
-}
-
 .aa-ItemWrapper[data-active='true'] {
   background-color: rgba(
     var(--aa-selected-color-rgb),
@@ -89,7 +85,7 @@ body {
 .aa-ItemPicture img {
   object-fit: cover;
   width: 100%;
-  height: 100%;
+  height: auto;
   transition: transform 1.8s ease-out, opacity 0.2s ease-out;
   transform-origin: center;
   position: relative;
@@ -128,6 +124,13 @@ body {
   height: calc(var(--aa-icon-size) * 0.6);
 }
 
+.aa-Breadcrumb mark {
+  background: none;
+  color: inherit;
+  font-style: normal;
+  font-weight: var(--aa-font-weight-bold);
+}
+
 /* Products */
 .aa-PanelSection--products {
   transition: background 0.2s ease-out;
@@ -157,18 +160,17 @@ body {
   padding: var(--aa-spacing-half);
 }
 
-.aa-PanelSection--products .aa-Item:hover .aa-ItemFavorite {
-  opacity: 1;
-}
-
 .aa-ProductItem {
   height: 100%;
-  min-height: 380px;
 }
 
 .aa-ProductItem.aa-ItemLink {
   align-items: flex-start;
   justify-content: stretch;
+}
+
+.aa-ProductItem .aa-ItemContent mark {
+  color: rgb(var(--aa-primary-color-rgb));
 }
 
 .aa-ProductItem .aa-ItemPicture {
@@ -199,9 +201,9 @@ body {
   width: 100%;
   height: 100%;
   background: rgba(var(--aa-muted-color-rgb), 0.2);
+  animation-name: loading;
   animation-duration: 1.5s;
   animation-iteration-count: infinite;
-  animation-name: loading;
   animation-timing-function: linear;
 }
 
@@ -220,6 +222,10 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.aa-ProductItem .aa-ItemContentBrand mark {
+  font-weight: normal;
 }
 
 .aa-ProductItem .aa-ItemContentTitleWrapper {
@@ -311,22 +317,26 @@ body {
 }
 
 /* See all */
-.aa-SeeAll {
+.aa-SeeAllBtn,
+.aa-SeeAllLink {
   display: inline-block;
+  text-decoration: none;
+  margin: var(--aa-spacing) auto 0 auto;
+  font-size: 0.9em;
+  font-weight: 600;
+}
+
+.aa-SeeAllBtn {
   background-color: rgba(var(--aa-primary-color-rgb), 0.8);
   transition: background 0.2s ease-out;
   color: #fff;
-  font-size: 0.9em;
-  font-weight: 600;
   padding: calc(var(--aa-spacing-half) * 1.5) var(--aa-spacing);
   border-radius: calc(var(--aa-spacing-half) / 2);
-  margin: var(--aa-spacing) auto 0 auto;
-  cursor: pointer;
-  text-decoration: none;
 }
 
-.aa-SeeAll:hover {
-  background-color: rgba(var(--aa-primary-color-rgb), 1);
+.aa-SeeAllLink {
+  color: rgb(var(--aa-primary-color-rgb));
+  transition: opacity 0.2s ease-out;
 }
 
 /* Articles */
@@ -524,10 +534,6 @@ body {
   transition: opacity 0.2s ease-out;
 }
 
-.aa-QuickAccessItem--help a:hover {
-  opacity: 0.6;
-}
-
 /* Faq preview */
 .aa-FaqPreview,
 .aa-FaqPreview .aa-ItemContent {
@@ -555,7 +561,7 @@ body {
 /* Popular categories */
 .aa-PanelSection--popularCategories .aa-List {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-auto-flow: column;
   grid-gap: var(--aa-spacing);
   font-size: 0.9em;
 }
@@ -568,8 +574,12 @@ body {
   margin-top: 0;
 }
 
-.aa-PopularCategoryItem .aa-ItemPicture {
-  width: 72px;
+.aa-PopularCategoryItem.aa-ItemWrapper {
+  justify-content: stretch;
+}
+
+.aa-PopularCategoryItem .aa-ItemContent {
+  grid-auto-flow: row;
 }
 
 .aa-PopularCategoryItem .aa-ItemContentTitle {
@@ -594,20 +604,52 @@ body {
   padding: 0;
   margin-top: 0;
   margin-left: calc(var(--aa-spacing) * 1.5);
-  margin-bottom: var(--aa-spacing);
+  margin-bottom: 0;
   display: flex;
   flex-direction: column;
   row-gap: calc(var(--aa-spacing-half) * 0.5);
 }
 
 /* Media queries */
+@media (hover: hover) {
+  /* Item */
+  .aa-Item:hover .aa-ItemPicture img {
+    transform: scale(1.1);
+  }
+
+  /* Products */
+  .aa-PanelSection--products .aa-Item:hover .aa-ItemFavorite {
+    opacity: 1;
+  }
+
+  /* See all */
+  .aa-SeeAllBtn:hover {
+    background-color: rgba(var(--aa-primary-color-rgb), 1);
+  }
+
+  .aa-SeeAllLink:hover {
+    opacity: 0.8;
+  }
+
+  /* Quick access */
+  .aa-QuickAccessItem--help a:hover {
+    opacity: 0.6;
+  }
+}
+
 @media screen and (prefers-reduced-motion: reduce) {
   .aa-Item,
   .aa-PanelSection--products,
-  .aa-ProductItem .aa-ItemPictureBlurred,
   .aa-ProductItem .aa-ItemFavorite,
-  .aa-QuickAccessItem--help a {
+  .aa-SeeAllBtn,
+  .aa-SeeAllLink,
+  .aa-QuickAccessItem--help a,
+  .aa-ItemPicture img {
     transition: none;
+  }
+
+  .aa-ProductItem .aa-ItemPicture--blurred {
+    animation: none;
   }
 }
 
@@ -645,6 +687,11 @@ body {
     display: none;
   }
 
+  .aa-SourceHeader--recentSearches,
+  .aa-PanelSection--popular .aa-SourceHeader {
+    display: block;
+  }
+
   /* Panel section */
   .aa-PanelSections {
     flex-direction: column;
@@ -673,6 +720,10 @@ body {
 
   .aa-PanelSection--products .aa-Item {
     width: calc(50% - var(--aa-spacing-half) / 2);
+  }
+
+  .aa-ProductItem {
+    min-height: 100%;
   }
 
   .aa-ProductItem .aa-ItemFavorite {
@@ -707,7 +758,8 @@ body {
 
   /* Popular categories */
   .aa-PanelSection--popularCategories .aa-List {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(3, 1fr);
+    grid-auto-flow: row;
     grid-gap: var(--aa-spacing-half);
   }
 

--- a/examples/two-column-layout/style.css
+++ b/examples/two-column-layout/style.css
@@ -3,6 +3,13 @@
 }
 
 body {
+  --aa-panel-max-height: 660px;
+
+  --aa-selected-color-rgb: 240, 238, 246;
+  --aa-selected-color-alpha: 1;
+
+  --aa-icon-size: 18px;
+
   background-color: #f4f4f9;
   color: #000;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -20,10 +27,6 @@ body {
 }
 
 /* Panel */
-.aa-Panel--scrollable {
-  --aa-panel-max-height: 660px;
-}
-
 .aa-Panel .aa-SourceHeader {
   margin: var(--aa-spacing-half) 0 var(--aa-spacing-half) 0;
 }
@@ -46,6 +49,7 @@ body {
 
 .aa-PanelSection--left .aa-ItemWrapper {
   height: 100%;
+  border-radius: calc(var(--aa-spacing-half) / 2);
 }
 
 .aa-PanelSection--right {
@@ -65,15 +69,15 @@ body {
   transition: background 0.2s ease-out;
 }
 
-.aa-Item[data-active='true'] {
+.aa-Item:hover .aa-ItemPicture img {
+  transform: scale(1.1);
+}
+
+.aa-ItemWrapper[data-active='true'] {
   background-color: rgba(
     var(--aa-selected-color-rgb),
     var(--aa-selected-color-alpha)
   );
-}
-
-.aa-Item:hover .aa-ItemPicture img {
-  transform: scale(1.1);
 }
 
 .aa-ItemPicture {
@@ -288,7 +292,6 @@ body {
 }
 
 .aa-ProductItem .aa-FavoriteIcon {
-  --aa-icon-size: 18px;
   color: rgb(var(--aa-primary-color-rgb));
   stroke-width: 2;
   stroke: currentColor;

--- a/examples/two-column-layout/style.css
+++ b/examples/two-column-layout/style.css
@@ -485,7 +485,7 @@ body {
 
 .aa-QuickAccessItem--sales-code .aa-ItemContentTitle {
   font-size: 1.2em;
-  line-height: 1.3em;
+  line-height: 1.3;
   font-weight: bold;
 }
 
@@ -516,7 +516,7 @@ body {
   text-transform: uppercase;
   font-size: 1.2em;
   font-weight: bold;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 
 .aa-QuickAccessItem--help ul {
@@ -601,6 +601,7 @@ body {
 
 .aa-NoResultsAdvicesList {
   font-size: 0.9em;
+  line-height: 1.3;
   padding: 0;
   margin-top: 0;
   margin-left: calc(var(--aa-spacing) * 1.5);

--- a/examples/two-column-layout/style.css
+++ b/examples/two-column-layout/style.css
@@ -692,7 +692,7 @@ body {
     display: none;
   }
 
-  .aa-SourceHeader--recentSearches,
+  .aa-PanelSection--quickAccess .aa-SourceHeader,
   .aa-PanelSection--popular .aa-SourceHeader {
     display: block;
   }

--- a/examples/two-column-layout/style.css
+++ b/examples/two-column-layout/style.css
@@ -111,7 +111,7 @@ body {
   display: flex;
   align-items: center;
   font-size: 0.8em;
-  text-transform: capitalize;
+  font-variant: small-caps;
 }
 
 .aa-Breadcrumb .aa-ItemIcon {

--- a/examples/two-column-layout/style.css
+++ b/examples/two-column-layout/style.css
@@ -111,7 +111,11 @@ body {
   display: flex;
   align-items: center;
   font-size: 0.8em;
-  font-variant: small-caps;
+  text-transform: capitalize;
+}
+
+.aa-Breadcrumb mark {
+  text-transform: none;
 }
 
 .aa-Breadcrumb .aa-ItemIcon {


### PR DESCRIPTION
This PR adds the no results state and popular categories plugin to the Autocomplete two columns layout example.

Main PR: #908