### PR TITLE
fix(insights): split large view event payloads into multiple chunks

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "packages/autocomplete-plugin-algolia-insights/dist/umd/index.production.js",
-      "maxSize": "2 kB"
+      "maxSize": "2.1 kB"
     },
     {
       "path": "packages/autocomplete-plugin-redirect-url/dist/umd/index.production.js",

--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createSearchInsightsApi.ts.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createSearchInsightsApi.ts.test.ts
@@ -1,3 +1,31 @@
+import { createSearchInsightsApi } from '../createSearchInsightsApi';
+
 describe('createSearchInsightsApi', () => {
-  test.todo('tests');
+  test('viewedObjectIDs splits large payloads into multiple chunks', () => {
+    const insightsClient = jest.fn();
+    const insightsApi = createSearchInsightsApi(insightsClient);
+
+    insightsApi.viewedObjectIDs({
+      eventName: 'Items Viewed',
+      index: 'index1',
+      objectIDs: Array.from({ length: 50 }, (_, i) => `${i}`),
+    });
+
+    expect(insightsClient).toHaveBeenCalledTimes(3);
+    expect(insightsClient).toHaveBeenNthCalledWith(1, 'viewedObjectIDs', {
+      eventName: 'Items Viewed',
+      index: 'index1',
+      objectIDs: Array.from({ length: 20 }, (_, i) => `${i}`),
+    });
+    expect(insightsClient).toHaveBeenNthCalledWith(2, 'viewedObjectIDs', {
+      eventName: 'Items Viewed',
+      index: 'index1',
+      objectIDs: Array.from({ length: 20 }, (_, i) => `${i + 20}`),
+    });
+    expect(insightsClient).toHaveBeenNthCalledWith(3, 'viewedObjectIDs', {
+      eventName: 'Items Viewed',
+      index: 'index1',
+      objectIDs: Array.from({ length: 10 }, (_, i) => `${i + 40}`),
+    });
+  });
 });

--- a/packages/autocomplete-plugin-algolia-insights/src/createSearchInsightsApi.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createSearchInsightsApi.ts
@@ -10,6 +10,20 @@ import {
   ViewedObjectIDsParams,
 } from './types';
 
+function chunk<TItem extends { objectIDs: string[] }>(
+  item: TItem,
+  chunkSize: number = 20
+): TItem[] {
+  const chunks: TItem[] = [];
+  for (let i = 0; i < item.objectIDs.length; i += chunkSize) {
+    chunks.push({
+      ...item,
+      objectIDs: item.objectIDs.slice(i, i + chunkSize),
+    });
+  }
+  return chunks;
+}
+
 export function createSearchInsightsApi(searchInsights: InsightsClient) {
   return {
     /**
@@ -95,7 +109,12 @@ export function createSearchInsightsApi(searchInsights: InsightsClient) {
      */
     viewedObjectIDs(...params: ViewedObjectIDsParams[]) {
       if (params.length > 0) {
-        searchInsights('viewedObjectIDs', ...params);
+        params
+          .reduce(
+            (acc, param) => [...acc, ...chunk<ViewedObjectIDsParams>(param)],
+            [] as ViewedObjectIDsParams[]
+          )
+          .forEach((param) => searchInsights('viewedObjectIDs', param));
       }
     },
     /**


### PR DESCRIPTION
Insights events containing more than 20 object IDs fail to be processed by the Insights API. This can happen with Autocomplete when an Algolia source shows more than 20 items (using `hitsPerPage` for example).

This PR ensures payloads containing more than 20 items are correctly split into smaller chunks that can be processed by the Insights API.

It also fixes another issue when only events from the first Insights-compatible plugin and/or source would be sent. For example, when typing on an Autocomplete that has both the Query Suggestions plugin and one or multiple Algolia sources, only the view events from the Query Suggestions are sent.