### PR TITLE
ci(renovate): enable automerge for minor and patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,21 @@
 {
-  "extends": ["config:js-lib", "algolia"],
+  "extends": [
+    "config:js-lib",
+    "schedule:monthly",
+    ":semanticCommitTypeAll(chore)"
+  ],
+  "timezone": "Europe/Paris",
   "packageRules": [
     {
       "packagePatterns": ["^@types"],
       "depTypeList": ["devDependencies"],
       "rangeStrategy": "replace"
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true,
+      "automergeType": "branch"
     }
   ]
 }


### PR DESCRIPTION
This enables monthly branch automerge for minor and patch updates.

On the first day of each month, Renovate will:
- Create a branch for each update, wait for test results
- Rebase it any time it gets out of date with the base branch
- Automerge the branch commit if it's up-to-date with the base branch, and passing all tests
- As a backup, raise a PR only if either tests fail, or tests remain pending for > 24 hours

## Summary

### automergeType

Using `automergeType: "branch"` instead of `automergeType: "pr"` allows for silent updates, because they don't generate GitHub notifications.

[See option →](https://docs.renovatebot.com/configuration-options/#automergetype)

### :semanticCommitTypeAll(chore)

This ensures all commits use the `chore` prefix. It prevents against updates using the `fix` prefix, which would trigger patch updates of the library.

[See preset →](https://docs.renovatebot.com/presets-default/#semanticcommittypeallarg0)

### matchCurrentVersion

Automerge will only occur for minor and patch updates unless the packages are `v0.x.x`.

[See option →](https://docs.renovatebot.com/configuration-options/#matchcurrentversion)

### Settings change

Historically we haven't been able to use automerge because of branch protection rules. While this is difficult to find consistent information on how to bypass that, [it _seems_ that we can get this to work](https://github.com/renovatebot/renovate/issues/846#issuecomment-528826053) by using the **Restrict who can push to matching branches** setting, like this:

![Capture d’écran 2022-11-23 à 12 09 12](https://user-images.githubusercontent.com/5370675/203532246-8a0276d9-79fa-4471-80a6-e83e7c86d3e5.png)

I haven't found any information that denies or confirms that it would work with `automergeType: "branch"` and while having **Require a pull request before merging** enabled as well. We'll have to try and see 🤷🏻‍♀️

If this PR is approved, I'll update the settings accordingly.

## Next steps

If this works, we can:
- Enable the same setup on the InstantSearch monorepo
- Update the [Algolia Renovate configuration](https://github.com/algolia/renovate-config-algolia)

FX-2025