### PR TITLE
fix(render): pass `renderer.render` to default `render` function

### DIFF
--- a/examples/react-instantsearch-hooks/src/components/Autocomplete.tsx
+++ b/examples/react-instantsearch-hooks/src/components/Autocomplete.tsx
@@ -1,10 +1,9 @@
 import type { SearchClient } from 'algoliasearch/lite';
 import type { BaseItem } from '@algolia/autocomplete-core';
-import type { AutocompleteOptions } from '@algolia/autocomplete-js';
+import type { AutocompleteOptions, Render } from '@algolia/autocomplete-js';
 
 import {
   createElement,
-  ReactElement,
   Fragment,
   useEffect,
   useMemo,
@@ -228,13 +227,7 @@ export function Autocomplete({
           });
         }
       },
-      renderer: {
-        createElement,
-        Fragment,
-      },
-      render({ children }, root) {
-        render(children as ReactElement, root);
-      },
+      renderer: { createElement, Fragment, render: render as Render },
     });
 
     return () => autocompleteInstance.destroy();

--- a/examples/react-instantsearch/src/Autocomplete.js
+++ b/examples/react-instantsearch/src/Autocomplete.js
@@ -14,10 +14,7 @@ export function Autocomplete(props) {
 
     const search = autocomplete({
       container: containerRef.current,
-      renderer: { createElement, Fragment },
-      render({ children }, root) {
-        render(children, root);
-      },
+      renderer: { createElement, Fragment, render },
       ...props,
     });
 

--- a/examples/vue-instantsearch/src/Autocomplete.vue
+++ b/examples/vue-instantsearch/src/Autocomplete.vue
@@ -244,9 +244,7 @@ export default {
       renderer: {
         createElement,
         Fragment,
-      },
-      render({ children }, root) {
-        render(children, root);
+        render,
       },
     });
   },

--- a/examples/vue/src/App.vue
+++ b/examples/vue/src/App.vue
@@ -53,9 +53,7 @@ export default {
         renderer: {
           createElement,
           Fragment,
-        },
-        render({ children }, root) {
-          render(children, root);
+          render,
         },
       });
     });

--- a/packages/autocomplete-js/src/getDefaultOptions.ts
+++ b/packages/autocomplete-js/src/getDefaultOptions.ts
@@ -54,11 +54,11 @@ const defaultClassNames: AutocompleteClassNames = {
   submitButton: 'aa-SubmitButton',
 };
 
-const defaultRender: AutocompleteRender<any> = ({ children }, root) => {
+const defaultRender: AutocompleteRender<any> = ({ children, render }, root) => {
   render(children, root);
 };
 
-const defaultRenderer: AutocompleteRenderer = {
+const defaultRenderer: Required<AutocompleteRenderer> = {
   createElement: preactCreateElement,
   Fragment: PreactFragment,
   render,

--- a/packages/autocomplete-js/src/render.tsx
+++ b/packages/autocomplete-js/src/render.tsx
@@ -27,7 +27,7 @@ type RenderProps<TItem extends BaseItem> = {
   panelContainer: HTMLElement;
   propGetters: AutocompletePropGetters<TItem>;
   state: AutocompleteState<TItem>;
-  renderer: AutocompleteRenderer;
+  renderer: Required<AutocompleteRenderer>;
 };
 
 export function renderSearchBox<TItem extends BaseItem>({

--- a/packages/autocomplete-js/src/types/AutocompleteRender.ts
+++ b/packages/autocomplete-js/src/types/AutocompleteRender.ts
@@ -20,7 +20,7 @@ export type AutocompleteRender<TItem extends BaseItem> = (
     createElement: Pragma;
     Fragment: PragmaFrag;
     html: HTMLTemplate;
-    render?: Render;
+    render: Render;
   },
   root: HTMLElement
 ) => void;


### PR DESCRIPTION
This PR fixes a bug when using the `renderer` option without the `render` option.

Since https://github.com/algolia/autocomplete/pull/920 you no longer need to pass the `render` option; instead you can pass a custom `render` function via the `renderer` option. This caused a bug with custom VDOM implementations because `render` wasn't passed to the internal `defaultRender` function, and fell back on Preact's `render`.

This PR also cleans up some tests that were never run. We can write them properly in a separate PR.