### PR TITLE
chore: Spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -673,7 +673,7 @@ This new version introduces breaking changes.
 ### Bug Fixes
 
 - **css:** don't display key shortcuts on mobile ([1adc418](https://github.com/francoischalifour/autocomplete.js/commit/1adc418722f0017b1d504e7d3f7dda8e8104a352))
-- **css:** firefox placeholder opacity ([49f7ac3](https://github.com/francoischalifour/autocomplete.js/commit/49f7ac3c9a7680a4e49593f278cb815d52d8d48b))
+- **css:** Firefox placeholder opacity ([49f7ac3](https://github.com/francoischalifour/autocomplete.js/commit/49f7ac3c9a7680a4e49593f278cb815d52d8d48b))
 - **docsearch:** remove theme media query ([a1030e4](https://github.com/francoischalifour/autocomplete.js/commit/a1030e493c22c5c615fa9c49e385030452b18729))
 - **test:** removed extra percy snapshot ([24e38b7](https://github.com/francoischalifour/autocomplete.js/commit/24e38b7771471609e190c5c1a61c57627126551a))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -705,7 +705,7 @@ This new version introduces breaking changes.
 - **cypress:** changed env var name for cypress key ([28307a8](https://github.com/francoischalifour/autocomplete.js/commit/28307a84c92b2fe79939cfa4e0755a44326de54c))
 - **docsearch:** hoist `transformItems` default value ([1e0ae9e](https://github.com/francoischalifour/autocomplete.js/commit/1e0ae9eefb5fc185cbf41e6ac5c876ed8be24075))
 - **lint:** Disable import/no-common for percy ([8af940d](https://github.com/francoischalifour/autocomplete.js/commit/8af940d69bf9eb35bcc70fbc533abdcf721ea209))
-- **lint:** set cariage return in prettier config ([3016601](https://github.com/francoischalifour/autocomplete.js/commit/3016601a47699a37e9fa30620e71eef3f30f8c6d))
+- **lint:** set carriage return in prettier config ([3016601](https://github.com/francoischalifour/autocomplete.js/commit/3016601a47699a37e9fa30620e71eef3f30f8c6d))
 - **lint:** set eol to auto ([e6db26e](https://github.com/francoischalifour/autocomplete.js/commit/e6db26e57aaf433b149dc16d9a846cdfa19c0314))
 - **test:** lint ([896ef59](https://github.com/francoischalifour/autocomplete.js/commit/896ef5959f06576f03d6ecd4ff7ee6ce96333a6d))
 - **ypress:** Record reuslts ([7dac93e](https://github.com/francoischalifour/autocomplete.js/commit/7dac93e6a538f69bfe44bfdfe0fbb939b0e241e1))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -708,7 +708,7 @@ This new version introduces breaking changes.
 - **lint:** set carriage return in prettier config ([3016601](https://github.com/francoischalifour/autocomplete.js/commit/3016601a47699a37e9fa30620e71eef3f30f8c6d))
 - **lint:** set eol to auto ([e6db26e](https://github.com/francoischalifour/autocomplete.js/commit/e6db26e57aaf433b149dc16d9a846cdfa19c0314))
 - **test:** lint ([896ef59](https://github.com/francoischalifour/autocomplete.js/commit/896ef5959f06576f03d6ecd4ff7ee6ce96333a6d))
-- **Cypress:** Record reuslts ([7dac93e](https://github.com/francoischalifour/autocomplete.js/commit/7dac93e6a538f69bfe44bfdfe0fbb939b0e241e1))
+- **Cypress:** Record results ([7dac93e](https://github.com/francoischalifour/autocomplete.js/commit/7dac93e6a538f69bfe44bfdfe0fbb939b0e241e1))
 
 # [1.0.0-alpha.18](https://github.com/francoischalifour/autocomplete.js/compare/v1.0.0-alpha.17...v1.0.0-alpha.18) (2020-06-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -708,7 +708,7 @@ This new version introduces breaking changes.
 - **lint:** set carriage return in prettier config ([3016601](https://github.com/francoischalifour/autocomplete.js/commit/3016601a47699a37e9fa30620e71eef3f30f8c6d))
 - **lint:** set eol to auto ([e6db26e](https://github.com/francoischalifour/autocomplete.js/commit/e6db26e57aaf433b149dc16d9a846cdfa19c0314))
 - **test:** lint ([896ef59](https://github.com/francoischalifour/autocomplete.js/commit/896ef5959f06576f03d6ecd4ff7ee6ce96333a6d))
-- **ypress:** Record reuslts ([7dac93e](https://github.com/francoischalifour/autocomplete.js/commit/7dac93e6a538f69bfe44bfdfe0fbb939b0e241e1))
+- **Cypress:** Record reuslts ([7dac93e](https://github.com/francoischalifour/autocomplete.js/commit/7dac93e6a538f69bfe44bfdfe0fbb939b0e241e1))
 
 # [1.0.0-alpha.18](https://github.com/francoischalifour/autocomplete.js/compare/v1.0.0-alpha.17...v1.0.0-alpha.18) (2020-06-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -731,7 +731,7 @@ This new version introduces breaking changes.
 ### Bug Fixes
 
 - **docsearch:** always use `aria-expanded` to `true` ([b89aeb5](https://github.com/francoischalifour/autocomplete.js/commit/b89aeb5c2eccb43b3657239c519caa34ed62299e))
-- **dosearch:** don't add `distinct` search parameter ([1c11457](https://github.com/francoischalifour/autocomplete.js/commit/1c1145768a74f372c683fbee9d0aaaf0dd3fb62a))
+- **docsearch:** don't add `distinct` search parameter ([1c11457](https://github.com/francoischalifour/autocomplete.js/commit/1c1145768a74f372c683fbee9d0aaaf0dd3fb62a))
 - **website:** don't pass default `appId` ([62e0609](https://github.com/francoischalifour/autocomplete.js/commit/62e060917b864e2a86328ea9816252d50c189654))
 - **website:** support missing `algolia` config ([4b30cdd](https://github.com/francoischalifour/autocomplete.js/commit/4b30cdd90bfb2226cfd5f34642ea1593a64f833b))
 - **website:** update netlify.com to netlify.app ([9cbb80b](https://github.com/francoischalifour/autocomplete.js/commit/9cbb80bb9078a7a19750e8f2bbef6e69ecce9cda))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -906,7 +906,7 @@ This new version introduces breaking changes.
 
 ### Bug Fixes
 
-- **dataset:** avoid to call the source when upadte is canceled ([a47696d](https://github.com/algolia/autocomplete.js/commit/a47696d))
+- **dataset:** avoid to call the source when update is canceled ([a47696d](https://github.com/algolia/autocomplete.js/commit/a47696d))
 - **dataset:** avoid usage of callNow for debounce ([1a0ce74](https://github.com/algolia/autocomplete.js/commit/1a0ce74))
 - Handle an odd case with the user agent ([#242](https://github.com/algolia/autocomplete.js/issues/242)) ([c194736](https://github.com/algolia/autocomplete.js/commit/c194736))
 

--- a/examples/recently-viewed-items/README.md
+++ b/examples/recently-viewed-items/README.md
@@ -20,7 +20,7 @@ git clone git@github.com:algolia/autocomplete.git
 
 ```sh
 yarn
-yarn workspace @algolia/autocomplete-example-recently-viwed-items start
+yarn workspace @algolia/autocomplete-example-recently-viewed-items start
 ```
 
 Alternatively, you may use npm:

--- a/examples/starter-algolia/README.md
+++ b/examples/starter-algolia/README.md
@@ -1,6 +1,6 @@
 # Autocomplete starter with Algolia index
 
-This example helps you quickly boostrap a basic Autocomplete experience using Algolia.
+This example helps you quickly bootstrap a basic Autocomplete experience using Algolia.
 
 <p align="center"><img src="capture.jpg" alt="A capture of the Autocomplete with Algolia" /></p>
 

--- a/examples/starter/README.md
+++ b/examples/starter/README.md
@@ -1,6 +1,6 @@
 # Autocomplete starter with static data
 
-This example helps you quickly boostrap a basic Autocomplete using static data.
+This example helps you quickly bootstrap a basic Autocomplete using static data.
 
 <p align="center"><img src="capture.jpg" alt="A capture of the Autocomplete starter using static data" /></p>
 

--- a/examples/two-column-layout/style.css
+++ b/examples/two-column-layout/style.css
@@ -106,7 +106,7 @@ body {
   margin-left: calc(var(--aa-icon-size) + var(--aa-spacing));
 }
 
-/* Breacrumb */
+/* Breadcrumb */
 .aa-Breadcrumb {
   color: rgb(var(--aa-muted-color-rgb));
   display: flex;

--- a/packages/autocomplete-js/src/__tests__/panelPlacement.test.ts
+++ b/packages/autocomplete-js/src/__tests__/panelPlacement.test.ts
@@ -86,7 +86,7 @@ describe('panelPlacement', () => {
       });
     });
 
-    test('keeps the panel positionned after scrolling', async () => {
+    test('keeps the panel positioned after scrolling', async () => {
       autocomplete({
         container,
         panelPlacement: 'input-wrapper-width',
@@ -143,7 +143,7 @@ describe('panelPlacement', () => {
       });
     });
 
-    test('keeps the panel positionned after scrolling', async () => {
+    test('keeps the panel positioned after scrolling', async () => {
       autocomplete({
         container,
         panelPlacement: 'start',
@@ -197,7 +197,7 @@ describe('panelPlacement', () => {
       });
     });
 
-    test('keeps the panel positionned after scrolling', async () => {
+    test('keeps the panel positioned after scrolling', async () => {
       autocomplete({
         container,
         panelPlacement: 'end',
@@ -254,7 +254,7 @@ describe('panelPlacement', () => {
       });
     });
 
-    test('keeps the panel positionned after scrolling', async () => {
+    test('keeps the panel positioned after scrolling', async () => {
       autocomplete({
         container,
         panelPlacement: 'full-width',
@@ -340,7 +340,7 @@ describe('panelPlacement', () => {
     });
   });
 
-  test('default value keeps the panel positionned after scrolling', async () => {
+  test('default value keeps the panel positioned after scrolling', async () => {
     autocomplete({
       container,
       initialState: {

--- a/packages/autocomplete-js/src/__tests__/positioning.test.ts
+++ b/packages/autocomplete-js/src/__tests__/positioning.test.ts
@@ -130,7 +130,7 @@ describe('Panel positioning', () => {
     });
   });
 
-  test('keeps the panel positionned after scrolling', async () => {
+  test('keeps the panel positioned after scrolling', async () => {
     const container = document.createElement('div');
     const panelContainer = document.body;
     document.body.appendChild(container);

--- a/packages/autocomplete-js/src/elements/Input.ts
+++ b/packages/autocomplete-js/src/elements/Input.ts
@@ -40,7 +40,7 @@ export const Input: AutocompleteElement<InputProps, HTMLInputElement> = ({
   setProperties(element, {
     ...inputProps,
     onKeyDown(event: KeyboardEvent) {
-      // In detached mode we don't want to close the panel when hittin `Tab`.
+      // In detached mode we don't want to close the panel when hitting `Tab`.
       if (isDetached && event.key === 'Tab') {
         return;
       }

--- a/packages/autocomplete-plugin-recent-searches/src/createRecentSearchesPlugin.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/createRecentSearchesPlugin.ts
@@ -47,7 +47,7 @@ export type CreateRecentSearchesPluginParams<
   subscribe?(params: PluginSubscribeParams<TItem>): void;
 };
 
-function getDefaultSubcribe<TItem extends RecentSearchesItem>(
+function getDefaultSubscribe<TItem extends RecentSearchesItem>(
   store: StorageApi<TItem>
 ) {
   return function subscribe({ onSelect }: PluginSubscribeParams<TItem>) {
@@ -75,7 +75,7 @@ export function createRecentSearchesPlugin<TItem extends RecentSearchesItem>(
 
   return {
     name: 'aa.recentSearchesPlugin',
-    subscribe: subscribe ?? getDefaultSubcribe(store),
+    subscribe: subscribe ?? getDefaultSubscribe(store),
     onSubmit({ state }) {
       const { query } = state;
 

--- a/packages/autocomplete-shared/src/__tests__/createRef.test.ts
+++ b/packages/autocomplete-shared/src/__tests__/createRef.test.ts
@@ -7,7 +7,7 @@ describe('createRef', () => {
     expect(ref).toEqual({ current: null });
   });
 
-  test('makes the current value mutabble', () => {
+  test('makes the current value mutable', () => {
     const ref = createRef<string | null>(null);
     ref.current = 'updated';
 

--- a/packages/autocomplete-shared/src/__tests__/isEqual.test.ts
+++ b/packages/autocomplete-shared/src/__tests__/isEqual.test.ts
@@ -155,7 +155,7 @@ describe('isEqual', () => {
       expect(isEqual(first, second)).toEqual(false);
     });
 
-    test('with full equal objets should be true', () => {
+    test('with full equal objects should be true', () => {
       const first = {
         index: '',
         query: '',
@@ -177,7 +177,7 @@ describe('isEqual', () => {
       expect(isEqual(first, second)).toEqual(true);
     });
 
-    test('with full different objets should be false', () => {
+    test('with full different objects should be false', () => {
       const first = {
         index: '',
         query: 'first query',

--- a/packages/autocomplete-theme-classic/src/theme.scss
+++ b/packages/autocomplete-theme-classic/src/theme.scss
@@ -256,7 +256,7 @@ body {
           box-shadow: none;
           outline: none;
         }
-        // Remove native appearence
+        // Remove native appearance
         &::-webkit-search-decoration,
         &::-webkit-search-cancel-button,
         &::-webkit-search-results-button,


### PR DESCRIPTION
closes #1071

This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/autocomplete/actions/runs/3815423602#summary-10380894959

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/autocomplete/actions/runs/3815423664#summary-10380895022

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.

I'm skipping the commit style. I'm happy to fix the commit style to match convention once people determine which change(s) they'd like to keep and whether they want a single commit or multiple commits.