### PR TITLE
build(deps): update minor Core JS dependencies

### DIFF
--- a/examples/vue-instantsearch/package.json
+++ b/examples/vue-instantsearch/package.json
@@ -15,7 +15,7 @@
     "@algolia/autocomplete-plugin-recent-searches": "1.7.4",
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "algoliasearch": "4.14.3",
-    "core-js": "^3.6.5",
+    "core-js": "3.26.1",
     "vue": "3.2.45",
     "vue-instantsearch": "4.6.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8506,6 +8506,11 @@ core-js-pure@^3.20.2:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.20.3.tgz#6cc4f36da06c61d95254efc54024fe4797fd5d02"
   integrity sha512-Q2H6tQ5MtPtcC7f3HxJ48i4Q7T9ybPKgvWyuH7JXIoNa2pm0KuBnycsET/qw1SLLZYfbsbrZQNMeIOClb+6WIA==
 
+core-js@3.26.1:
+  version "3.26.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.26.1.tgz#7a9816dabd9ee846c1c0fe0e8fcad68f3709134e"
+  integrity sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA==
+
 core-js@^2.4.0:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"


### PR DESCRIPTION
We have a lot of Renovate PRs open and this is becoming difficult to merge since every PR must be up to date with the base branch.

This PR attempts at updating minor Core JS dependencies with low risk of breakage, so we can auto close a bunch of Renovate PRs. Later we'll also need to figure out how to make our Renovate setup work (or change it).

>I'm doing multiple PRs for minor dependencies because doing them all fails and it's hard to pinpoint what the problem is.