### PR TITLE
fix(autocomplete-js): leave the modal open on reset on pointer devices

### DIFF
--- a/packages/autocomplete-core/src/__tests__/concurrency.test.ts
+++ b/packages/autocomplete-core/src/__tests__/concurrency.test.ts
@@ -294,9 +294,8 @@ describe('concurrency', () => {
           })
         );
 
-        window.document.dispatchEvent(
-          new CustomEvent('touchstart', { bubbles: true })
-        );
+        const customEvent = new CustomEvent('touchstart', { bubbles: true });
+        window.document.dispatchEvent(customEvent);
 
         // The status is immediately set to "idle" and the panel is closed
         expect(onStateChange).toHaveBeenLastCalledWith(

--- a/packages/autocomplete-core/src/__tests__/concurrency.test.ts
+++ b/packages/autocomplete-core/src/__tests__/concurrency.test.ts
@@ -134,7 +134,7 @@ describe('concurrency', () => {
         expect(getSources).toHaveBeenCalledTimes(3);
       });
 
-      test('keeps the panel closed on blur', async () => {
+      test('keeps the panel closed on Enter', async () => {
         const onStateChange = jest.fn();
         const { timeout, delayedGetSources } = createDelayedGetSources({
           sources: [100, 200],
@@ -188,7 +188,74 @@ describe('concurrency', () => {
         expect(getSources).toHaveBeenCalledTimes(2);
       });
 
-      test('keeps the panel closed on touchstart blur', async () => {
+      test('keeps the panel closed on click outside', async () => {
+        const onStateChange = jest.fn();
+        const { timeout, delayedGetSources } = createDelayedGetSources({
+          sources: [100, 200],
+        });
+        const getSources = jest.fn(delayedGetSources);
+
+        const {
+          inputElement,
+          getEnvironmentProps,
+          formElement,
+        } = createPlayground(createAutocomplete, {
+          onStateChange,
+          getSources,
+        });
+
+        const panelElement = document.createElement('div');
+
+        const { onMouseDown } = getEnvironmentProps({
+          inputElement,
+          formElement,
+          panelElement,
+        });
+        window.addEventListener('mousedown', onMouseDown);
+
+        userEvent.type(inputElement, 'a');
+
+        await runAllMicroTasks();
+
+        // The search request is triggered
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            state: expect.objectContaining({
+              status: 'loading',
+              query: 'a',
+            }),
+          })
+        );
+
+        userEvent.click(document.body);
+
+        // The status is immediately set to "idle" and the panel is closed
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            state: expect.objectContaining({
+              status: 'idle',
+              isOpen: false,
+              query: 'a',
+            }),
+          })
+        );
+
+        await defer(noop, timeout);
+
+        // Once the request is settled, the state remains unchanged
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            state: expect.objectContaining({
+              status: 'idle',
+              isOpen: false,
+            }),
+          })
+        );
+
+        expect(getSources).toHaveBeenCalledTimes(1);
+      });
+
+      test('keeps the panel closed on touchstart', async () => {
         const onStateChange = jest.fn();
         const { timeout, delayedGetSources } = createDelayedGetSources({
           sources: [100, 200],
@@ -227,8 +294,9 @@ describe('concurrency', () => {
           })
         );
 
-        const customEvent = new CustomEvent('touchstart', { bubbles: true });
-        window.document.dispatchEvent(customEvent);
+        window.document.dispatchEvent(
+          new CustomEvent('touchstart', { bubbles: true })
+        );
 
         // The status is immediately set to "idle" and the panel is closed
         expect(onStateChange).toHaveBeenLastCalledWith(

--- a/packages/autocomplete-core/src/__tests__/getEnvironmentProps.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getEnvironmentProps.test.ts
@@ -1,3 +1,5 @@
+import userEvent from '@testing-library/user-event';
+
 import {
   createPlayground,
   createSource,
@@ -27,6 +29,202 @@ describe('getEnvironmentProps', () => {
     expect(environmentProps).toEqual(
       expect.objectContaining({ customProps: {} })
     );
+  });
+
+  describe('onMouseDown', () => {
+    test('is a noop when panel is not open and status is idle', () => {
+      const onStateChange = jest.fn();
+      const {
+        getEnvironmentProps,
+        inputElement,
+        formElement,
+      } = createPlayground(createAutocomplete, { onStateChange });
+      const panelElement = document.createElement('div');
+
+      const { onMouseDown } = getEnvironmentProps({
+        inputElement,
+        formElement,
+        panelElement,
+      });
+      window.addEventListener('mousedown', onMouseDown);
+
+      // Dispatch MouseDown event on window
+      const customEvent = new CustomEvent('mousedown', { bubbles: true });
+      window.dispatchEvent(customEvent);
+
+      expect(onStateChange).not.toHaveBeenCalled();
+
+      window.removeEventListener('mousedown', onMouseDown);
+    });
+
+    test('is a noop when the event target is the input element', async () => {
+      const onStateChange = jest.fn();
+      const {
+        getEnvironmentProps,
+        inputElement,
+        formElement,
+      } = createPlayground(createAutocomplete, {
+        onStateChange,
+        openOnFocus: true,
+        getSources() {
+          return [
+            createSource({
+              getItems: () => [{ label: '1' }],
+            }),
+          ];
+        },
+      });
+      const panelElement = document.createElement('div');
+
+      const { onMouseDown } = getEnvironmentProps({
+        inputElement,
+        formElement,
+        panelElement,
+      });
+      window.addEventListener('mousedown', onMouseDown);
+
+      // Click input (focuses it, which opens the panel)
+      userEvent.click(inputElement);
+
+      await runAllMicroTasks();
+
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({
+            isOpen: true,
+          }),
+        })
+      );
+
+      onStateChange.mockClear();
+
+      // Dispatch MouseDown event on the input (bubbles to window)
+      const customEvent = new CustomEvent('mousedown', { bubbles: true });
+      inputElement.dispatchEvent(customEvent);
+
+      await runAllMicroTasks();
+
+      expect(onStateChange).not.toHaveBeenCalled();
+
+      window.removeEventListener('mousedown', onMouseDown);
+    });
+
+    test('closes panel and resets `activeItemId` if the target is outside Autocomplete', async () => {
+      const onStateChange = jest.fn();
+      const {
+        getEnvironmentProps,
+        inputElement,
+        formElement,
+      } = createPlayground(createAutocomplete, {
+        onStateChange,
+        openOnFocus: true,
+        defaultActiveItemId: 1,
+        getSources() {
+          return [
+            createSource({
+              getItems: () => [{ label: '1' }],
+            }),
+          ];
+        },
+      });
+      const panelElement = document.createElement('div');
+
+      const { onMouseDown } = getEnvironmentProps({
+        inputElement,
+        formElement,
+        panelElement,
+      });
+      window.addEventListener('mousedown', onMouseDown);
+
+      // Click input (focuses it, which opens the panel)
+      userEvent.click(inputElement);
+
+      await runAllMicroTasks();
+
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({
+            isOpen: true,
+          }),
+        })
+      );
+
+      onStateChange.mockClear();
+
+      // Dispatch MouseDown event on window (so, outside of Autocomplete)
+      const customEvent = new CustomEvent('mousedown', { bubbles: true });
+      window.document.dispatchEvent(customEvent);
+
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({
+            isOpen: false,
+            activeItemId: null,
+          }),
+        })
+      );
+
+      window.removeEventListener('mousedown', onMouseDown);
+    });
+
+    test('does not close panel nor reset `activeItemId` if the target is outside Autocomplete in debug mode', async () => {
+      const onStateChange = jest.fn();
+      const {
+        getEnvironmentProps,
+        inputElement,
+        formElement,
+      } = createPlayground(createAutocomplete, {
+        onStateChange,
+        openOnFocus: true,
+        defaultActiveItemId: 1,
+        debug: true,
+        getSources() {
+          return [
+            createSource({
+              getItems: () => [{ label: '1' }],
+            }),
+          ];
+        },
+      });
+      const panelElement = document.createElement('div');
+
+      const { onMouseDown } = getEnvironmentProps({
+        inputElement,
+        formElement,
+        panelElement,
+      });
+      window.addEventListener('mousedown', onMouseDown);
+
+      // Click input (focuses it, which opens the panel)
+      userEvent.click(inputElement);
+
+      await runAllMicroTasks();
+
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({
+            isOpen: true,
+          }),
+        })
+      );
+
+      onStateChange.mockClear();
+
+      // Dispatch MouseDown event on window (so, outside of Autocomplete)
+      const customEvent = new CustomEvent('mousedown', { bubbles: true });
+      window.document.dispatchEvent(customEvent);
+
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({
+            isOpen: true,
+            activeItemId: 1,
+          }),
+        })
+      );
+
+      window.removeEventListener('mousedown', onMouseDown);
+    });
   });
 
   describe('onTouchStart', () => {
@@ -107,7 +305,7 @@ describe('getEnvironmentProps', () => {
       window.removeEventListener('touchstart', onTouchStart);
     });
 
-    test('closes panel if the target is outside Autocomplete', async () => {
+    test('closes panel and resets `activeItemId` if the target is outside Autocomplete', async () => {
       const onStateChange = jest.fn();
       const {
         getEnvironmentProps,
@@ -116,6 +314,7 @@ describe('getEnvironmentProps', () => {
       } = createPlayground(createAutocomplete, {
         onStateChange,
         openOnFocus: true,
+        defaultActiveItemId: 1,
         getSources() {
           return [
             createSource({
@@ -156,6 +355,66 @@ describe('getEnvironmentProps', () => {
         expect.objectContaining({
           state: expect.objectContaining({
             isOpen: false,
+            activeItemId: null,
+          }),
+        })
+      );
+
+      window.removeEventListener('touchstart', onTouchStart);
+    });
+
+    test('does not close panel nor reset `activeItemId` if the target is outside Autocomplete in debug mode', async () => {
+      const onStateChange = jest.fn();
+      const {
+        getEnvironmentProps,
+        inputElement,
+        formElement,
+      } = createPlayground(createAutocomplete, {
+        onStateChange,
+        openOnFocus: true,
+        defaultActiveItemId: 1,
+        debug: true,
+        getSources() {
+          return [
+            createSource({
+              getItems: () => [{ label: '1' }],
+            }),
+          ];
+        },
+      });
+      const panelElement = document.createElement('div');
+
+      const { onTouchStart } = getEnvironmentProps({
+        inputElement,
+        formElement,
+        panelElement,
+      });
+      window.addEventListener('touchstart', onTouchStart);
+
+      // Focus input (opens the panel)
+      inputElement.focus();
+
+      await runAllMicroTasks();
+
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({
+            isOpen: true,
+          }),
+        })
+      );
+
+      onStateChange.mockClear();
+
+      // Dispatch TouchStart event on window (so, outside of Autocomplete)
+      const customEvent = new CustomEvent('touchstart', { bubbles: true });
+      window.document.dispatchEvent(customEvent);
+
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({
+            isOpen: true,
+            activeItemId: 1,
           }),
         })
       );

--- a/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
@@ -1034,6 +1034,7 @@ describe('getInputProps', () => {
           openOnFocus: true,
           initialState: {
             completion: 'a',
+            isOpen: true,
             collections: [
               createCollection({
                 items: [{ label: '1' }, { label: '2' }],
@@ -1042,7 +1043,6 @@ describe('getInputProps', () => {
           },
         });
 
-        inputElement.focus();
         userEvent.type(inputElement, '{esc}');
 
         expect(onStateChange).toHaveBeenLastCalledWith(
@@ -1153,6 +1153,31 @@ describe('getInputProps', () => {
         inputProps.onKeyDown(event);
 
         expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      });
+
+      test('closes the panel when no item was selected', async () => {
+        const onStateChange = jest.fn();
+        const { inputElement } = createPlayground(createAutocomplete, {
+          onStateChange,
+          initialState: {
+            isOpen: true,
+            collections: [
+              createCollection({
+                items: [{ label: '1' }, { label: '2' }],
+              }),
+            ],
+          },
+        });
+
+        userEvent.type(inputElement, '{enter}');
+
+        await runAllMicroTasks();
+
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            state: expect.objectContaining({ isOpen: false }),
+          })
+        );
       });
 
       describe('Plain Enter', () => {
@@ -1890,81 +1915,6 @@ describe('getInputProps', () => {
           );
         });
       });
-    });
-  });
-
-  describe('onBlur', () => {
-    test('resets activeItemId and isOpen', async () => {
-      const onStateChange = jest.fn();
-      const { inputElement } = createPlayground(createAutocomplete, {
-        onStateChange,
-        defaultActiveItemId: 1,
-        openOnFocus: true,
-      });
-
-      inputElement.focus();
-      inputElement.blur();
-
-      await runAllMicroTasks();
-
-      expect(onStateChange).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          state: expect.objectContaining({
-            activeItemId: null,
-            isOpen: false,
-          }),
-        })
-      );
-    });
-
-    test('does not reset activeItemId and isOpen when debug is true', () => {
-      const onStateChange = jest.fn();
-      const { inputElement } = createPlayground(createAutocomplete, {
-        onStateChange,
-        debug: true,
-        defaultActiveItemId: 1,
-        openOnFocus: true,
-        shouldPanelOpen: () => true,
-      });
-
-      inputElement.focus();
-      inputElement.blur();
-
-      expect(onStateChange).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          state: expect.objectContaining({
-            activeItemId: 1,
-            isOpen: true,
-          }),
-        })
-      );
-    });
-
-    test('does not reset activeItemId and isOpen on touch devices', () => {
-      const environment = {
-        ...global,
-        ontouchstart: () => {},
-      };
-      const onStateChange = jest.fn();
-      const { inputElement } = createPlayground(createAutocomplete, {
-        environment,
-        onStateChange,
-        defaultActiveItemId: 1,
-        openOnFocus: true,
-        shouldPanelOpen: () => true,
-      });
-
-      inputElement.focus();
-      inputElement.blur();
-
-      expect(onStateChange).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          state: expect.objectContaining({
-            activeItemId: 1,
-            isOpen: true,
-          }),
-        })
-      );
     });
   });
 

--- a/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
@@ -1689,6 +1689,180 @@ describe('getInputProps', () => {
         });
       });
     });
+
+    describe('Tab', () => {
+      test('closes the panel and resets `activeItemId`', async () => {
+        const onStateChange = jest.fn();
+        const { inputElement } = createPlayground(createAutocomplete, {
+          onStateChange,
+          openOnFocus: true,
+          defaultActiveItemId: 1,
+          getSources() {
+            return [
+              createSource({
+                getItems: () => [{ label: '1' }],
+              }),
+            ];
+          },
+        });
+
+        userEvent.click(inputElement);
+
+        await runAllMicroTasks();
+
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            state: expect.objectContaining({
+              isOpen: true,
+              activeItemId: 1,
+            }),
+          })
+        );
+
+        userEvent.tab();
+
+        await runAllMicroTasks();
+
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            state: expect.objectContaining({
+              isOpen: false,
+              activeItemId: null,
+            }),
+          })
+        );
+      });
+
+      test('does not close closes the panel nor reset `activeItemId` in debug mode', async () => {
+        const onStateChange = jest.fn();
+        const { inputElement } = createPlayground(createAutocomplete, {
+          onStateChange,
+          debug: true,
+          openOnFocus: true,
+          defaultActiveItemId: 1,
+          getSources() {
+            return [
+              createSource({
+                getItems: () => [{ label: '1' }],
+              }),
+            ];
+          },
+        });
+
+        userEvent.click(inputElement);
+
+        await runAllMicroTasks();
+
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            state: expect.objectContaining({
+              isOpen: true,
+              activeItemId: 1,
+            }),
+          })
+        );
+
+        userEvent.tab();
+
+        await runAllMicroTasks();
+
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            state: expect.objectContaining({
+              isOpen: true,
+              activeItemId: 1,
+            }),
+          })
+        );
+      });
+    });
+
+    describe('Tab+Shift', () => {
+      test('closes the panel and resets `activeItemId`', async () => {
+        const onStateChange = jest.fn();
+        const { inputElement } = createPlayground(createAutocomplete, {
+          onStateChange,
+          openOnFocus: true,
+          defaultActiveItemId: 1,
+          getSources() {
+            return [
+              createSource({
+                getItems: () => [{ label: '1' }],
+              }),
+            ];
+          },
+        });
+
+        userEvent.click(inputElement);
+
+        await runAllMicroTasks();
+
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            state: expect.objectContaining({
+              isOpen: true,
+              activeItemId: 1,
+            }),
+          })
+        );
+
+        userEvent.tab({ shift: true });
+
+        await runAllMicroTasks();
+
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            state: expect.objectContaining({
+              isOpen: false,
+              activeItemId: null,
+            }),
+          })
+        );
+      });
+
+      test('does not close closes the panel nor reset `activeItemId` in debug mode', async () => {
+        const onStateChange = jest.fn();
+        const { inputElement } = createPlayground(createAutocomplete, {
+          onStateChange,
+          debug: true,
+          openOnFocus: true,
+          defaultActiveItemId: 1,
+          getSources() {
+            return [
+              createSource({
+                getItems: () => [{ label: '1' }],
+              }),
+            ];
+          },
+        });
+
+        userEvent.click(inputElement);
+
+        await runAllMicroTasks();
+
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            state: expect.objectContaining({
+              isOpen: true,
+              activeItemId: 1,
+            }),
+          })
+        );
+
+        userEvent.tab({ shift: true });
+
+        await runAllMicroTasks();
+
+        expect(onStateChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            state: expect.objectContaining({
+              isOpen: true,
+              activeItemId: 1,
+            }),
+          })
+        );
+      });
+    });
   });
 
   describe('onFocus', () => {

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -47,6 +47,8 @@ export function getPropGetters<
         return;
       }
 
+      // @TODO: support cases where there are multiple Autocomplete instances.
+      // Right now, a second instance makes this computation return false.
       const isTargetWithinAutocomplete = [formElement, panelElement].some(
         (contextNode) => {
           return isOrContainsNode(contextNode, event.target as Node);
@@ -76,8 +78,6 @@ export function getPropGetters<
       // `openOnFocus=true`, it shouldn't close the panel.
       // On touch devices, scrolling results (`touchmove`) causes an input blur
       // but shouldn't close the panel.
-      // @TODO: support cases where there are multiple Autocomplete instances.
-      // Right now, a second instance makes this computation return false.
       onTouchStart: onMouseDownOrTouchStart,
       onMouseDown: onMouseDownOrTouchStart,
       // When scrolling on touch devices (mobiles, tablets, etc.), we want to

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -1,3 +1,5 @@
+import { noop } from '@algolia/autocomplete-shared';
+
 import { onInput } from './onInput';
 import { onKeyDown } from './onKeyDown';
 import {
@@ -31,46 +33,53 @@ export function getPropGetters<
   const getEnvironmentProps: GetEnvironmentProps = (providedProps) => {
     const { inputElement, formElement, panelElement, ...rest } = providedProps;
 
+    function onMouseDownOrTouchStart(event: MouseEvent | TouchEvent) {
+      // The `onTouchStart`/`onMouseDown` events shouldn't trigger the `blur`
+      // handler when it's not an interaction with Autocomplete.
+      // We detect it with the following heuristics:
+      // - the panel is closed AND there are no pending requests
+      //   (no interaction with the autocomplete, no future state updates)
+      // - OR the touched target is the input element (should open the panel)
+      const isAutocompleteInteraction =
+        store.getState().isOpen || !store.pendingRequests.isEmpty();
+
+      if (!isAutocompleteInteraction || event.target === inputElement) {
+        return;
+      }
+
+      const isTargetWithinAutocomplete = [formElement, panelElement].some(
+        (contextNode) => {
+          return isOrContainsNode(contextNode, event.target as Node);
+        }
+      );
+
+      if (isTargetWithinAutocomplete === false) {
+        store.dispatch('blur', null);
+
+        // If requests are still pending when the user closes the panel, they
+        // could reopen the panel once they resolve.
+        // We want to prevent any subsequent query from reopening the panel
+        // because it would result in an unsolicited UI behavior.
+        if (!props.debug) {
+          store.pendingRequests.cancelAll();
+        }
+      }
+    }
+
     return {
-      // On touch devices, we do not rely on the native `blur` event of the
-      // input to close the panel, but rather on a custom `touchstart` event
-      // outside of the autocomplete elements.
-      // This ensures a working experience on mobile because we blur the input
-      // on touch devices when the user starts scrolling (`touchmove`).
+      // We do not rely on the native `blur` event of the input to close the
+      // panel, but rather on a custom `touchstart`/`mousedown` event outside
+      // of the autocomplete elements.
+      // This ensures we don't mistakenly interpret interactions within the
+      // autocomplete (but outside of the input) as a signal to close the panel.
+      // For example, clicking reset button causes an input blur, but if
+      // `openOnFocus=true`, it shouldn't close the panel.
+      // On touch devices, scrolling results (`touchmove`) causes an input blur
+      // but shouldn't close the panel.
       // @TODO: support cases where there are multiple Autocomplete instances.
       // Right now, a second instance makes this computation return false.
-      onTouchStart(event) {
-        // The `onTouchStart` event shouldn't trigger the `blur` handler when
-        // it's not an interaction with Autocomplete. We detect it with the
-        // following heuristics:
-        // - the panel is closed AND there are no pending requests
-        //   (no interaction with the autocomplete, no future state updates)
-        // - OR the touched target is the input element (should open the panel)
-        const isAutocompleteInteraction =
-          store.getState().isOpen || !store.pendingRequests.isEmpty();
-
-        if (!isAutocompleteInteraction || event.target === inputElement) {
-          return;
-        }
-
-        const isTargetWithinAutocomplete = [formElement, panelElement].some(
-          (contextNode) => {
-            return isOrContainsNode(contextNode, event.target as Node);
-          }
-        );
-
-        if (isTargetWithinAutocomplete === false) {
-          store.dispatch('blur', null);
-
-          // If requests are still pending when the user closes the panel, they
-          // could reopen the panel once they resolve.
-          // We want to prevent any subsequent query from reopening the panel
-          // because it would result in an unsolicited UI behavior.
-          if (!props.debug) {
-            store.pendingRequests.cancelAll();
-          }
-        }
-      },
+      onTouchStart: onMouseDownOrTouchStart,
+      onMouseDown: onMouseDownOrTouchStart,
       // When scrolling on touch devices (mobiles, tablets, etc.), we want to
       // mimic the native platform behavior where the input is blurred to
       // hide the virtual keyboard. This gives more vertical space to
@@ -158,7 +167,6 @@ export function getPropGetters<
       store.dispatch('focus', null);
     }
 
-    const isTouchDevice = 'ontouchstart' in props.environment;
     const { inputElement, maxLength = 512, ...rest } = providedProps || {};
     const activeItem = getActiveItem(store.getState());
 
@@ -207,21 +215,10 @@ export function getPropGetters<
         });
       },
       onFocus,
-      onBlur: () => {
-        // We do rely on the `blur` event on touch devices.
-        // See explanation in `onTouchStart`.
-        if (!isTouchDevice) {
-          store.dispatch('blur', null);
-
-          // If requests are still pending when the user closes the panel, they
-          // could reopen the panel once they resolve.
-          // We want to prevent any subsequent query from reopening the panel
-          // because it would result in an unsolicited UI behavior.
-          if (!props.debug) {
-            store.pendingRequests.cancelAll();
-          }
-        }
-      },
+      // We don't rely on the `blur` event.
+      // See explanation in `onTouchStart`/`onMouseDown`.
+      // @MAJOR See if we need to keep this handler.
+      onBlur: noop,
       onClick: (event) => {
         // When the panel is closed and you click on the input while
         // the input is focused, the `onFocus` event is not triggered

--- a/packages/autocomplete-core/src/onKeyDown.ts
+++ b/packages/autocomplete-core/src/onKeyDown.ts
@@ -114,6 +114,14 @@ export function onKeyDown<TItem extends BaseItem>({
         .getState()
         .collections.every((collection) => collection.items.length === 0)
     ) {
+      // If requests are still pending when the panel closes, they could reopen
+      // the panel once they resolve.
+      // We want to prevent any subsequent query from reopening the panel
+      // because it would result in an unsolicited UI behavior.
+      if (!props.debug) {
+        store.pendingRequests.cancelAll();
+      }
+
       return;
     }
 

--- a/packages/autocomplete-core/src/onKeyDown.ts
+++ b/packages/autocomplete-core/src/onKeyDown.ts
@@ -105,6 +105,14 @@ export function onKeyDown<TItem extends BaseItem>({
     // pending and could reopen the panel once they resolve, because that would
     // result in an unsolicited UI behavior.
     store.pendingRequests.cancelAll();
+  } else if (event.key === 'Tab') {
+    store.dispatch('blur', null);
+
+    // Hitting the `Escape` key signals the end of a user interaction with the
+    // autocomplete. At this point, we should ignore any requests that are still
+    // pending and could reopen the panel once they resolve, because that would
+    // result in an unsolicited UI behavior.
+    store.pendingRequests.cancelAll();
   } else if (event.key === 'Enter') {
     // No active item, so we let the browser handle the native `onSubmit` form
     // event.

--- a/packages/autocomplete-core/src/types/AutocompletePropGetters.ts
+++ b/packages/autocomplete-core/src/types/AutocompletePropGetters.ts
@@ -25,6 +25,7 @@ export type GetEnvironmentProps = (props: {
 }) => {
   onTouchStart(event: TouchEvent): void;
   onTouchMove(event: TouchEvent): void;
+  onMouseDown(event: MouseEvent): void;
 };
 
 export type GetRootProps = (props?: {

--- a/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
+++ b/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
@@ -1,5 +1,6 @@
 import * as autocompleteShared from '@algolia/autocomplete-shared';
 import { fireEvent, waitFor } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
 
 import {
   castToJestMock,
@@ -15,6 +16,10 @@ jest.mock('@algolia/autocomplete-shared', () => {
     ...module,
     generateAutocompleteId: jest.fn(() => `autocomplete-test`),
   };
+});
+
+beforeEach(() => {
+  document.body.innerHTML = '';
 });
 
 describe('autocomplete-js', () => {
@@ -561,5 +566,109 @@ describe('autocomplete-js', () => {
     await runAllMicroTasks();
 
     expect(input).toHaveValue('a');
+  });
+
+  test('closes the panel and focuses the next focusable element on `Tab`', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    autocomplete<{ label: string }>({
+      id: 'autocomplete',
+      container,
+      initialState: {
+        query: 'a',
+        isOpen: true,
+      },
+      getSources() {
+        return [
+          {
+            sourceId: 'testSource',
+            getItems() {
+              return [
+                { label: 'Item 1' },
+                { label: 'Item 2' },
+                { label: 'Item 3' },
+              ];
+            },
+            templates: {
+              item({ item }) {
+                return item.label;
+              },
+            },
+          },
+        ];
+      },
+    });
+
+    // Wait for the panel to open
+    await waitFor(() => {
+      expect(
+        document.querySelector<HTMLElement>('.aa-Panel')
+      ).toBeInTheDocument();
+    });
+
+    userEvent.click(document.querySelector('.aa-Input')!);
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.aa-DetachedOverlay')
+      ).not.toBeInTheDocument();
+      expect(document.body).not.toHaveClass('aa-Detached');
+      expect(document.activeElement).toEqual(
+        document.querySelector('.aa-ClearButton')
+      );
+    });
+  });
+
+  test('closes the panel and focuses the next focusable element on `Shift+Tab`', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    autocomplete<{ label: string }>({
+      id: 'autocomplete',
+      container,
+      initialState: {
+        query: 'a',
+        isOpen: true,
+      },
+      getSources() {
+        return [
+          {
+            sourceId: 'testSource',
+            getItems() {
+              return [
+                { label: 'Item 1' },
+                { label: 'Item 2' },
+                { label: 'Item 3' },
+              ];
+            },
+            templates: {
+              item({ item }) {
+                return item.label;
+              },
+            },
+          },
+        ];
+      },
+    });
+
+    // Wait for the panel to open
+    await waitFor(() => {
+      expect(
+        document.querySelector<HTMLElement>('.aa-Panel')
+      ).toBeInTheDocument();
+    });
+
+    userEvent.click(document.querySelector('.aa-Input')!);
+    userEvent.tab({ shift: true });
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.aa-DetachedOverlay')
+      ).not.toBeInTheDocument();
+      expect(document.body).not.toHaveClass('aa-Detached');
+      expect(document.activeElement).toEqual(
+        document.querySelector('.aa-SubmitButton')
+      );
+    });
   });
 });

--- a/packages/autocomplete-js/src/__tests__/detached.test.ts
+++ b/packages/autocomplete-js/src/__tests__/detached.test.ts
@@ -1,7 +1,16 @@
-import { fireEvent, waitFor } from '@testing-library/dom';
+import {
+  fireEvent,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
 
 import { createMatchMedia } from '../../../../test/utils';
 import { autocomplete } from '../autocomplete';
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
 
 describe('detached', () => {
   beforeAll(() => {
@@ -137,6 +146,114 @@ describe('detached', () => {
     cancelButton.click();
 
     // The detached overlay should close
+    await waitFor(() => {
+      expect(
+        document.querySelector('.aa-DetachedOverlay')
+      ).not.toBeInTheDocument();
+      expect(document.body).not.toHaveClass('aa-Detached');
+    });
+  });
+
+  test('stays open after clear when `openOnFocus` is `true`', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    autocomplete<{ label: string }>({
+      id: 'autocomplete',
+      detachedMediaQuery: '',
+      openOnFocus: true,
+      container,
+      initialState: {
+        query: 'a',
+        isOpen: true,
+      },
+      getSources() {
+        return [
+          {
+            sourceId: 'testSource',
+            getItems() {
+              return [
+                { label: 'Item 1' },
+                { label: 'Item 2' },
+                { label: 'Item 3' },
+              ];
+            },
+            templates: {
+              item({ item }) {
+                return item.label;
+              },
+            },
+          },
+        ];
+      },
+    });
+
+    // Wait for the panel to open
+    await waitFor(() => {
+      expect(
+        document.querySelector<HTMLElement>('.aa-Panel')
+      ).toBeInTheDocument();
+    });
+
+    // Clear the query
+    userEvent.click(
+      document.querySelector<HTMLButtonElement>('.aa-ClearButton')
+    );
+
+    // Ensures the overlay never disappears
+    await waitForElementToBeRemoved(
+      document.querySelector('.aa-DetachedOverlay')
+    ).catch(() => {});
+
+    await waitFor(() => {
+      expect(document.querySelector('.aa-DetachedOverlay')).toBeInTheDocument();
+      expect(document.body).toHaveClass('aa-Detached');
+    });
+  });
+
+  test('closes after clear when `openOnFocus` is `false`', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    autocomplete<{ label: string }>({
+      id: 'autocomplete',
+      detachedMediaQuery: '',
+      container,
+      initialState: {
+        query: 'a',
+        isOpen: true,
+      },
+      getSources() {
+        return [
+          {
+            sourceId: 'testSource',
+            getItems() {
+              return [
+                { label: 'Item 1' },
+                { label: 'Item 2' },
+                { label: 'Item 3' },
+              ];
+            },
+            templates: {
+              item({ item }) {
+                return item.label;
+              },
+            },
+          },
+        ];
+      },
+    });
+
+    // Wait for the panel to open
+    await waitFor(() => {
+      expect(
+        document.querySelector<HTMLElement>('.aa-Panel')
+      ).toBeInTheDocument();
+    });
+
+    // Clear the query
+    userEvent.click(
+      document.querySelector<HTMLButtonElement>('.aa-ClearButton')
+    );
+
     await waitFor(() => {
       expect(
         document.querySelector('.aa-DetachedOverlay')

--- a/packages/autocomplete-js/src/__tests__/detached.test.ts
+++ b/packages/autocomplete-js/src/__tests__/detached.test.ts
@@ -216,6 +216,7 @@ describe('detached', () => {
     autocomplete<{ label: string }>({
       id: 'autocomplete',
       detachedMediaQuery: '',
+      openOnFocus: false,
       container,
       initialState: {
         query: 'a',

--- a/packages/autocomplete-js/src/__tests__/detached.test.ts
+++ b/packages/autocomplete-js/src/__tests__/detached.test.ts
@@ -196,7 +196,7 @@ describe('detached', () => {
 
     // Clear the query
     userEvent.click(
-      document.querySelector<HTMLButtonElement>('.aa-ClearButton')
+      document.querySelector<HTMLButtonElement>('.aa-ClearButton')!
     );
 
     // Ensures the overlay never disappears

--- a/packages/autocomplete-js/src/__tests__/detached.test.ts
+++ b/packages/autocomplete-js/src/__tests__/detached.test.ts
@@ -252,7 +252,7 @@ describe('detached', () => {
 
     // Clear the query
     userEvent.click(
-      document.querySelector<HTMLButtonElement>('.aa-ClearButton')
+      document.querySelector<HTMLButtonElement>('.aa-ClearButton')!
     );
 
     await waitFor(() => {
@@ -260,6 +260,116 @@ describe('detached', () => {
         document.querySelector('.aa-DetachedOverlay')
       ).not.toBeInTheDocument();
       expect(document.body).not.toHaveClass('aa-Detached');
+    });
+  });
+
+  test('stays open and focuses the next focusable element on `Tab`', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    autocomplete<{ label: string }>({
+      id: 'autocomplete',
+      detachedMediaQuery: '',
+      container,
+      initialState: {
+        query: 'a',
+        isOpen: true,
+      },
+      getSources() {
+        return [
+          {
+            sourceId: 'testSource',
+            getItems() {
+              return [
+                { label: 'Item 1' },
+                { label: 'Item 2' },
+                { label: 'Item 3' },
+              ];
+            },
+            templates: {
+              item({ item }) {
+                return item.label;
+              },
+            },
+          },
+        ];
+      },
+    });
+
+    // Wait for the panel to open
+    await waitFor(() => {
+      expect(
+        document.querySelector<HTMLElement>('.aa-Panel')
+      ).toBeInTheDocument();
+    });
+
+    userEvent.tab();
+
+    // Ensures the overlay never disappears
+    await waitForElementToBeRemoved(
+      document.querySelector('.aa-DetachedOverlay')
+    ).catch(() => {});
+
+    await waitFor(() => {
+      expect(document.querySelector('.aa-DetachedOverlay')).toBeInTheDocument();
+      expect(document.body).toHaveClass('aa-Detached');
+      expect(document.activeElement).toEqual(
+        document.querySelector('.aa-ClearButton')
+      );
+    });
+  });
+
+  test('stays open and focuses the previous focusable element on `Shift+Tab`', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    autocomplete<{ label: string }>({
+      id: 'autocomplete',
+      detachedMediaQuery: '',
+      container,
+      initialState: {
+        query: 'a',
+        isOpen: true,
+      },
+      getSources() {
+        return [
+          {
+            sourceId: 'testSource',
+            getItems() {
+              return [
+                { label: 'Item 1' },
+                { label: 'Item 2' },
+                { label: 'Item 3' },
+              ];
+            },
+            templates: {
+              item({ item }) {
+                return item.label;
+              },
+            },
+          },
+        ];
+      },
+    });
+
+    // Wait for the panel to open
+    await waitFor(() => {
+      expect(
+        document.querySelector<HTMLElement>('.aa-Panel')
+      ).toBeInTheDocument();
+    });
+
+    userEvent.tab({ shift: true });
+
+    // Ensures the overlay never disappears
+    await waitForElementToBeRemoved(
+      document.querySelector('.aa-DetachedOverlay')
+    ).catch(() => {});
+
+    await waitFor(() => {
+      expect(document.querySelector('.aa-DetachedOverlay')).toBeInTheDocument();
+      expect(document.body).toHaveClass('aa-Detached');
+      expect(document.activeElement).toEqual(
+        document.querySelector('.aa-SubmitButton')
+      );
     });
   });
 });

--- a/packages/autocomplete-js/src/__tests__/positioning.test.ts
+++ b/packages/autocomplete-js/src/__tests__/positioning.test.ts
@@ -191,7 +191,7 @@ describe('Panel positioning', () => {
       right: '1020px',
     });
 
-    input.blur();
+    userEvent.click(document.body);
 
     // Move the root vertically
     root.getBoundingClientRect = jest

--- a/packages/autocomplete-js/src/createAutocompleteDom.ts
+++ b/packages/autocomplete-js/src/createAutocompleteDom.ts
@@ -101,12 +101,6 @@ export function createAutocompleteDom<TItem extends BaseItem>({
     getInputProps: propGetters.getInputProps,
     getInputPropsCore: autocomplete.getInputProps,
     autocompleteScopeApi,
-    onDetachedEscape: isDetached
-      ? () => {
-          autocomplete.setIsOpen(false);
-          setIsModalOpen(false);
-        }
-      : undefined,
   });
 
   const inputWrapperPrefix = createDomElement('div', {

--- a/packages/autocomplete-js/src/createAutocompleteDom.ts
+++ b/packages/autocomplete-js/src/createAutocompleteDom.ts
@@ -4,7 +4,6 @@ import {
   AutocompleteScopeApi,
   BaseItem,
 } from '@algolia/autocomplete-core';
-import { noop } from '@algolia/autocomplete-shared';
 
 import { ClearIcon, Input, LoadingIcon, SearchIcon } from './elements';
 import { getCreateDomElement } from './getCreateDomElement';
@@ -102,8 +101,7 @@ export function createAutocompleteDom<TItem extends BaseItem>({
     getInputProps: propGetters.getInputProps,
     getInputPropsCore: autocomplete.getInputProps,
     autocompleteScopeApi,
-    // In detached mode we don't want to close the panel when hittin `Tab`.
-    onDetachedTab: isDetached ? noop : undefined,
+    isDetached,
   });
 
   const inputWrapperPrefix = createDomElement('div', {

--- a/packages/autocomplete-js/src/createAutocompleteDom.ts
+++ b/packages/autocomplete-js/src/createAutocompleteDom.ts
@@ -4,6 +4,7 @@ import {
   AutocompleteScopeApi,
   BaseItem,
 } from '@algolia/autocomplete-core';
+import { noop } from '@algolia/autocomplete-shared';
 
 import { ClearIcon, Input, LoadingIcon, SearchIcon } from './elements';
 import { getCreateDomElement } from './getCreateDomElement';
@@ -101,6 +102,8 @@ export function createAutocompleteDom<TItem extends BaseItem>({
     getInputProps: propGetters.getInputProps,
     getInputPropsCore: autocomplete.getInputProps,
     autocompleteScopeApi,
+    // In detached mode we don't want to close the panel when hittin `Tab`.
+    onDetachedTab: isDetached ? noop : undefined,
   });
 
   const inputWrapperPrefix = createDomElement('div', {

--- a/packages/autocomplete-js/src/elements/Input.ts
+++ b/packages/autocomplete-js/src/elements/Input.ts
@@ -14,7 +14,7 @@ type InputProps = {
   environment: AutocompleteEnvironment;
   getInputProps: AutocompletePropGetters<any>['getInputProps'];
   getInputPropsCore: AutocompleteCoreApi<any>['getInputProps'];
-  onDetachedTab?(): void;
+  isDetached: boolean;
   state: AutocompleteState<any>;
 };
 
@@ -24,7 +24,7 @@ export const Input: AutocompleteElement<InputProps, HTMLInputElement> = ({
   classNames,
   getInputProps,
   getInputPropsCore,
-  onDetachedTab,
+  isDetached,
   state,
   ...props
 }) => {
@@ -40,9 +40,8 @@ export const Input: AutocompleteElement<InputProps, HTMLInputElement> = ({
   setProperties(element, {
     ...inputProps,
     onKeyDown(event: KeyboardEvent) {
-      if (onDetachedTab && event.key === 'Tab') {
-        onDetachedTab();
-
+      // In detached mode we don't want to close the panel when hittin `Tab`.
+      if (isDetached && event.key === 'Tab') {
         return;
       }
 

--- a/packages/autocomplete-js/src/elements/Input.ts
+++ b/packages/autocomplete-js/src/elements/Input.ts
@@ -14,7 +14,6 @@ type InputProps = {
   environment: AutocompleteEnvironment;
   getInputProps: AutocompletePropGetters<any>['getInputProps'];
   getInputPropsCore: AutocompleteCoreApi<any>['getInputProps'];
-  onDetachedEscape?(): void;
   state: AutocompleteState<any>;
 };
 
@@ -24,7 +23,6 @@ export const Input: AutocompleteElement<InputProps, HTMLInputElement> = ({
   classNames,
   getInputProps,
   getInputPropsCore,
-  onDetachedEscape,
   state,
   ...props
 }) => {
@@ -37,18 +35,7 @@ export const Input: AutocompleteElement<InputProps, HTMLInputElement> = ({
     ...autocompleteScopeApi,
   });
 
-  setProperties(element, {
-    ...inputProps,
-    onKeyDown(event: KeyboardEvent) {
-      if (onDetachedEscape && event.key === 'Escape') {
-        event.preventDefault();
-        onDetachedEscape();
-        return;
-      }
-
-      inputProps.onKeyDown(event);
-    },
-  });
+  setProperties(element, inputProps);
 
   return element;
 };

--- a/packages/autocomplete-js/src/elements/Input.ts
+++ b/packages/autocomplete-js/src/elements/Input.ts
@@ -14,6 +14,7 @@ type InputProps = {
   environment: AutocompleteEnvironment;
   getInputProps: AutocompletePropGetters<any>['getInputProps'];
   getInputPropsCore: AutocompleteCoreApi<any>['getInputProps'];
+  onDetachedTab?(): void;
   state: AutocompleteState<any>;
 };
 
@@ -23,6 +24,7 @@ export const Input: AutocompleteElement<InputProps, HTMLInputElement> = ({
   classNames,
   getInputProps,
   getInputPropsCore,
+  onDetachedTab,
   state,
   ...props
 }) => {
@@ -35,7 +37,18 @@ export const Input: AutocompleteElement<InputProps, HTMLInputElement> = ({
     ...autocompleteScopeApi,
   });
 
-  setProperties(element, inputProps);
+  setProperties(element, {
+    ...inputProps,
+    onKeyDown(event: KeyboardEvent) {
+      if (onDetachedTab && event.key === 'Tab') {
+        onDetachedTab();
+
+        return;
+      }
+
+      inputProps.onKeyDown(event);
+    },
+  });
 
   return element;
 };


### PR DESCRIPTION
This PR fixes a bug in detached mode where clicking the reset button would also close the modal, even with `openOnFocus=true`. This bug appeared only on pointer devices, not on touch devices.

## Preview

Here are a gew scenarios that this PR fixes. You can test it out in [this sandbox](https://mqnib7.csb.app/). To compare, here's the [same sandbox without the fix](https://nt0gqu.csb.app/).

<table>
<thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr>
<td>

https://user-images.githubusercontent.com/5370675/168618662-6b647834-bae2-4fc8-b638-c7b5063d87b1.mov

<small>The modal closes on reset.</small>
</td>
<td>

https://user-images.githubusercontent.com/5370675/174252527-21045a57-4171-401d-b017-4495d5d0057d.mov

<small>The modal stays open on reset.</small>
</td>
</tr>
<tr>
<td>

https://user-images.githubusercontent.com/5370675/168618425-16ee2f20-dae4-452c-ba3e-6635e59a867b.mov

<small>The panel "flickers": it closes then reopens on focus.</small>
</td>
<td>

https://user-images.githubusercontent.com/5370675/174252049-14c7319b-790a-40db-b0c0-46a866c04c31.mov

<small>The panel stays open, there's no flicker.</small>
</td>
</tr>
<tr>
<td>

https://user-images.githubusercontent.com/5370675/168619102-445e3df4-3223-4cc6-8bbd-7ace81d4e155.mov

<small>The modal stays open in detached mode on a touch device</small>
</td>
<td>

https://user-images.githubusercontent.com/5370675/174254035-8969fd20-0d0f-4873-9816-e2961eeda8cb.mov

<small>The modal still stays open in detached mode on a touch device</small>
</td>
</tr>
</tbody>
</table>

## Root cause

Clicking the reset button triggers the DOM `blur` event on the `<input>`. Before this fix, we had an `onBlur` handler that triggered logic that closed the search modal. This didn't happen on touch devices because of some [guard logic](https://github.com/algolia/autocomplete/blob/93a1fc25c720eb3f4fb3900c8f71e0423bd9a0d5/packages/autocomplete-core/src/getPropGetters.ts#L62) that [only applied to touch devices](https://github.com/algolia/autocomplete/blob/93a1fc25c720eb3f4fb3900c8f71e0423bd9a0d5/packages/autocomplete-core/src/getPropGetters.ts#L213).

This is a problem, because **detached mode isn't touch-specific**: it's the default mode on screens below 500px, and users can enable it with manually.

[**More context in the issue →**](https://github.com/algolia/autocomplete/issues/971#issuecomment-1132961504)

## Solution

This PR fixes the problem by no longer relying on the `blur` input event, and instead using the `mousedown` event at the environment level. This is a similar approach to what we're doing with the `touchstart` event, but for pointer devices. Both handlers reuse the same logic, and are colocated.

>The `blur` event isn't only triggered by "clicks" or "touches" outside of the focused element, it also happens when we hit `Enter` or `Escape`—the difference being that these are intentional blurs that we don't need to guard. The relevant part of the `onBlur` handler for these events (canceling all pending requests) was added to these event's handlers, in `onKeyDown`.

The rationale behind choosing this path is the following:
- **We should avoid conditionals as much as we can on large pieces of logic**, especially for core behaviors.
- The current logic needs access to the `formElement` and `panelElement`. Keeping the `onBlur` handler would mean making these elements available in `getInputProps`, which would be complicated, **and a breaking change**.
- **It's easier to respond to direct events** (e.g., `reset`, `keydown`, etc.) than consequential events, particularly because we know exactly what caused them. Tracing the origin on a `blur` isn't always possible.

## Output

This PR fixes the issue, and solves other problems in the process:
- When resetting the form, but you're not in detached mode, you no longer have a flash of the panel closing then reopening (see preview at the top).
- Triggering `Escape` in detached mode on touch devices was still vulnerable to stale promises due to some [outdated logic](https://github.com/algolia/autocomplete/pull/987/files#r899847862) that was removed in this PR. This was an unlikely scenario anyway, since you don't use `Escape` on most mobile and tablet devices. Still, it could technically happen on some computers with touch screens.

## Next steps

- We might not have enough high-level tests, and it's difficult to cover all scenarios on all devices. In the future, it would be highly beneficial to be able to write high-level test suites and run them on multiple devices. We could probably use our BrowserStack account for this.
- We should ensure our behavioral tests interact with the library like a user would do—users don't call `blur()` on an input, they click on things or press keys. They don't call `reset()` on a form, they click a reset button, etc. We do this irregularly in our tests, which causes false negatives and positives. We should do a pass to straighten this out.

fixes https://github.com/algolia/autocomplete/issues/971