### PR TITLE
fix(redirect): reopen menu when redirect detected

### DIFF
--- a/packages/autocomplete-plugin-redirect-url/src/__tests__/createRedirectUrlPlugin.test.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/__tests__/createRedirectUrlPlugin.test.ts
@@ -225,7 +225,7 @@ describe('createRedirectUrlPlugin', () => {
         Array [
           HTMLCollection [
             <a>
-              My custom option:
+              My custom option: 
               redirect item
             </a>,
           ],

--- a/packages/autocomplete-plugin-redirect-url/src/__tests__/createRedirectUrlPlugin.test.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/__tests__/createRedirectUrlPlugin.test.ts
@@ -225,7 +225,7 @@ describe('createRedirectUrlPlugin', () => {
         Array [
           HTMLCollection [
             <a>
-              My custom option: 
+              My custom option:
               redirect item
             </a>,
           ],
@@ -499,6 +499,155 @@ describe('createRedirectUrlPlugin', () => {
 
     await waitFor(() => {
       expect(input.value).toBe(REDIRECT_QUERY);
+      expect(navigator.navigate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('selecting a hit that creates a redirect url will reopen the dropdown menu and then submitting the form will trigger the navigator', async () => {
+    const redirectUrlPlugin = createRedirectUrlPlugin();
+    const navigator = createNavigator();
+
+    const container = document.createElement('div');
+    const panelContainer = document.createElement('div');
+
+    document.body.appendChild(panelContainer);
+
+    autocomplete({
+      container,
+      panelContainer,
+      plugins: [redirectUrlPlugin],
+      navigator,
+      getSources({ query }) {
+        return [
+          createMockSource({
+            results:
+              query === REDIRECT_QUERY
+                ? [
+                    {
+                      hits: [{ query: REDIRECT_QUERY }],
+                      renderingContent: {
+                        redirect: {
+                          url: 'https://www.algolia.com',
+                        },
+                      },
+                    },
+                  ]
+                : [
+                    {
+                      hits: [
+                        { query: 'something else' },
+                        { query: REDIRECT_QUERY },
+                      ],
+                    },
+                  ],
+            getItemInputValue({ item }) {
+              return item.query;
+            },
+          }),
+        ];
+      },
+    });
+
+    const input = findInput(container);
+
+    fireEvent.input(input, { target: { value: 'hey' } });
+
+    await waitFor(() => {
+      expect(findRedirectSection(panelContainer)).not.toBeInTheDocument();
+      expect(findDropdownOptions(findHitsSection(panelContainer)))
+        .toMatchInlineSnapshot(`
+        Array [
+          HTMLCollection [
+            <a>
+              something else
+            </a>,
+          ],
+          HTMLCollection [
+            <a>
+              redirect item
+            </a>,
+          ],
+        ]
+      `);
+    });
+
+    fireEvent.click(findDropdownOptions(panelContainer)[1][0]);
+
+    await waitFor(() => {
+      expect(input.value).toBe(REDIRECT_QUERY);
+      expect(findHitsSection(panelContainer)).not.toBeInTheDocument();
+      expect(findDropdownOptions(findRedirectSection(panelContainer)))
+        .toMatchInlineSnapshot(`
+        Array [
+          HTMLCollection [
+            <div
+              class="aa-ItemWrapper"
+            >
+              <div
+                class="aa-ItemContent"
+              >
+                <div
+                  class="aa-ItemIcon aa-ItemIcon--noBorder"
+                >
+                  <svg
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16.041 15.856c-0.034 0.026-0.067 0.055-0.099 0.087s-0.060 0.064-0.087 0.099c-1.258 1.213-2.969 1.958-4.855 1.958-1.933 0-3.682-0.782-4.95-2.050s-2.050-3.017-2.050-4.95 0.782-3.682 2.050-4.95 3.017-2.050 4.95-2.050 3.682 0.782 4.95 2.050 2.050 3.017 2.050 4.95c0 1.886-0.745 3.597-1.959 4.856zM21.707 20.293l-3.675-3.675c1.231-1.54 1.968-3.493 1.968-5.618 0-2.485-1.008-4.736-2.636-6.364s-3.879-2.636-6.364-2.636-4.736 1.008-6.364 2.636-2.636 3.879-2.636 6.364 1.008 4.736 2.636 6.364 3.879 2.636 6.364 2.636c2.125 0 4.078-0.737 5.618-1.968l3.675 3.675c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="aa-ItemContentBody"
+                >
+                  <div
+                    class="aa-ItemContentTitle"
+                  >
+                    <a
+                      class="aa-ItemLink"
+                      href="https://www.algolia.com"
+                    >
+                      redirect item
+                    </a>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="aa-ItemActions"
+              >
+                <div
+                  class="aa-ItemActionButton"
+                >
+                  <svg
+                    fill="none"
+                    stroke="currentColor"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    viewBox="0 0 24 24"
+                  >
+                    <line
+                      x1="5"
+                      x2="19"
+                      y1="12"
+                      y2="12"
+                    />
+                    <polyline
+                      points="12 5 19 12 12 19"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>,
+          ],
+        ]
+      `);
+    });
+
+    fireEvent.submit(input);
+
+    await waitFor(() => {
       expect(navigator.navigate).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/autocomplete-plugin-redirect-url/src/createRedirectUrlPlugin.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/createRedirectUrlPlugin.ts
@@ -92,7 +92,7 @@ export function createRedirectUrlPlugin<TItem extends BaseItem>(
 
   return {
     name: 'aa.redirectUrlPlugin',
-    subscribe({ onResolve, setContext }) {
+    subscribe({ onResolve, onSelect, setContext, setIsOpen }) {
       onResolve(({ results, source, state }) => {
         setContext({
           ...state.context,
@@ -100,6 +100,13 @@ export function createRedirectUrlPlugin<TItem extends BaseItem>(
             data: createRedirects({ results, source, state }),
           },
         });
+      });
+
+      onSelect(({ state }) => {
+        const redirects = getRedirectData({ state });
+        if (redirects.length > 0) {
+          setIsOpen(true);
+        }
       });
     },
     reshape({ state, sourcesBySourceId }) {


### PR DESCRIPTION
If a redirect item is found after selecting a hit, then reopen the menu with the latest results (notably the redirect item).

Spun off from https://github.com/algolia/autocomplete/pull/1089

After discussing further, consistency of the UX was determined to be the top priority. Before there were situations when a redirect could occur without the user knowing. This approach, while less ideal functionally because two selects/submits are required, will always show a redirect item in the dropdown when the current query will redirect.

Two cases covered in the demo below:
1. Type query, select hit corresponding to a redirect, menu reopens with new results, **press enter**
2. Type query, select hit corresponding to a redirect, menu reopens with new results, **select redirect item**

https://user-images.githubusercontent.com/19941480/218475714-303ef5a1-edcb-4431-b939-d81c0131d3df.mov