### PR TITLE
build(deps): update minor Preact dependencies

### DIFF
--- a/cypress/test-apps/js/package.json
+++ b/cypress/test-apps/js/package.json
@@ -18,7 +18,7 @@
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "@algolia/client-search": "4.14.3",
     "algoliasearch": "4.14.3",
-    "preact": "10.6.4",
+    "preact": "10.11.3",
     "search-insights": "1.7.1"
   },
   "devDependencies": {

--- a/examples/github-notification-filters/package.json
+++ b/examples/github-notification-filters/package.json
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-plugin-tags": "1.7.4",
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "algoliasearch": "4.14.3",
-    "preact": "10.5.13",
+    "preact": "10.11.3",
     "qs": "6.11.0"
   },
   "devDependencies": {

--- a/examples/github-repositories-custom-plugin/package.json
+++ b/examples/github-repositories-custom-plugin/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.7.4",
     "@algolia/autocomplete-theme-classic": "1.7.4",
-    "preact": "10.5.13",
+    "preact": "10.11.3",
     "qs": "6.11.0"
   },
   "devDependencies": {

--- a/examples/multiple-datasets-with-headers/package.json
+++ b/examples/multiple-datasets-with-headers/package.json
@@ -14,7 +14,7 @@
     "@algolia/autocomplete-plugin-recent-searches": "1.7.4",
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "algoliasearch": "4.14.3",
-    "preact": "10.5.13"
+    "preact": "10.11.3"
   },
   "devDependencies": {
     "parcel": "2.8.2"

--- a/examples/panel-placement/package.json
+++ b/examples/panel-placement/package.json
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-js": "1.7.4",
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "algoliasearch": "4.14.3",
-    "preact": "10.5.13"
+    "preact": "10.11.3"
   },
   "devDependencies": {
     "@algolia/client-search": "4.14.3",

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -17,7 +17,7 @@
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "@algolia/client-search": "4.14.3",
     "algoliasearch": "4.14.3",
-    "preact": "10.5.13",
+    "preact": "10.11.3",
     "search-insights": "1.7.1"
   },
   "devDependencies": {

--- a/examples/preview-panel-in-modal/package.json
+++ b/examples/preview-panel-in-modal/package.json
@@ -12,7 +12,7 @@
     "@algolia/autocomplete-js": "1.7.4",
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "algoliasearch": "4.14.3",
-    "preact": "10.5.13",
+    "preact": "10.11.3",
     "qs": "6.11.0"
   },
   "devDependencies": {

--- a/examples/query-suggestions-with-categories/package.json
+++ b/examples/query-suggestions-with-categories/package.json
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-plugin-query-suggestions": "1.7.4",
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "algoliasearch": "4.14.3",
-    "preact": "10.5.13"
+    "preact": "10.11.3"
   },
   "devDependencies": {
     "parcel": "2.8.2"

--- a/examples/query-suggestions-with-hits/package.json
+++ b/examples/query-suggestions-with-hits/package.json
@@ -17,7 +17,7 @@
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "@algolia/client-search": "4.14.3",
     "algoliasearch": "4.14.3",
-    "preact": "10.5.13",
+    "preact": "10.11.3",
     "search-insights": "1.7.1"
   },
   "devDependencies": {

--- a/examples/query-suggestions-with-inline-categories/package.json
+++ b/examples/query-suggestions-with-inline-categories/package.json
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-plugin-query-suggestions": "1.7.4",
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "algoliasearch": "4.14.3",
-    "preact": "10.5.13"
+    "preact": "10.11.3"
   },
   "devDependencies": {
     "parcel": "2.8.2"

--- a/examples/query-suggestions-with-recent-searches-and-categories/package.json
+++ b/examples/query-suggestions-with-recent-searches-and-categories/package.json
@@ -15,7 +15,7 @@
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "@algolia/client-search": "4.14.3",
     "algoliasearch": "4.14.3",
-    "preact": "10.5.13"
+    "preact": "10.11.3"
   },
   "devDependencies": {
     "parcel": "2.8.2"

--- a/examples/query-suggestions-with-recent-searches/package.json
+++ b/examples/query-suggestions-with-recent-searches/package.json
@@ -14,7 +14,7 @@
     "@algolia/autocomplete-plugin-recent-searches": "1.7.4",
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "algoliasearch": "4.14.3",
-    "preact": "10.5.13"
+    "preact": "10.11.3"
   },
   "devDependencies": {
     "parcel": "2.8.2"

--- a/examples/query-suggestions/package.json
+++ b/examples/query-suggestions/package.json
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-plugin-query-suggestions": "1.7.4",
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "algoliasearch": "4.14.3",
-    "preact": "10.5.13"
+    "preact": "10.11.3"
   },
   "devDependencies": {
     "parcel": "2.8.2"

--- a/examples/recently-viewed-items/package.json
+++ b/examples/recently-viewed-items/package.json
@@ -14,7 +14,7 @@
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "@algolia/client-search": "4.14.3",
     "algoliasearch": "4.14.3",
-    "preact": "10.5.13"
+    "preact": "10.11.3"
   },
   "devDependencies": {
     "@algolia/autocomplete-core": "1.7.4",

--- a/examples/reshape/package.json
+++ b/examples/reshape/package.json
@@ -17,7 +17,7 @@
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "@algolia/client-search": "4.14.3",
     "algoliasearch": "4.14.3",
-    "preact": "10.5.13",
+    "preact": "10.11.3",
     "ramda": "0.27.1",
     "search-insights": "1.7.1"
   },

--- a/examples/starter-algolia/package.json
+++ b/examples/starter-algolia/package.json
@@ -12,7 +12,7 @@
     "@algolia/autocomplete-js": "1.7.4",
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "algoliasearch": "4.14.3",
-    "preact": "10.5.13"
+    "preact": "10.11.3"
   },
   "devDependencies": {
     "@algolia/client-search": "4.14.3",

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.7.4",
     "@algolia/autocomplete-theme-classic": "1.7.4",
-    "preact": "10.5.13"
+    "preact": "10.11.3"
   },
   "devDependencies": {
     "parcel": "2.8.2"

--- a/examples/tags-in-searchbox/package.json
+++ b/examples/tags-in-searchbox/package.json
@@ -15,7 +15,7 @@
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "@algolia/client-search": "4.14.3",
     "algoliasearch": "4.14.3",
-    "preact": "10.5.13",
+    "preact": "10.11.3",
     "ramda": "0.27.1",
     "search-insights": "1.7.1"
   },

--- a/examples/tags-with-hits/package.json
+++ b/examples/tags-with-hits/package.json
@@ -15,7 +15,7 @@
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "@algolia/client-search": "4.14.3",
     "algoliasearch": "4.14.3",
-    "preact": "10.5.13",
+    "preact": "10.11.3",
     "ramda": "0.27.1",
     "search-insights": "1.7.1"
   },

--- a/examples/voice-search/package.json
+++ b/examples/voice-search/package.json
@@ -12,7 +12,7 @@
     "@algolia/autocomplete-js": "1.7.4",
     "@algolia/autocomplete-theme-classic": "1.7.4",
     "algoliasearch": "4.14.3",
-    "preact": "10.5.13"
+    "preact": "10.11.3"
   },
   "devDependencies": {
     "@algolia/client-search": "4.14.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17572,17 +17572,17 @@ posthtml@^0.16.4, posthtml@^0.16.5:
     posthtml-parser "^0.11.0"
     posthtml-render "^3.0.0"
 
-preact@10.5.13:
-  version "10.5.13"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.13.tgz#85f6c9197ecd736ce8e3bec044d08fd1330fa019"
-  integrity sha512-q/vlKIGNwzTLu+jCcvywgGrt+H/1P/oIRSD6mV4ln3hmlC+Aa34C7yfPI4+5bzW8pONyVXYS7SvXosy2dKKtWQ==
+preact@10.11.3:
+  version "10.11.3"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.11.3.tgz#8a7e4ba19d3992c488b0785afcc0f8aa13c78d19"
+  integrity sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==
 
 preact@10.5.14:
   version "10.5.14"
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.14.tgz#0b14a2eefba3c10a57116b90d1a65f5f00cd2701"
   integrity sha512-KojoltCrshZ099ksUZ2OQKfbH66uquFoxHSbnwKbTJHeQNvx42EmC7wQVWNuDt6vC5s3nudRHFtKbpY4ijKlaQ==
 
-preact@10.6.4, preact@^10.0.0:
+preact@^10.0.0:
   version "10.6.4"
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.6.4.tgz#ad12c409ff1b4316158486e0a7b8d43636f7ced8"
   integrity sha512-WyosM7pxGcndU8hY0OQlLd54tOU+qmG45QXj2dAYrL11HoyU/EzOSTlpJsirbBr1QW7lICxSsVJJmcmUglovHQ==


### PR DESCRIPTION
We have a lot of Renovate PRs open and this is becoming difficult to merge since every PR must be up to date with the base branch.

This PR attempts at updating minor Preact dependencies (aside from the `autocomplete-js` one which stays with `^10`) with low risk of breakage, so we can auto close a bunch of Renovate PRs. Later we'll also need to figure out how to make our Renovate setup work (or change it).

>I'm doing multiple PRs for minor dependencies because doing them all fails and it's hard to pinpoint what the problem is.