### PR TITLE
fix(preset-algolia): support algoliasearch v5

### DIFF
--- a/packages/autocomplete-preset-algolia/package.json
+++ b/packages/autocomplete-preset-algolia/package.json
@@ -38,7 +38,7 @@
     "algoliasearch": "4.9.1"
   },
   "peerDependencies": {
-    "@algolia/client-search": "^4.9.1",
-    "algoliasearch": "^4.9.1"
+    "@algolia/client-search": ">= 4.9.1 < 6",
+    "algoliasearch": ">= 4.9.1 < 6"
   }
 }

--- a/packages/autocomplete-preset-algolia/src/highlight/HighlightedHit.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/HighlightedHit.ts
@@ -1,4 +1,4 @@
-import { HighlightResult } from '@algolia/client-search';
+import { HighlightResult } from '../types';
 
 export type HighlightedHit<THit> = THit & {
   _highlightResult?: HighlightResult<THit>;

--- a/packages/autocomplete-preset-algolia/src/highlight/SnippetedHit.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/SnippetedHit.ts
@@ -1,4 +1,4 @@
-import { SnippetResult } from '@algolia/client-search';
+import { SnippetResult } from '../types';
 
 export type SnippetedHit<THit> = THit & {
   _snippetResult?: SnippetResult<THit>;

--- a/packages/autocomplete-preset-algolia/src/requester/createRequester.ts
+++ b/packages/autocomplete-preset-algolia/src/requester/createRequester.ts
@@ -1,11 +1,10 @@
-import {
+import { fetchAlgoliaResults } from '../search';
+import type {
   MultipleQueriesQuery,
   SearchForFacetValuesResponse,
   SearchResponse,
-} from '@algolia/client-search';
-import { SearchClient } from 'algoliasearch/lite';
-
-import { fetchAlgoliaResults } from '../search';
+  SearchClient,
+} from '../types';
 
 type Fetcher = typeof fetchAlgoliaResults;
 

--- a/packages/autocomplete-preset-algolia/src/requester/getAlgoliaFacets.ts
+++ b/packages/autocomplete-preset-algolia/src/requester/getAlgoliaFacets.ts
@@ -1,4 +1,4 @@
-import { MultipleQueriesQuery } from '@algolia/client-search';
+import type { MultipleQueriesQuery } from '../types';
 
 import { createAlgoliaRequester } from './createAlgoliaRequester';
 import { RequestParams } from './createRequester';

--- a/packages/autocomplete-preset-algolia/src/search/fetchAlgoliaResults.ts
+++ b/packages/autocomplete-preset-algolia/src/search/fetchAlgoliaResults.ts
@@ -2,14 +2,14 @@ import {
   userAgents as coreUserAgents,
   UserAgent,
 } from '@algolia/autocomplete-shared';
-import {
+
+import { HIGHLIGHT_PRE_TAG, HIGHLIGHT_POST_TAG } from '../constants';
+import type {
   MultipleQueriesQuery,
   SearchForFacetValuesResponse,
   SearchResponse,
-} from '@algolia/client-search';
-import type { SearchClient } from 'algoliasearch/lite';
-
-import { HIGHLIGHT_PRE_TAG, HIGHLIGHT_POST_TAG } from '../constants';
+  SearchClient,
+} from '../types';
 
 export interface SearchParams {
   /**

--- a/packages/autocomplete-preset-algolia/src/types/algoliasearch.ts
+++ b/packages/autocomplete-preset-algolia/src/types/algoliasearch.ts
@@ -1,0 +1,71 @@
+import * as ClientSearch from '@algolia/client-search';
+import type * as AlgoliaSearch from 'algoliasearch/lite';
+
+// turns any to unknown, so it can be used as a conditional
+type AnyToUnknown<TSubject> = (any extends TSubject ? true : false) extends true
+  ? unknown
+  : TSubject;
+
+type SearchClientShape = {
+  search: unknown;
+};
+
+type ClientLiteV5 = AnyToUnknown<
+  // @ts-ignore
+  ReturnType<typeof AlgoliaSearch.liteClient>
+>;
+type ClientSearchV5 = AnyToUnknown<
+  // @ts-ignore
+  ReturnType<typeof ClientSearch.searchClient>
+>;
+type ClientV5 = ClientLiteV5 extends SearchClientShape
+  ? ClientLiteV5
+  : ClientSearchV5 extends SearchClientShape
+  ? ClientSearchV5
+  : unknown;
+
+type PickForClient<
+  TMapping extends { v4: unknown; v5: unknown }
+> = ClientV5 extends SearchClientShape ? TMapping['v5'] : TMapping['v4'];
+
+export type SearchClient = PickForClient<{
+  // @ts-ignore
+  v4: AlgoliaSearch.SearchClient;
+  // @ts-ignore
+  v5: ClientV5;
+}>;
+
+export type MultipleQueriesQuery = PickForClient<{
+  // @ts-ignore
+  v4: ClientSearch.MultipleQueriesQuery;
+  // @ts-ignore
+  v5: AlgoliaSearch.LegacySearchMethodProps[number];
+}>;
+
+export type SearchForFacetValuesResponse = PickForClient<{
+  // @ts-ignore
+  v4: ClientSearch.SearchForFacetValuesResponse;
+  // @ts-ignore
+  v5: AlgoliaSearch.SearchForFacetValuesResponse;
+}>;
+
+export type SearchResponse<THit> = PickForClient<{
+  // @ts-ignore
+  v4: ClientSearch.SearchResponse<THit>;
+  // @ts-ignore
+  v5: AlgoliaSearch.SearchResponse; // should be generic, but isn't yet in the client
+}>;
+
+export type HighlightResult<THit> = PickForClient<{
+  // @ts-ignore
+  v4: ClientSearch.HighlightResult<THit>;
+  // @ts-ignore
+  v5: AlgoliaSearch.HighlightResult; // should be generic, but isn't yet in the client
+}>;
+
+export type SnippetResult<THit> = PickForClient<{
+  // @ts-ignore
+  v4: ClientSearch.SnippetResult<THit>;
+  // @ts-ignore
+  v5: AlgoliaSearch.SnippetResult; // should be generic, but isn't yet in the client
+}>;

--- a/packages/autocomplete-preset-algolia/src/types/algoliasearch.ts
+++ b/packages/autocomplete-preset-algolia/src/types/algoliasearch.ts
@@ -53,7 +53,7 @@ export type SearchResponse<THit> = PickForClient<{
   // @ts-ignore
   v4: ClientSearch.SearchResponse<THit>;
   // @ts-ignore
-  v5: AlgoliaSearch.SearchResponse; // should be generic, but isn't yet in the client
+  v5: AlgoliaSearch.SearchResponse<THit>;
 }>;
 
 export type HighlightResult<THit> = PickForClient<{

--- a/packages/autocomplete-preset-algolia/src/types/index.ts
+++ b/packages/autocomplete-preset-algolia/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './algoliasearch';


### PR DESCRIPTION
Similar to https://github.com/algolia/algoliasearch-helper-js/pull/910, but with support for v4 and v5 only

to try this out you can use a dependency like this:

```json
  "dependencies": {
    "algoliasearch": "npm:@experimental-api-clients-automation/algoliasearch@0.7.2"
  },
```