### PR TITLE
feat(createAlgoliaInsightsPlugin): automatically load Insights when not passed

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "packages/autocomplete-plugin-algolia-insights/dist/umd/index.production.js",
-      "maxSize": "2.1 kB"
+      "maxSize": "2.5 kB"
     },
     {
       "path": "packages/autocomplete-plugin-redirect-url/dist/umd/index.production.js",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "rollup-plugin-filesize": "9.1.2",
     "rollup-plugin-license": "2.9.1",
     "rollup-plugin-terser": "7.0.2",
+    "search-insights": "2.3.0",
     "shipjs": "0.24.1",
     "start-server-and-test": "1.15.2",
     "stylelint": "13.13.1",

--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -197,8 +197,8 @@ describe('createAlgoliaInsightsPlugin', () => {
           </form>
         </body>
       `);
-      expect((window as any).AlgoliaAnalyticsObject).toBe(undefined);
-      expect((window as any).aa).toBe(undefined);
+      expect((window as any).AlgoliaAnalyticsObject).toBeUndefined();
+      expect((window as any).aa).toBeUndefined();
     });
 
     it('does not load the script when the Insights client is present in the page', async () => {
@@ -221,6 +221,7 @@ describe('createAlgoliaInsightsPlugin', () => {
       `);
       expect((window as any).AlgoliaAnalyticsObject).toBe('aa');
       expect((window as any).aa).toBe(aa);
+      expect((window as any).aa.version).toBeUndefined();
     });
 
     it('loads the script when the Insights client is not passed and not present in the page', async () => {
@@ -242,6 +243,7 @@ describe('createAlgoliaInsightsPlugin', () => {
       `);
       expect((window as any).AlgoliaAnalyticsObject).toBe('aa');
       expect((window as any).aa).toEqual(expect.any(Function));
+      expect((window as any).aa.version).toBe('2.3.0');
     });
 
     it('notifies when the script fails to be added', () => {

--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -4,6 +4,7 @@ import {
   getAlgoliaResults,
 } from '@algolia/autocomplete-preset-algolia';
 import { noop } from '@algolia/autocomplete-shared';
+import { fireEvent } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import insightsClient from 'search-insights';
 
@@ -12,11 +13,17 @@ import {
   createPlayground,
   createSearchClient,
   createSource,
+  defer,
   runAllMicroTasks,
 } from '../../../../test/utils';
 import { createAlgoliaInsightsPlugin } from '../createAlgoliaInsightsPlugin';
 
-jest.useFakeTimers();
+beforeEach(() => {
+  (window as any).AlgoliaAnalyticsObject = undefined;
+  (window as any).aa = undefined;
+
+  document.body.innerHTML = '';
+});
 
 describe('createAlgoliaInsightsPlugin', () => {
   test('has a name', () => {
@@ -70,7 +77,7 @@ describe('createAlgoliaInsightsPlugin', () => {
     );
   });
 
-  test('sets a user agent on the Insights client on subscribe', () => {
+  test('sets a user agent on  on subscribe', () => {
     const insightsClient = jest.fn();
     const insightsPlugin = createAlgoliaInsightsPlugin({ insightsClient });
 
@@ -167,7 +174,127 @@ describe('createAlgoliaInsightsPlugin', () => {
     ]);
   });
 
+  describe('automatic pulling', () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    afterAll(() => {
+      consoleError.mockReset();
+    });
+
+    it('does not load the script when the Insights client is passed', async () => {
+      createPlayground(createAutocomplete, {
+        plugins: [createAlgoliaInsightsPlugin({ insightsClient: noop })],
+      });
+
+      await defer(noop, 0);
+
+      expect(document.body).toMatchInlineSnapshot(`
+        <body>
+          <form>
+            <input />
+          </form>
+        </body>
+      `);
+      expect((window as any).AlgoliaAnalyticsObject).toBe(undefined);
+      expect((window as any).aa).toBe(undefined);
+    });
+
+    it('does not load the script when the Insights client is present in the page', async () => {
+      (window as any).AlgoliaAnalyticsObject = 'aa';
+      const aa = noop;
+      (window as any).aa = aa;
+
+      createPlayground(createAutocomplete, {
+        plugins: [createAlgoliaInsightsPlugin({})],
+      });
+
+      await defer(noop, 0);
+
+      expect(document.body).toMatchInlineSnapshot(`
+        <body>
+          <form>
+            <input />
+          </form>
+        </body>
+      `);
+      expect((window as any).AlgoliaAnalyticsObject).toBe('aa');
+      expect((window as any).aa).toBe(aa);
+    });
+
+    it('loads the script when the Insights client is not passed and not present in the page', async () => {
+      createPlayground(createAutocomplete, {
+        plugins: [createAlgoliaInsightsPlugin({})],
+      });
+
+      await defer(noop, 0);
+
+      expect(document.body).toMatchInlineSnapshot(`
+        <body>
+          <script
+            src="https://cdn.jsdelivr.net/npm/search-insights@2.3.0/dist/search-insights.min.js"
+          />
+          <form>
+            <input />
+          </form>
+        </body>
+      `);
+      expect((window as any).AlgoliaAnalyticsObject).toBe('aa');
+      expect((window as any).aa).toEqual(expect.any(Function));
+    });
+
+    it('notifies when the script fails to be added', () => {
+      // @ts-ignore `createElement` is a class method can thus only be called on
+      // an instance of `Document`, not as a standalone function.
+      // This is needed to call the actual implementation later in the test.
+      document.originalCreateElement = document.createElement;
+
+      document.createElement = (tagName) => {
+        if (tagName === 'script') {
+          throw new Error('error');
+        }
+
+        // @ts-ignore
+        return document.originalCreateElement(tagName);
+      };
+
+      createPlayground(createAutocomplete, {
+        plugins: [createAlgoliaInsightsPlugin({})],
+      });
+
+      expect(consoleError).toHaveBeenCalledWith(
+        '[Autocomplete]: Could not load search-insights.js. Please load it manually following https://alg.li/insights-autocomplete'
+      );
+
+      // @ts-ignore
+      document.createElement = document.originalCreateElement;
+    });
+
+    it('notifies when the script fails to load', async () => {
+      createPlayground(createAutocomplete, {
+        plugins: [createAlgoliaInsightsPlugin({})],
+      });
+
+      await defer(noop, 0);
+
+      fireEvent(document.querySelector('script')!, new ErrorEvent('error'));
+
+      expect(consoleError).toHaveBeenCalledWith(
+        '[Autocomplete]: Could not load search-insights.js. Please load it manually following https://alg.li/insights-autocomplete'
+      );
+    });
+  });
+
   describe('onItemsChange', () => {
+    beforeAll(() => {
+      jest.useFakeTimers();
+    });
+
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
     test('sends a `viewedObjectIDs` event by default', async () => {
       const insightsClient = jest.fn();
       const insightsPlugin = createAlgoliaInsightsPlugin({ insightsClient });

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -92,7 +92,7 @@ export function createAlgoliaInsightsPlugin(
     onSelect: onSelectEvent,
     onActive: onActiveEvent,
   } = getOptions(options);
-  let insightsClient: InsightsClient = providedInsightsClient || noop;
+  let insightsClient = providedInsightsClient as InsightsClient;
 
   if (!providedInsightsClient) {
     safelyRunOnBrowser(({ window }) => {

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -115,6 +115,8 @@ export function createAlgoliaInsightsPlugin(
           };
         }
 
+        window[pointer].version = ALGOLIA_INSIGHTS_VERSION;
+
         insightsClient = window[pointer];
 
         loadInsights(window);

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -213,7 +213,6 @@ export function createAlgoliaInsightsPlugin(
 
 function getOptions(options: CreateAlgoliaInsightsPluginParams) {
   return {
-    // insightsClient: noop,
     onItemsChange({ insights, insightsEvents }) {
       insights.viewedObjectIDs(...insightsEvents);
     },

--- a/packages/autocomplete-plugin-algolia-insights/src/types/InsightsClient.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/types/InsightsClient.ts
@@ -1,1 +1,30 @@
-export type InsightsClient = any;
+import type {
+  InsightsMethodMap,
+  InsightsClient as _InsightsClient,
+} from 'search-insights';
+
+export type {
+  Init as InsightsInit,
+  AddAlgoliaAgent as InsightsAddAlgoliaAgent,
+  SetUserToken as InsightsSetUserToken,
+  GetUserToken as InsightsGetUserToken,
+  OnUserTokenChange as InsightsOnUserTokenChange,
+} from 'search-insights';
+
+export type InsightsClientMethod = keyof InsightsMethodMap;
+
+export type InsightsClientPayload = {
+  eventName: string;
+  queryID: string;
+  index: string;
+  objectIDs: string[];
+  positions?: number[];
+};
+
+type QueueItemMap = Record<string, unknown>;
+
+type QueueItem = QueueItemMap[keyof QueueItemMap];
+
+export type InsightsClient = _InsightsClient & {
+  queue?: QueueItem[];
+};

--- a/packages/autocomplete-shared/src/__tests__/safelyRunOnBrowser.test.ts
+++ b/packages/autocomplete-shared/src/__tests__/safelyRunOnBrowser.test.ts
@@ -1,12 +1,5 @@
 import { safelyRunOnBrowser } from '../safelyRunOnBrowser';
 
-type CallbackReturn = {
-  env: 'client' | 'server';
-};
-
-const CLIENT = 'client' as const;
-const SERVER = 'server' as const;
-
 describe('safelyRunOnBrowser', () => {
   const originalWindow = (global as any).window;
 
@@ -15,24 +8,12 @@ describe('safelyRunOnBrowser', () => {
   });
 
   test('runs callback on browsers', () => {
-    const callback = jest.fn(() => ({ env: CLIENT }));
+    const callback = jest.fn(() => ({ env: 'client' }));
 
-    const result = safelyRunOnBrowser<CallbackReturn>(callback);
-
-    expect(callback).toHaveBeenCalledTimes(1);
-    expect(callback).toHaveBeenCalledWith({ window });
-    expect(result).toEqual({ env: 'client' });
-  });
-
-  test('does not run fallback on browsers', () => {
-    const callback = jest.fn(() => ({ env: CLIENT }));
-    const fallback = jest.fn(() => ({ env: SERVER }));
-
-    const result = safelyRunOnBrowser<CallbackReturn>(callback, { fallback });
+    const result = safelyRunOnBrowser(callback);
 
     expect(callback).toHaveBeenCalledTimes(1);
     expect(callback).toHaveBeenCalledWith({ window });
-    expect(fallback).toHaveBeenCalledTimes(0);
     expect(result).toEqual({ env: 'client' });
   });
 
@@ -40,25 +21,11 @@ describe('safelyRunOnBrowser', () => {
     // @ts-expect-error
     delete global.window;
 
-    const callback = jest.fn(() => ({ env: CLIENT }));
+    const callback = jest.fn(() => ({ env: 'client' }));
 
-    const result = safelyRunOnBrowser<CallbackReturn>(callback);
+    const result = safelyRunOnBrowser(callback);
 
     expect(callback).toHaveBeenCalledTimes(0);
     expect(result).toBeUndefined();
-  });
-
-  test('runs fallback on servers', () => {
-    // @ts-expect-error
-    delete global.window;
-
-    const callback = jest.fn(() => ({ env: CLIENT }));
-    const fallback = jest.fn(() => ({ env: SERVER }));
-
-    const result = safelyRunOnBrowser<CallbackReturn>(callback, { fallback });
-
-    expect(callback).toHaveBeenCalledTimes(0);
-    expect(fallback).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ env: 'server' });
   });
 });

--- a/packages/autocomplete-shared/src/__tests__/safelyRunOnBrowser.test.ts
+++ b/packages/autocomplete-shared/src/__tests__/safelyRunOnBrowser.test.ts
@@ -1,0 +1,64 @@
+import { safelyRunOnBrowser } from '../safelyRunOnBrowser';
+
+type CallbackReturn = {
+  env: 'client' | 'server';
+};
+
+const CLIENT = 'client' as const;
+const SERVER = 'server' as const;
+
+describe('safelyRunOnBrowser', () => {
+  const originalWindow = (global as any).window;
+
+  afterEach(() => {
+    (global as any).window = originalWindow;
+  });
+
+  test('runs callback on browsers', () => {
+    const callback = jest.fn(() => ({ env: CLIENT }));
+
+    const result = safelyRunOnBrowser<CallbackReturn>(callback);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith({ window });
+    expect(result).toEqual({ env: 'client' });
+  });
+
+  test('does not run fallback on browsers', () => {
+    const callback = jest.fn(() => ({ env: CLIENT }));
+    const fallback = jest.fn(() => ({ env: SERVER }));
+
+    const result = safelyRunOnBrowser<CallbackReturn>(callback, { fallback });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith({ window });
+    expect(fallback).toHaveBeenCalledTimes(0);
+    expect(result).toEqual({ env: 'client' });
+  });
+
+  test('does not run callback on servers', () => {
+    // @ts-expect-error
+    delete global.window;
+
+    const callback = jest.fn(() => ({ env: CLIENT }));
+
+    const result = safelyRunOnBrowser<CallbackReturn>(callback);
+
+    expect(callback).toHaveBeenCalledTimes(0);
+    expect(result).toBeUndefined();
+  });
+
+  test('runs fallback on servers', () => {
+    // @ts-expect-error
+    delete global.window;
+
+    const callback = jest.fn(() => ({ env: CLIENT }));
+    const fallback = jest.fn(() => ({ env: SERVER }));
+
+    const result = safelyRunOnBrowser<CallbackReturn>(callback, { fallback });
+
+    expect(callback).toHaveBeenCalledTimes(0);
+    expect(fallback).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ env: 'server' });
+  });
+});

--- a/packages/autocomplete-shared/src/index.ts
+++ b/packages/autocomplete-shared/src/index.ts
@@ -9,6 +9,7 @@ export * from './invariant';
 export * from './isEqual';
 export * from './MaybePromise';
 export * from './noop';
+export * from './safelyRunOnBrowser';
 export * from './UserAgent';
 export * from './userAgents';
 export * from './version';

--- a/packages/autocomplete-shared/src/safelyRunOnBrowser.ts
+++ b/packages/autocomplete-shared/src/safelyRunOnBrowser.ts
@@ -1,24 +1,14 @@
 type BrowserCallback<TReturn> = (params: { window: typeof window }) => TReturn;
 
-type SafelyRunOnBrowserOptions<TReturn> = {
-  /**
-   * Fallback to run on server environments.
-   */
-  fallback: () => TReturn;
-};
-
 /**
  * Safely runs code meant for browser environments only.
  */
 export function safelyRunOnBrowser<TReturn>(
-  callback: BrowserCallback<TReturn>,
-  { fallback }: SafelyRunOnBrowserOptions<TReturn> = {
-    fallback: () => (undefined as unknown) as TReturn,
-  }
-): TReturn {
-  if (typeof window === 'undefined') {
-    return fallback();
+  callback: BrowserCallback<TReturn>
+): TReturn | undefined {
+  if (typeof window !== 'undefined') {
+    return callback({ window });
   }
 
-  return callback({ window });
+  return undefined;
 }

--- a/packages/autocomplete-shared/src/safelyRunOnBrowser.ts
+++ b/packages/autocomplete-shared/src/safelyRunOnBrowser.ts
@@ -1,0 +1,24 @@
+type BrowserCallback<TReturn> = (params: { window: typeof window }) => TReturn;
+
+type SafelyRunOnBrowserOptions<TReturn> = {
+  /**
+   * Fallback to run on server environments.
+   */
+  fallback: () => TReturn;
+};
+
+/**
+ * Safely runs code meant for browser environments only.
+ */
+export function safelyRunOnBrowser<TReturn>(
+  callback: BrowserCallback<TReturn>,
+  { fallback }: SafelyRunOnBrowserOptions<TReturn> = {
+    fallback: () => (undefined as unknown) as TReturn,
+  }
+): TReturn {
+  if (typeof window === 'undefined') {
+    return fallback();
+  }
+
+  return callback({ window });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -19226,6 +19226,11 @@ search-insights@1.7.1:
   resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-1.7.1.tgz#eddfa56910e28cbbb0df80aec2ab8acf0a86cb6b"
   integrity sha512-CSuSKIJp+WcSwYrD9GgIt1e3xmI85uyAefC4/KYGgtvNEm6rt4kBGilhVRmTJXxRE2W1JknvP598Q7SMhm7qKA==
 
+search-insights@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.3.0.tgz#9a7bb25428fc7f003bafdb5638e90276113daae6"
+  integrity sha512-0v/TTO4fbd6I91sFBK/e2zNfD0f51A+fMoYNkMplmR77NpThUye/7gIxNoJ3LejKpZH6Z2KNBIpxxFmDKj10Yw==
+
 search-insights@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.2.1.tgz#9c93344fbae5fbf2f88c1a81b46b4b5d888c11f7"


### PR DESCRIPTION
This automatically loads the Insights library when using the Insights plugin without passing a client.

The `insightsClient` parameter is now optional, allowing us to later initialize the plugin internally without a client if we can't find one on the page.

[FX-2245](https://algolia.atlassian.net/browse/FX-2245)

[FX-2245]: https://algolia.atlassian.net/browse/FX-2245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ