### PR TITLE
fix(autocomplete-js): `query` is reflected in the detached search `button`

### DIFF
--- a/packages/autocomplete-js/src/__tests__/detached.test.ts
+++ b/packages/autocomplete-js/src/__tests__/detached.test.ts
@@ -373,100 +373,15 @@ describe('detached', () => {
     });
   });
 
-  test('preserves `query` after closing', async () => {
+  test('preserves `query` in the detached search `button` after closing', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const onStateChange = jest.fn();
-    const { setQuery } = autocomplete({
+    autocomplete({
       id: 'autocomplete',
       detachedMediaQuery: '',
       container,
       onStateChange,
-    });
-
-    const searchButton = container.querySelector<HTMLButtonElement>(
-      '.aa-DetachedSearchButton'
-    )!;
-
-    // Open detached overlay
-    searchButton.click();
-
-    await waitFor(() => {
-      expect(document.querySelector('.aa-DetachedOverlay')).toBeInTheDocument();
-      expect(document.body).toHaveClass('aa-Detached');
-    });
-
-    setQuery('a');
-
-    const cancelButton = document.querySelector<HTMLButtonElement>(
-      '.aa-DetachedCancelButton'
-    )!;
-
-    // Close detached overlay
-    cancelButton.click();
-
-    // The detached overlay should close
-    await waitFor(() => {
-      expect(
-        document.querySelector('.aa-DetachedOverlay')
-      ).not.toBeInTheDocument();
-      expect(document.body).not.toHaveClass('aa-Detached');
-    });
-
-    // The `query` should still be present
-    expect(onStateChange).toHaveBeenCalledTimes(3);
-    expect(onStateChange).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        state: expect.objectContaining({ query: 'a' }),
-      })
-    );
-  });
-
-  test('reflects the initial `query` in the detached search `button`', async () => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    autocomplete({
-      id: 'autocomplete',
-      detachedMediaQuery: '',
-      container,
-      initialState: {
-        query: 'a',
-      },
-    });
-
-    await waitFor(() => {
-      expect(
-        container.querySelector('.aa-DetachedSearchButtonQuery')
-      ).toHaveTextContent('a');
-    });
-  });
-
-  test('hides detached search `button` placeholder when `query` exists', async () => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    autocomplete({
-      id: 'autocomplete',
-      detachedMediaQuery: '',
-      container,
-      initialState: {
-        query: 'a',
-      },
-    });
-
-    await waitFor(() => {
-      expect(
-        container.querySelector('.aa-DetachedSearchButtonPlaceholder')
-      ).toHaveAttribute('hidden');
-    });
-  });
-
-  test('persists the `query` in the detached search `button` after closing', async () => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    autocomplete({
-      id: 'autocomplete',
-      detachedMediaQuery: '',
-      container,
     });
 
     const searchButton = container.querySelector<HTMLButtonElement>(
@@ -508,11 +423,43 @@ describe('detached', () => {
       expect(document.body).not.toHaveClass('aa-Detached');
     });
 
-    // The detached search button should contain the query
+    // The `query` should still be present
+    expect(onStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        state: expect.objectContaining({ query: 'a' }),
+      })
+    );
+
+    // The detached search `button` should contain the `query`
+    expect(
+      container.querySelector('.aa-DetachedSearchButtonQuery')
+    ).toHaveTextContent('a');
+
+    // The detached search `button` placeholder should be hidden when `query` exists
+    expect(
+      container.querySelector('.aa-DetachedSearchButtonPlaceholder')
+    ).toHaveAttribute('hidden');
+  });
+
+  test('reflects the initial `query` in the detached search `button`', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    autocomplete({
+      id: 'autocomplete',
+      detachedMediaQuery: '',
+      container,
+      initialState: {
+        query: 'a',
+      },
+    });
+
     await waitFor(() => {
+      // The detached search `button` should have the initial `query`
       expect(
         container.querySelector('.aa-DetachedSearchButtonQuery')
       ).toHaveTextContent('a');
+
+      // The detached search `button` placeholder should be hidden when `query` exists
       expect(
         container.querySelector('.aa-DetachedSearchButtonPlaceholder')
       ).toHaveAttribute('hidden');

--- a/packages/autocomplete-js/src/__tests__/detached.test.ts
+++ b/packages/autocomplete-js/src/__tests__/detached.test.ts
@@ -391,6 +391,7 @@ describe('detached', () => {
     // Open detached overlay
     searchButton.click();
 
+    // Type a query in the focused input
     await waitFor(() => {
       const input = document.querySelector<HTMLInputElement>('.aa-Input')!;
 

--- a/packages/autocomplete-js/src/__tests__/detached.test.ts
+++ b/packages/autocomplete-js/src/__tests__/detached.test.ts
@@ -436,8 +436,8 @@ describe('detached', () => {
 
     await waitFor(() => {
       expect(
-        container.querySelector('.aa-DetachedSearchButtonQuery')?.innerHTML
-      ).toEqual('a');
+        container.querySelector('.aa-DetachedSearchButtonQuery')
+      ).toHaveTextContent('a');
     });
   });
 
@@ -511,8 +511,8 @@ describe('detached', () => {
     // The detached search button should contain the query
     await waitFor(() => {
       expect(
-        container.querySelector('.aa-DetachedSearchButtonQuery')?.innerHTML
-      ).toEqual('a');
+        container.querySelector('.aa-DetachedSearchButtonQuery')
+      ).toHaveTextContent('a');
       expect(
         container.querySelector('.aa-DetachedSearchButtonPlaceholder')
       ).toHaveAttribute('hidden');

--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -393,8 +393,6 @@ export function autocomplete<TItem extends BaseItem>(
         props.value.core.environment.document.body.classList.remove(
           'aa-Detached'
         );
-        autocomplete.value.setQuery('');
-        autocomplete.value.refresh();
       }
     });
   }

--- a/packages/autocomplete-js/src/createAutocompleteDom.ts
+++ b/packages/autocomplete-js/src/createAutocompleteDom.ts
@@ -137,6 +137,16 @@ export function createAutocompleteDom<TItem extends BaseItem>({
     ...panelProps,
   });
 
+  const detachedSearchButtonQuery = createDomElement('div', {
+    class: classNames.detachedSearchButtonQuery,
+    textContent: state.query,
+  });
+  const detachedSearchButtonPlaceholder = createDomElement('div', {
+    class: classNames.detachedSearchButtonPlaceholder,
+    hidden: Boolean(state.query),
+    textContent: placeholder,
+  });
+
   if (__TEST__) {
     setProperties(panel, {
       'data-testid': 'panel',
@@ -148,17 +158,17 @@ export function createAutocompleteDom<TItem extends BaseItem>({
       class: classNames.detachedSearchButtonIcon,
       children: [SearchIcon({ environment })],
     });
-    const detachedSearchButtonPlaceholder = createDomElement('div', {
-      class: classNames.detachedSearchButtonPlaceholder,
-      textContent: placeholder,
-    });
     const detachedSearchButton = createDomElement('button', {
       type: 'button',
       class: classNames.detachedSearchButton,
       onClick() {
         setIsModalOpen(true);
       },
-      children: [detachedSearchButtonIcon, detachedSearchButtonPlaceholder],
+      children: [
+        detachedSearchButtonIcon,
+        detachedSearchButtonPlaceholder,
+        detachedSearchButtonQuery,
+      ],
     });
     const detachedCancelButton = createDomElement('button', {
       type: 'button',
@@ -188,6 +198,8 @@ export function createAutocompleteDom<TItem extends BaseItem>({
   return {
     detachedContainer,
     detachedOverlay,
+    detachedSearchButtonQuery,
+    detachedSearchButtonPlaceholder,
     inputWrapper,
     input,
     root,

--- a/packages/autocomplete-js/src/getDefaultOptions.ts
+++ b/packages/autocomplete-js/src/getDefaultOptions.ts
@@ -35,6 +35,7 @@ const defaultClassNames: AutocompleteClassNames = {
   detachedSearchButton: 'aa-DetachedSearchButton',
   detachedSearchButtonIcon: 'aa-DetachedSearchButtonIcon',
   detachedSearchButtonPlaceholder: 'aa-DetachedSearchButtonPlaceholder',
+  detachedSearchButtonQuery: 'aa-DetachedSearchButtonQuery',
   form: 'aa-Form',
   input: 'aa-Input',
   inputWrapper: 'aa-InputWrapper',

--- a/packages/autocomplete-js/src/render.tsx
+++ b/packages/autocomplete-js/src/render.tsx
@@ -58,6 +58,12 @@ export function renderSearchBox<TItem extends BaseItem>({
   setProperties(dom.label, { hidden: state.status === 'stalled' });
   setProperties(dom.loadingIndicator, { hidden: state.status !== 'stalled' });
   setProperties(dom.clearButton, { hidden: !state.query });
+  setProperties(dom.detachedSearchButtonQuery, {
+    textContent: state.query,
+  });
+  setProperties(dom.detachedSearchButtonPlaceholder, {
+    hidden: Boolean(state.query),
+  });
 }
 
 export function renderPanel<TItem extends BaseItem>(

--- a/packages/autocomplete-js/src/types/AutocompleteClassNames.ts
+++ b/packages/autocomplete-js/src/types/AutocompleteClassNames.ts
@@ -6,6 +6,7 @@ export type AutocompleteClassNames = {
   detachedSearchButton: string;
   detachedSearchButtonIcon: string;
   detachedSearchButtonPlaceholder: string;
+  detachedSearchButtonQuery: string;
   form: string;
   input: string;
   inputWrapper: string;

--- a/packages/autocomplete-js/src/types/AutocompleteDom.ts
+++ b/packages/autocomplete-js/src/types/AutocompleteDom.ts
@@ -10,4 +10,6 @@ export type AutocompleteDom = {
   panel: HTMLDivElement;
   detachedContainer: HTMLDivElement;
   detachedOverlay: HTMLDivElement;
+  detachedSearchButtonQuery: HTMLDivElement;
+  detachedSearchButtonPlaceholder: HTMLDivElement;
 };

--- a/packages/autocomplete-theme-classic/src/theme.scss
+++ b/packages/autocomplete-theme-classic/src/theme.scss
@@ -933,9 +933,14 @@ body {
     height: 100%;
     justify-content: center;
     width: calc(var(--aa-icon-size) + var(--aa-spacing));
+    flex-shrink: 0;
   }
   @at-root .aa-DetachedSearchButtonQuery {
     color: rgba(var(--aa-text-color-rgb), 1);
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    line-height: 1.25em;
   }
   @at-root .aa-DetachedSearchButtonPlaceholder {
     &[hidden] {

--- a/packages/autocomplete-theme-classic/src/theme.scss
+++ b/packages/autocomplete-theme-classic/src/theme.scss
@@ -930,17 +930,17 @@ body {
     color: rgba(var(--aa-primary-color-rgb), 1);
     cursor: initial;
     display: flex;
+    flex-shrink: 0;
     height: 100%;
     justify-content: center;
     width: calc(var(--aa-icon-size) + var(--aa-spacing));
-    flex-shrink: 0;
   }
   @at-root .aa-DetachedSearchButtonQuery {
     color: rgba(var(--aa-text-color-rgb), 1);
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
     line-height: 1.25em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   @at-root .aa-DetachedSearchButtonPlaceholder {
     &[hidden] {

--- a/packages/autocomplete-theme-classic/src/theme.scss
+++ b/packages/autocomplete-theme-classic/src/theme.scss
@@ -934,6 +934,14 @@ body {
     justify-content: center;
     width: calc(var(--aa-icon-size) + var(--aa-spacing));
   }
+  @at-root .aa-DetachedSearchButtonQuery {
+    color: rgba(var(--aa-text-color-rgb), 1);
+  }
+  @at-root .aa-DetachedSearchButtonPlaceholder {
+    &[hidden] {
+      display: none;
+    }
+  }
 }
 
 // Remove scroll on `body`

--- a/yarn.lock
+++ b/yarn.lock
@@ -7554,15 +7554,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001179, caniuse-lite@^1.0.30001286:
-  version "1.0.30001303"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001303.tgz#9b168e4f43ccfc372b86f4bc5a551d9b909c95c9"
-  integrity sha512-/Mqc1oESndUNszJP0kx0UaQU9kEv9nNtJ7Kn8AdA0mNnH8eR1cj0kG+NbNuC1Wq/b21eA8prhKRA3bbkjONegQ==
-
-caniuse-lite@^1.0.30001161, caniuse-lite@^1.0.30001400:
-  version "1.0.30001439"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz#ab7371faeb4adff4b74dad1718a6fd122e45d9cb"
-  integrity sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001161, caniuse-lite@^1.0.30001179, caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001400:
+  version "1.0.30001458"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001458.tgz"
+  integrity sha512-lQ1VlUUq5q9ro9X+5gOEyH7i3vm+AYVT1WDCVB69XOZ17KZRhnZ9J0Sqz7wTHQaLBJccNCHq8/Ww5LlOIZbB0w==
 
 capital-case@^1.0.3, capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
### Summary

Currently in `autocomplete-js` using the detached mode:

- When the modal is closed (clicking on an item of the panel/using the cancel button/using the escape key), the `query` is reset.
- The detached search button (used to open the modal) doesn't reflect the current `query`.

### Result

- In detached mode, the `query` is persisted in a new `div` with the class `.aa-DetachedSearchButtonQuery`.
- When the `query` is not empty, the placeholder `.aa-DetachedSearchButtonPlaceholder` is hidden.

[**→ CodeSandbox**](https://codesandbox.io/s/algolia-autocomplete-example-starter-forked-fokkpt?resolutionWidth=320&resolutionHeight=675)

Fixes #636 and #1010