### PR TITLE
fix(insights): add Algolia agent on `subscribe`

### DIFF
--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -64,6 +64,21 @@ describe('createAlgoliaInsightsPlugin', () => {
     );
   });
 
+  test('sets a user agent on the Insights client on subscribe', () => {
+    const insightsClient = jest.fn();
+    const insightsPlugin = createAlgoliaInsightsPlugin({ insightsClient });
+
+    expect(insightsClient).not.toHaveBeenCalled();
+
+    createPlayground(createAutocomplete, { plugins: [insightsPlugin] });
+
+    expect(insightsClient).toHaveBeenCalledTimes(1);
+    expect(insightsClient).toHaveBeenCalledWith(
+      'addAlgoliaAgent',
+      'insights-plugin'
+    );
+  });
+
   describe('onItemsChange', () => {
     test('sends a `viewedObjectIDs` event by default', async () => {
       const insightsClient = jest.fn();

--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -195,7 +195,10 @@ describe('createAlgoliaInsightsPlugin', () => {
       await runAllMicroTasks();
       jest.runAllTimers();
 
-      expect(insightsClient).not.toHaveBeenCalled();
+      expect(insightsClient).not.toHaveBeenCalledWith(
+        'viewedObjectIDs',
+        expect.any(Object)
+      );
     });
 
     test('debounces calls', async () => {
@@ -286,7 +289,10 @@ describe('createAlgoliaInsightsPlugin', () => {
       await runAllMicroTasks();
       jest.runAllTimers();
 
-      expect(insightsClient).not.toHaveBeenCalled();
+      expect(insightsClient).not.toHaveBeenCalledWith(
+        'viewedObjectIDs',
+        expect.any(Object)
+      );
     });
 
     test('does not send an event when there are no results', async () => {
@@ -311,7 +317,10 @@ describe('createAlgoliaInsightsPlugin', () => {
       await runAllMicroTasks();
       jest.runAllTimers();
 
-      expect(insightsClient).not.toHaveBeenCalled();
+      expect(insightsClient).not.toHaveBeenCalledWith(
+        'viewedObjectIDs',
+        expect.any(Object)
+      );
     });
   });
 
@@ -451,7 +460,10 @@ describe('createAlgoliaInsightsPlugin', () => {
 
       await runAllMicroTasks();
 
-      expect(insightsClient).not.toHaveBeenCalled();
+      expect(insightsClient).not.toHaveBeenCalledWith(
+        'clickedObjectIDsAfterSearch',
+        expect.any(Object)
+      );
     });
 
     test('does not send an event with non-Algolia Insights hits', async () => {
@@ -479,7 +491,10 @@ describe('createAlgoliaInsightsPlugin', () => {
 
       await runAllMicroTasks();
 
-      expect(insightsClient).not.toHaveBeenCalled();
+      expect(insightsClient).not.toHaveBeenCalledWith(
+        'viewedObjectIDs',
+        expect.any(Object)
+      );
     });
   });
 
@@ -507,6 +522,9 @@ describe('createAlgoliaInsightsPlugin', () => {
           ];
         },
       });
+
+      // The client is always called once with `addAlgoliaAgent` on `subscribe`
+      insightsClient.mockClear();
 
       inputElement.focus();
 

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -89,7 +89,6 @@ export function createAlgoliaInsightsPlugin(
     onSelect: onSelectEvent,
     onActive: onActiveEvent,
   } = getOptions(options);
-
   const insights = createSearchInsightsApi(insightsClient);
   const previousItems = createRef<AlgoliaInsightsHit[]>([]);
 
@@ -123,6 +122,8 @@ export function createAlgoliaInsightsPlugin(
   return {
     name: 'aa.algoliaInsightsPlugin',
     subscribe({ setContext, onSelect, onActive }) {
+      insightsClient('addAlgoliaAgent', 'insights-plugin');
+
       setContext({ algoliaInsightsPlugin: { insights } });
 
       onSelect(({ item, state, event }) => {


### PR DESCRIPTION
## Summary

This adds an Algolia agent on the Insights client when the plugin subscribes so that Insights calls coming from the plugin can be identified as such.

I'm making a direct call on the passed client and didn't implement an `addAlgoliaAgent` on the wrapped client that we expose in methods. This saves a few bytes, and we don't want users to ever add agents anyway.

Now that the Insights client sends at least one event on `subscribe`, some tests had to be tightened as they were causing false positives.

FX-2062