### PR TITLE
docs: add TSDoc for cancelable promise list methods

### DIFF
--- a/packages/autocomplete-core/src/utils/createCancelablePromiseList.ts
+++ b/packages/autocomplete-core/src/utils/createCancelablePromiseList.ts
@@ -1,8 +1,22 @@
 import { CancelablePromise } from '.';
 
 export type CancelablePromiseList<TValue> = {
+  /**
+   * Add a cancelable promise to the list.
+   *
+   * @param cancelablePromise The cancelable promise to add.
+   */
   add(cancelablePromise: CancelablePromise<TValue>): CancelablePromise<TValue>;
+  /**
+   * Cancel all pending promises.
+   *
+   * Requests aren't actually stopped. All pending promises will settle, but
+   * attached handlers won't run.
+   */
   cancelAll(): void;
+  /**
+   * Whether there are pending promises in the list.
+   */
   isEmpty(): boolean;
 };
 


### PR DESCRIPTION
This documents the `CancelablePromiseList` methods, as requested by @Haroenv in https://github.com/algolia/autocomplete/pull/987#discussion_r901546628.