### PR TITLE
fix(redirect): add select handler to ensure matching queries get redirected

### DIFF
--- a/packages/autocomplete-plugin-redirect-url/src/createRedirectUrlPlugin.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/createRedirectUrlPlugin.ts
@@ -92,7 +92,7 @@ export function createRedirectUrlPlugin<TItem extends BaseItem>(
 
   return {
     name: 'aa.redirectUrlPlugin',
-    subscribe({ onResolve, setContext }) {
+    subscribe({ onResolve, onSelect, setContext }) {
       onResolve(({ results, source, state }) => {
         setContext({
           ...state.context,
@@ -100,6 +100,10 @@ export function createRedirectUrlPlugin<TItem extends BaseItem>(
             data: createRedirects({ results, source, state }),
           },
         });
+      });
+
+      onSelect(({ state, event, navigator }) => {
+        onRedirect(getRedirectData({ state }), { event, navigator, state });
       });
     },
     reshape({ state, sourcesBySourceId }) {


### PR DESCRIPTION
If you click on an item, that when that response returns will have a redirect, then you are also redirected