### PR TITLE
fix(react-renderer): panel now closes when clicking/touching outside

### DIFF
--- a/examples/react-renderer/src/App.tsx
+++ b/examples/react-renderer/src/App.tsx
@@ -6,7 +6,7 @@ import './App.css';
 export function App() {
   return (
     <div className="container">
-      <Autocomplete placeholder="Search" openOnFocus={true} debug={true} />
+      <Autocomplete placeholder="Search" openOnFocus={true} />
     </div>
   );
 }

--- a/examples/react-renderer/src/Autocomplete.tsx
+++ b/examples/react-renderer/src/Autocomplete.tsx
@@ -89,20 +89,22 @@ export function Autocomplete(
       return undefined;
     }
 
-    const { onTouchStart, onTouchMove } = getEnvironmentProps({
+    const { onTouchStart, onTouchMove, onMouseDown } = getEnvironmentProps({
       formElement: formRef.current,
       inputElement: inputRef.current,
       panelElement: panelRef.current,
     });
 
+    window.addEventListener('mousedown', onMouseDown);
     window.addEventListener('touchstart', onTouchStart);
     window.addEventListener('touchmove', onTouchMove);
 
     return () => {
+      window.removeEventListener('mousedown', onMouseDown);
       window.removeEventListener('touchstart', onTouchStart);
       window.removeEventListener('touchmove', onTouchMove);
     };
-  }, [getEnvironmentProps, formRef, inputRef, panelRef]);
+  }, [getEnvironmentProps, autocompleteState.isOpen]);
 
   return (
     <div className="aa-Autocomplete" {...autocomplete.getRootProps({})}>


### PR DESCRIPTION
[Our current custom renderer implementation with React](https://codesandbox.io/s/github/algolia/autocomplete/tree/next/examples/react-renderer?file=/src/Autocomplete.tsx) does not close the panel when clicking outside of it, even when `debug` is `false`.

The deps list in the `useEffect` should not have refs as they are stable, which also means previously the effect only ran once so the event listeners did not get added, which is why I added `autocompleteState.isOpen` as it will create a new ref for panel each time it's opened.
I also added a missing `mousedown` event so it works on desktop too.

Also removed the `debug` option as it prevents from closing when clicking outside, I don't think it should be kept as users base their implementations on our examples and it's not obvious that `debug` does this.