### PR TITLE
docs(two-column-layout-example): add a link to the guide in readme

### DIFF
--- a/examples/two-column-layout/README.md
+++ b/examples/two-column-layout/README.md
@@ -6,11 +6,7 @@ This example shows how to integrate Autocomplete with a two-column layout.
 
 ## Demo
 
-[Access the demo](https://codesandbox.io/s/github/algolia/autocomplete/tree/next/examples/two-column-layout)
-
-## Guide
-
-You can find a detailed guide to this example here: https://www.algolia.com/doc/ui-libraries/autocomplete/guides/creating-an-advanced-ecommerce-experience/
+[Access the demo](https://codesandbox.io/s/github/algolia/autocomplete/tree/next/examples/two-column-layout) | [Follow the guide](https://www.algolia.com/doc/ui-libraries/autocomplete/guides/creating-an-advanced-ecommerce-experience/)
 
 ## How to run this example locally
 

--- a/examples/two-column-layout/README.md
+++ b/examples/two-column-layout/README.md
@@ -8,6 +8,10 @@ This example shows how to integrate Autocomplete with a two-column layout.
 
 [Access the demo](https://codesandbox.io/s/github/algolia/autocomplete/tree/next/examples/two-column-layout)
 
+## Guide
+
+You can find a detailed guide to this example here: https://www.algolia.com/doc/ui-libraries/autocomplete/guides/creating-an-advanced-ecommerce-experience/
+
 ## How to run this example locally
 
 ### 1. Clone this repository


### PR DESCRIPTION
### Summary

This PR adds a link to the Autocomplete guide describing the two-column layout example.

**Note:** We need to wait for the guide to be merged in the docs before merging this one.