### PR TITLE
fix: prevent event bubbling on cancel button click

### DIFF
--- a/packages/autocomplete-js/src/__tests__/detached.test.ts
+++ b/packages/autocomplete-js/src/__tests__/detached.test.ts
@@ -85,4 +85,50 @@ describe('detached', () => {
       expect(document.body).not.toHaveClass('aa-Detached');
     });
   });
+
+  test('closes after cancel', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    autocomplete<{ label: string }>({
+      id: 'autocomplete',
+      detachedMediaQuery: '',
+      container,
+    });
+
+    const searchButton = container.querySelector<HTMLButtonElement>(
+      '.aa-DetachedSearchButton'
+    );
+
+    // Open detached overlay
+    searchButton.click();
+
+    await waitFor(() => {
+      expect(document.querySelector('.aa-DetachedOverlay')).toBeInTheDocument();
+      expect(document.body).toHaveClass('aa-Detached');
+    });
+
+    const cancelButton = document.querySelector<HTMLButtonElement>(
+      '.aa-DetachedCancelButton'
+    );
+
+    const bodyClickListener = jest.fn();
+    document.querySelector('body').addEventListener('click', bodyClickListener);
+
+    // Close detached overlay
+    cancelButton.click();
+
+    expect(bodyClickListener).toHaveBeenCalledTimes(0);
+
+    document
+      .querySelector('body')
+      .removeEventListener('click', bodyClickListener);
+
+    // The detached overlay should close
+    await waitFor(() => {
+      expect(
+        document.querySelector('.aa-DetachedOverlay')
+      ).not.toBeInTheDocument();
+      expect(document.body).not.toHaveClass('aa-Detached');
+    });
+  });
 });

--- a/packages/autocomplete-js/src/createAutocompleteDom.ts
+++ b/packages/autocomplete-js/src/createAutocompleteDom.ts
@@ -168,7 +168,9 @@ export function createAutocompleteDom<TItem extends BaseItem>({
     const detachedCancelButton = createDomElement('button', {
       class: classNames.detachedCancelButton,
       textContent: translations.detachedCancelButtonText,
-      onClick() {
+      onClick(event: MouseEvent) {
+        event.preventDefault();
+        event.stopPropagation();
         autocomplete.setIsOpen(false);
         setIsModalOpen(false);
       },

--- a/packages/autocomplete-js/src/createAutocompleteDom.ts
+++ b/packages/autocomplete-js/src/createAutocompleteDom.ts
@@ -158,18 +158,18 @@ export function createAutocompleteDom<TItem extends BaseItem>({
       textContent: placeholder,
     });
     const detachedSearchButton = createDomElement('button', {
+      type: 'button',
       class: classNames.detachedSearchButton,
-      onClick(event: MouseEvent) {
-        event.preventDefault();
+      onClick() {
         setIsModalOpen(true);
       },
       children: [detachedSearchButtonIcon, detachedSearchButtonPlaceholder],
     });
     const detachedCancelButton = createDomElement('button', {
+      type: 'button',
       class: classNames.detachedCancelButton,
       textContent: translations.detachedCancelButtonText,
       onClick(event: MouseEvent) {
-        event.preventDefault();
         event.stopPropagation();
         autocomplete.setIsOpen(false);
         setIsModalOpen(false);


### PR DESCRIPTION
In detached mode, the cancel button does not stop event propagation on click, which might cause misclicks in elements that are under the overlay when the latter disappears.

Closes #853 