### PR TITLE
fix(querySuggestions): allow categoryAttribute to be optional in hit

### DIFF
--- a/packages/autocomplete-plugin-query-suggestions/src/__tests__/createQuerySuggestionsPlugin.test.ts
+++ b/packages/autocomplete-plugin-query-suggestions/src/__tests__/createQuerySuggestionsPlugin.test.ts
@@ -45,6 +45,19 @@ const hits: Hit<any> = [
       },
     },
   },
+  {
+    nb_words: 1,
+    popularity: 1230,
+    query: 'range',
+    objectID: 'range',
+    _highlightResult: {
+      query: {
+        value: 'range',
+        matchLevel: 'none',
+        matchedWords: [],
+      },
+    },
+  },
 ];
 /* eslint-enable @typescript-eslint/camelcase */
 
@@ -160,6 +173,54 @@ describe('createQuerySuggestionsPlugin', () => {
               </div>
             </div>,
           ],
+          HTMLCollection [
+            <div
+              class="aa-ItemWrapper"
+            >
+              <div
+                class="aa-ItemContent"
+              >
+                <div
+                  class="aa-ItemIcon aa-ItemIcon--noBorder"
+                >
+                  <svg
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16.041 15.856c-0.034 0.026-0.067 0.055-0.099 0.087s-0.060 0.064-0.087 0.099c-1.258 1.213-2.969 1.958-4.855 1.958-1.933 0-3.682-0.782-4.95-2.050s-2.050-3.017-2.050-4.95 0.782-3.682 2.050-4.95 3.017-2.050 4.95-2.050 3.682 0.782 4.95 2.050 2.050 3.017 2.050 4.95c0 1.886-0.745 3.597-1.959 4.856zM21.707 20.293l-3.675-3.675c1.231-1.54 1.968-3.493 1.968-5.618 0-2.485-1.008-4.736-2.636-6.364s-3.879-2.636-6.364-2.636-4.736 1.008-6.364 2.636-2.636 3.879-2.636 6.364 1.008 4.736 2.636 6.364 3.879 2.636 6.364 2.636c2.125 0 4.078-0.737 5.618-1.968l3.675 3.675c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="aa-ItemContentBody"
+                >
+                  <div
+                    class="aa-ItemContentTitle"
+                  >
+                    range
+                  </div>
+                </div>
+              </div>
+              <div
+                class="aa-ItemActions"
+              >
+                <button
+                  class="aa-ItemActionButton"
+                  title="Fill query with \\"range\\""
+                >
+                  <svg
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M8 17v-7.586l8.293 8.293c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-8.293-8.293h7.586c0.552 0 1-0.448 1-1s-0.448-1-1-1h-10c-0.552 0-1 0.448-1 1v10c0 0.552 0.448 1 1 1s1-0.448 1-1z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>,
+          ],
         ]
       `);
     });
@@ -201,7 +262,7 @@ describe('createQuerySuggestionsPlugin', () => {
         .getAllByRole('option')
         .map((option) => option.children);
 
-      expect(options).toHaveLength(2);
+      expect(options).toHaveLength(3);
       expect(options[1]).toMatchInlineSnapshot(`
         HTMLCollection [
           <div
@@ -226,6 +287,56 @@ describe('createQuerySuggestionsPlugin', () => {
                   </span>
                 </span>
               </div>
+            </div>
+          </div>,
+        ]
+      `);
+      expect(options[2]).toMatchInlineSnapshot(`
+        HTMLCollection [
+          <div
+            class="aa-ItemWrapper"
+          >
+            <div
+              class="aa-ItemContent"
+            >
+              <div
+                class="aa-ItemIcon aa-ItemIcon--noBorder"
+              >
+                <svg
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16.041 15.856c-0.034 0.026-0.067 0.055-0.099 0.087s-0.060 0.064-0.087 0.099c-1.258 1.213-2.969 1.958-4.855 1.958-1.933 0-3.682-0.782-4.95-2.050s-2.050-3.017-2.050-4.95 0.782-3.682 2.050-4.95 3.017-2.050 4.95-2.050 3.682 0.782 4.95 2.050 2.050 3.017 2.050 4.95c0 1.886-0.745 3.597-1.959 4.856zM21.707 20.293l-3.675-3.675c1.231-1.54 1.968-3.493 1.968-5.618 0-2.485-1.008-4.736-2.636-6.364s-3.879-2.636-6.364-2.636-4.736 1.008-6.364 2.636-2.636 3.879-2.636 6.364 1.008 4.736 2.636 6.364 3.879 2.636 6.364 2.636c2.125 0 4.078-0.737 5.618-1.968l3.675 3.675c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414z"
+                  />
+                </svg>
+              </div>
+              <div
+                class="aa-ItemContentBody"
+              >
+                <div
+                  class="aa-ItemContentTitle"
+                >
+                  range
+                </div>
+              </div>
+            </div>
+            <div
+              class="aa-ItemActions"
+            >
+              <button
+                class="aa-ItemActionButton"
+                title="Fill query with \\"range\\""
+              >
+                <svg
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M8 17v-7.586l8.293 8.293c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-8.293-8.293h7.586c0.552 0 1-0.448 1-1s-0.448-1-1-1h-10c-0.552 0-1 0.448-1 1v10c0 0.552 0.448 1 1 1s1-0.448 1-1z"
+                  />
+                </svg>
+              </button>
             </div>
           </div>,
         ]
@@ -280,7 +391,9 @@ describe('createQuerySuggestionsPlugin', () => {
       ).toEqual([
         'cooktop', // Query Suggestions item
         'in Appliances', // Category item
+        'range', // Query Suggestions item
         'cooktop', // Query Suggestions item
+        'range', // Query Suggestions item
       ]);
     });
   });
@@ -333,9 +446,12 @@ describe('createQuerySuggestionsPlugin', () => {
       ).toEqual([
         'cooktop', // Query Suggestions item
         'in Appliances', // Category item
+        'range', // Query Suggestions item
         'cooktop', // Query Suggestions item
         'in Appliances', // Category item
+        'range', // Query Suggestions item
         'cooktop', // Query Suggestions item
+        'range', // Query Suggestions item
       ]);
     });
   });
@@ -389,7 +505,9 @@ describe('createQuerySuggestionsPlugin', () => {
         'cooktop', // Query Suggestions item
         'in Appliances', // Category item
         'in Ranges, Cooktops & Ovens', // Category item
+        'range', // Query Suggestions item
         'cooktop', // Query Suggestions item
+        'range', // Query Suggestions item
       ]);
     });
   });
@@ -487,6 +605,14 @@ describe('createQuerySuggestionsPlugin', () => {
             </span>,
             <button>
               Fill with "cooktop"
+            </button>,
+          ],
+          HTMLCollection [
+            <span>
+              range
+            </span>,
+            <button>
+              Fill with "range"
             </button>,
           ],
         ]

--- a/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
+++ b/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
@@ -137,7 +137,7 @@ export function createQuerySuggestionsPlugin<
                         .map((x) => x.value)
                         .slice(0, categoriesPerItem);
 
-                      itemsWithCategoriesAdded += categories.length;
+                      itemsWithCategoriesAdded++;
 
                       for (const category of categories) {
                         items.push({

--- a/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
+++ b/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
@@ -137,7 +137,9 @@ export function createQuerySuggestionsPlugin<
                         .map((x) => x.value)
                         .slice(0, categoriesPerItem);
 
-                      itemsWithCategoriesAdded++;
+                      if (categories.length > 0) {
+                        itemsWithCategoriesAdded++;
+                      }
 
                       for (const category of categories) {
                         items.push({

--- a/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
+++ b/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
@@ -120,7 +120,7 @@ export function createQuerySuggestionsPlugin<
                   let itemsWithCategoriesAdded = 0;
                   return querySuggestionsHits.reduce<
                     Array<AutocompleteQuerySuggestionsHit<typeof indexName>>
-                  >((acc, current, i) => {
+                  >((acc, current) => {
                     const items: Array<
                       AutocompleteQuerySuggestionsHit<typeof indexName>
                     > = [current];

--- a/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
+++ b/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
@@ -117,6 +117,7 @@ export function createQuerySuggestionsPlugin<
                     return querySuggestionsHits as any;
                   }
 
+                  let itemsWithCategoriesAdded = 0;
                   return querySuggestionsHits.reduce<
                     Array<AutocompleteQuerySuggestionsHit<typeof indexName>>
                   >((acc, current, i) => {
@@ -124,15 +125,19 @@ export function createQuerySuggestionsPlugin<
                       AutocompleteQuerySuggestionsHit<typeof indexName>
                     > = [current];
 
-                    if (i <= itemsWithCategories - 1) {
-                      const categories = getAttributeValueByPath(
-                        current,
-                        Array.isArray(categoryAttribute)
-                          ? categoryAttribute
-                          : [categoryAttribute]
+                    if (itemsWithCategoriesAdded < itemsWithCategories) {
+                      const categories = (
+                        getAttributeValueByPath(
+                          current,
+                          Array.isArray(categoryAttribute)
+                            ? categoryAttribute
+                            : [categoryAttribute]
+                        ) || []
                       )
                         .map((x) => x.value)
                         .slice(0, categoriesPerItem);
+
+                      itemsWithCategoriesAdded += categories.length;
 
                       for (const category of categories) {
                         items.push({


### PR DESCRIPTION
if you have a hit without the path you passed in `categoryAttribute`, there would be a "method map doesn't exist on undefined" before this PR

cc @And1DS 