### PR TITLE
ci: use environment variables from context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,6 +210,7 @@ workflows:
       #     requires:
       #       - build
       - release:
+          context: fx-libraries
           requires:
             - test_unit
             - test_lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,6 +204,7 @@ workflows:
           requires:
             - build
       - test_size:
+          context: fx-libraries
           requires:
             - build
       # - test_cypress:


### PR DESCRIPTION
This PR updates the CircleCI config file so that jobs retrieve relevant environment variables from context. Doing this will allow us to use the same tokens in similar projects.