### PR TITLE
fix(autocomplete-js): display warning when there are more than one instances of autocomplete

### DIFF
--- a/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
+++ b/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
@@ -39,7 +39,7 @@ describe('autocomplete-js', () => {
     ).toWarnDev(
       `[Autocomplete] Autocomplete doesn't support multiple instances running at the same time. Make sure to destroy the previous instance before creating a new one.
 
-See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#returns`
+See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-destroy`
     );
   });
 

--- a/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
+++ b/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
@@ -37,7 +37,9 @@ describe('autocomplete-js', () => {
         container: secondContainer,
       })
     ).toWarnDev(
-      '[Autocomplete] Multiple instances of Autocomplete are not currently supported and can introduce unwanted behavior during user interaction. Please destroy the previous instance before creating a new one.'
+      `[Autocomplete] Autocomplete doesn't support multiple instances running at the same time. Make sure to destroy the previous instance before creating a new one.
+
+See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#returns`
     );
   });
 

--- a/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
+++ b/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
@@ -23,6 +23,24 @@ beforeEach(() => {
 });
 
 describe('autocomplete-js', () => {
+  test('warns when more than one instance is detected in a document', () => {
+    const firstContainer = document.createElement('div');
+    expect(() =>
+      autocomplete({
+        container: firstContainer,
+      })
+    ).not.toWarnDev();
+
+    const secondContainer = document.createElement('div');
+    expect(() =>
+      autocomplete({
+        container: secondContainer,
+      })
+    ).toWarnDev(
+      '[Autocomplete] Multiple instances of Autocomplete are not currently supported and can introduce unwanted behavior during user interaction. Please destroy the previous instance before creating a new one.'
+    );
+  });
+
   test('renders with default options', () => {
     const container = document.createElement('div');
     autocomplete<{ label: string }>({

--- a/packages/autocomplete-js/src/__tests__/renderer.test.ts
+++ b/packages/autocomplete-js/src/__tests__/renderer.test.ts
@@ -24,7 +24,7 @@ describe('renderer', () => {
     const panelContainer = document.createElement('div');
 
     document.body.appendChild(panelContainer);
-    autocomplete<{ label: string }>({
+    const { destroy } = autocomplete<{ label: string }>({
       container,
       panelContainer,
       initialState: {
@@ -53,6 +53,8 @@ describe('renderer', () => {
         render(createElement(Fragment, null, 'testSource'), root);
       },
     });
+
+    destroy();
   });
 
   test('accepts a custom renderer', () => {
@@ -66,7 +68,7 @@ describe('renderer', () => {
 
     document.body.appendChild(panelContainer);
 
-    autocomplete<{ label: string }>({
+    const { destroy } = autocomplete<{ label: string }>({
       container,
       panelContainer,
       initialState: {
@@ -110,6 +112,8 @@ describe('renderer', () => {
         render: mockRender,
       },
     });
+
+    destroy();
   });
 
   test('defaults `render` when not specified in the renderer', () => {
@@ -122,7 +126,7 @@ describe('renderer', () => {
 
     document.body.appendChild(panelContainer);
 
-    autocomplete<{ label: string }>({
+    const { destroy } = autocomplete<{ label: string }>({
       container,
       panelContainer,
       initialState: {
@@ -153,6 +157,8 @@ describe('renderer', () => {
         Fragment: CustomFragment,
       },
     });
+
+    destroy();
   });
 
   test('uses a custom `render` via `renderer`', async () => {
@@ -165,7 +171,7 @@ describe('renderer', () => {
     const mockCreateElement = jest.fn(preactCreateElement);
     const mockRender = jest.fn().mockImplementation(preactRender);
 
-    autocomplete<{ label: string }>({
+    const { destroy } = autocomplete<{ label: string }>({
       container,
       panelContainer,
       id: 'autocomplete-0',
@@ -238,6 +244,8 @@ describe('renderer', () => {
         </div>
       `);
     });
+
+    destroy();
   });
 
   test('warns about renderer mismatch when specifying an incomplete renderer', () => {
@@ -249,8 +257,10 @@ describe('renderer', () => {
 
     document.body.appendChild(panelContainer);
 
+    let instance;
+
     expect(() => {
-      autocomplete<{ label: string }>({
+      instance = autocomplete<{ label: string }>({
         container,
         panelContainer,
         initialState: {
@@ -280,9 +290,10 @@ describe('renderer', () => {
       '[Autocomplete] You provided an incomplete `renderer` (missing: `renderer.render`). This can cause rendering issues.' +
         '\nSee https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-renderer'
     );
+    instance.destroy();
 
     expect(() => {
-      autocomplete<{ label: string }>({
+      instance = autocomplete<{ label: string }>({
         container,
         panelContainer,
         initialState: {
@@ -315,9 +326,10 @@ describe('renderer', () => {
       '[Autocomplete] You provided an incomplete `renderer` (missing: `renderer.createElement`). This can cause rendering issues.' +
         '\nSee https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-renderer'
     );
+    instance.destroy();
 
     expect(() => {
-      autocomplete<{ label: string }>({
+      instance = autocomplete<{ label: string }>({
         container,
         panelContainer,
         initialState: {
@@ -350,9 +362,10 @@ describe('renderer', () => {
       '[Autocomplete] You provided an incomplete `renderer` (missing: `renderer.Fragment`). This can cause rendering issues.' +
         '\nSee https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-renderer'
     );
+    instance.destroy();
 
     expect(() => {
-      autocomplete<{ label: string }>({
+      instance = autocomplete<{ label: string }>({
         container,
         panelContainer,
         initialState: {
@@ -384,6 +397,7 @@ describe('renderer', () => {
       '[Autocomplete] You provided an incomplete `renderer` (missing: `renderer.Fragment`, `renderer.render`). This can cause rendering issues.' +
         '\nSee https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-renderer'
     );
+    instance.destroy();
   });
 
   test('warns about new `renderer.render` option when specifying an incomplete renderer and a `render` option', () => {
@@ -394,8 +408,9 @@ describe('renderer', () => {
 
     document.body.appendChild(panelContainer);
 
+    let instance;
     function startAutocomplete() {
-      autocomplete<{ label: string }>({
+      instance = autocomplete<{ label: string }>({
         container,
         panelContainer,
         initialState: {
@@ -434,11 +449,13 @@ describe('renderer', () => {
         '\n- If you are using the `render` option to work with React 18, pass an empty `render` function into `renderer`.' +
         '\nSee https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-render'
     );
+    instance.destroy();
 
     expect(startAutocomplete).not.toWarnDev(
       '[Autocomplete] You provided an incomplete `renderer` (missing: `renderer.Fragment`, `renderer.render`). This can cause rendering issues.' +
         '\nSee https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-renderer'
     );
+    instance.destroy();
   });
 
   test('does not warn at all when only passing a `render` option', () => {
@@ -447,8 +464,9 @@ describe('renderer', () => {
 
     document.body.appendChild(panelContainer);
 
+    let instance;
     expect(() => {
-      autocomplete<{ label: string }>({
+      instance = autocomplete<{ label: string }>({
         container,
         panelContainer,
         initialState: {
@@ -474,6 +492,7 @@ describe('renderer', () => {
         },
       });
     }).not.toWarnDev();
+    instance.destroy();
   });
 
   test('does not warn at all when passing an empty `renderer.render` function', () => {
@@ -484,8 +503,9 @@ describe('renderer', () => {
 
     document.body.appendChild(panelContainer);
 
+    let instance;
     expect(() => {
-      autocomplete<{ label: string }>({
+      instance = autocomplete<{ label: string }>({
         container,
         panelContainer,
         initialState: {
@@ -513,6 +533,7 @@ describe('renderer', () => {
         },
       });
     }).not.toWarnDev();
+    instance.destroy();
   });
 
   test('does not warn at all when not passing a custom renderer', () => {
@@ -521,8 +542,9 @@ describe('renderer', () => {
 
     document.body.appendChild(panelContainer);
 
+    let instance;
     expect(() => {
-      autocomplete<{ label: string }>({
+      instance = autocomplete<{ label: string }>({
         container,
         panelContainer,
         initialState: {
@@ -545,6 +567,7 @@ describe('renderer', () => {
         },
       });
     }).not.toWarnDev();
+    instance.destroy();
   });
 
   test('does not warn at all when passing a full custom renderer', () => {
@@ -556,8 +579,9 @@ describe('renderer', () => {
 
     document.body.appendChild(panelContainer);
 
+    let instance;
     expect(() => {
-      autocomplete<{ label: string }>({
+      instance = autocomplete<{ label: string }>({
         container,
         panelContainer,
         initialState: {
@@ -585,5 +609,6 @@ describe('renderer', () => {
         },
       });
     }).not.toWarnDev();
+    instance.destroy();
   });
 });

--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -405,7 +405,7 @@ export function autocomplete<TItem extends BaseItem>(
     instancesCount === 0,
     `Autocomplete doesn't support multiple instances running at the same time. Make sure to destroy the previous instance before creating a new one.
 
-See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#returns`
+See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-destroy`
   );
 
   instancesCount++;

--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -7,6 +7,7 @@ import {
   createRef,
   debounce,
   getItemsCount,
+  warn,
 } from '@algolia/autocomplete-shared';
 import htm from 'htm';
 
@@ -26,6 +27,8 @@ import {
 } from './types';
 import { userAgents } from './userAgents';
 import { mergeDeep, pickBy, setProperties } from './utils';
+
+let instancesCount = 0;
 
 export function autocomplete<TItem extends BaseItem>(
   options: AutocompleteOptions<TItem>
@@ -336,6 +339,7 @@ export function autocomplete<TItem extends BaseItem>(
   });
 
   function destroy() {
+    instancesCount--;
     cleanupEffects();
   }
 
@@ -396,6 +400,13 @@ export function autocomplete<TItem extends BaseItem>(
       }
     });
   }
+
+  warn(
+    instancesCount === 0,
+    'Multiple instances of Autocomplete are not currently supported and can introduce unwanted behavior during user interaction. Please destroy the previous instance before creating a new one.'
+  );
+
+  instancesCount++;
 
   return {
     ...autocompleteScopeApi,

--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -403,7 +403,9 @@ export function autocomplete<TItem extends BaseItem>(
 
   warn(
     instancesCount === 0,
-    'Multiple instances of Autocomplete are not currently supported and can introduce unwanted behavior during user interaction. Please destroy the previous instance before creating a new one.'
+    `Autocomplete doesn't support multiple instances running at the same time. Make sure to destroy the previous instance before creating a new one.
+
+See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#returns`
   );
 
   instancesCount++;


### PR DESCRIPTION
While autocomplate can technically render multiple instances in the same document, in practice it results in inconsistent behavior when a user interacts with them.

This is because we currently bind pointer events on Window to determine whether a panel should be closed after a user clicks outside of it. This only works for one of the autocomplete added to the document.

Until we find a way to handle that, and to make customers aware of this limitation, this PR displays a warning in dev when there are more than a single instance of Autocomplete on a document.