### PR TITLE
docs(examples): use lite client

### DIFF
--- a/examples/github-notification-filters/searchClient.ts
+++ b/examples/github-notification-filters/searchClient.ts
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 
 const appId = 'latency';
 const apiKey = '147a0e7dbc37d4c4dec9ec31b0f68716';

--- a/examples/multiple-datasets-with-headers/app.tsx
+++ b/examples/multiple-datasets-with-headers/app.tsx
@@ -2,7 +2,7 @@
 import { autocomplete } from '@algolia/autocomplete-js';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
 import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 import { h, Fragment } from 'preact';
 
 import '@algolia/autocomplete-theme-classic';

--- a/examples/panel-placement/app.tsx
+++ b/examples/panel-placement/app.tsx
@@ -7,7 +7,7 @@ import {
   GetSources,
 } from '@algolia/autocomplete-js';
 import { Hit } from '@algolia/client-search';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 import { h } from 'preact';
 
 import '@algolia/autocomplete-theme-classic';

--- a/examples/playground/app.tsx
+++ b/examples/playground/app.tsx
@@ -10,7 +10,7 @@ import {
 } from '@algolia/autocomplete-plugin-algolia-insights';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
 import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 import { h, Fragment } from 'preact';
 import insightsClient from 'search-insights';
 

--- a/examples/query-suggestions-with-categories/app.tsx
+++ b/examples/query-suggestions-with-categories/app.tsx
@@ -1,6 +1,6 @@
 import { autocomplete } from '@algolia/autocomplete-js';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 
 import '@algolia/autocomplete-theme-classic';
 

--- a/examples/query-suggestions-with-hits/app.tsx
+++ b/examples/query-suggestions-with-hits/app.tsx
@@ -9,7 +9,7 @@ import {
   createAlgoliaInsightsPlugin,
 } from '@algolia/autocomplete-plugin-algolia-insights';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 import { h, Fragment } from 'preact';
 import insightsClient from 'search-insights';
 

--- a/examples/query-suggestions-with-inline-categories/app.tsx
+++ b/examples/query-suggestions-with-inline-categories/app.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { autocomplete } from '@algolia/autocomplete-js';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 import { h } from 'preact';
 
 import '@algolia/autocomplete-theme-classic';

--- a/examples/query-suggestions-with-recent-searches-and-categories/app.tsx
+++ b/examples/query-suggestions-with-recent-searches-and-categories/app.tsx
@@ -1,7 +1,7 @@
 import { autocomplete } from '@algolia/autocomplete-js';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
 import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 
 import '@algolia/autocomplete-theme-classic';
 

--- a/examples/query-suggestions-with-recent-searches/app.tsx
+++ b/examples/query-suggestions-with-recent-searches/app.tsx
@@ -2,7 +2,7 @@
 import { autocomplete } from '@algolia/autocomplete-js';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
 import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 import { h, Fragment } from 'preact';
 
 import '@algolia/autocomplete-theme-classic';

--- a/examples/query-suggestions/app.tsx
+++ b/examples/query-suggestions/app.tsx
@@ -1,6 +1,6 @@
 import { autocomplete } from '@algolia/autocomplete-js';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 
 import '@algolia/autocomplete-theme-classic';
 

--- a/examples/recently-viewed-items/app.tsx
+++ b/examples/recently-viewed-items/app.tsx
@@ -4,7 +4,7 @@ import {
   AutocompleteComponents,
   getAlgoliaResults,
 } from '@algolia/autocomplete-js';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 import { h, Fragment } from 'preact';
 
 import '@algolia/autocomplete-theme-classic';

--- a/examples/reshape/searchClient.ts
+++ b/examples/reshape/searchClient.ts
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 
 const appId = 'latency';
 const apiKey = '6be0576ff61c053d5f9a3225e2a90f76';

--- a/examples/starter-algolia/app.tsx
+++ b/examples/starter-algolia/app.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { autocomplete, getAlgoliaResults } from '@algolia/autocomplete-js';
 import { Hit } from '@algolia/client-search';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 import { h } from 'preact';
 
 import '@algolia/autocomplete-theme-classic';

--- a/examples/tags-in-searchbox/app.tsx
+++ b/examples/tags-in-searchbox/app.tsx
@@ -10,7 +10,7 @@ import {
   createAlgoliaInsightsPlugin,
 } from '@algolia/autocomplete-plugin-algolia-insights';
 import { createTagsPlugin, Tag } from '@algolia/autocomplete-plugin-tags';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 import { h, Fragment, render } from 'preact';
 import groupBy from 'ramda/src/groupBy';
 import insightsClient from 'search-insights';

--- a/examples/tags-with-hits/app.tsx
+++ b/examples/tags-with-hits/app.tsx
@@ -10,7 +10,7 @@ import {
   createAlgoliaInsightsPlugin,
 } from '@algolia/autocomplete-plugin-algolia-insights';
 import { createTagsPlugin, Tag } from '@algolia/autocomplete-plugin-tags';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 import { h, Fragment } from 'preact';
 import groupBy from 'ramda/src/groupBy';
 import insightsClient from 'search-insights';

--- a/examples/voice-search/app.tsx
+++ b/examples/voice-search/app.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { autocomplete, getAlgoliaResults } from '@algolia/autocomplete-js';
 import { Hit } from '@algolia/client-search';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 import { h } from 'preact';
 
 import '@algolia/autocomplete-theme-classic';


### PR DESCRIPTION
We use the full client instead of the lite one in many of our examples even though we only use it for search.

This moves all examples to the lite client. I'll do a pass in the docs to ensure we do the same.