### PR TITLE
docs(examples): fix call to Algolia facets

### DIFF
--- a/examples/multiple-datasets-with-headers/categoriesPlugin.tsx
+++ b/examples/multiple-datasets-with-headers/categoriesPlugin.tsx
@@ -26,8 +26,8 @@ export function createCategoriesPlugin({
               queries: [
                 {
                   indexName: 'instant_search',
+                  facet: 'categories',
                   params: {
-                    facetName: 'categories',
                     facetQuery: query,
                     maxFacetHits: 5,
                   },


### PR DESCRIPTION
## Summary

This fixes the **Multiple Datasets with Headers** example by fixing the call to Algolia facets.

## Next steps

We didn't catch this error because we disabled linting and type checking in our examples because of parsing issues. We should look into it and solve the issue to ensure we catch those errors at build time.