### PR TITLE
feat(createAlgoliaInsightsPlugin): use `search-insights@2.4.0`

### DIFF
--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -234,7 +234,7 @@ describe('createAlgoliaInsightsPlugin', () => {
       expect(document.body).toMatchInlineSnapshot(`
         <body>
           <script
-            src="https://cdn.jsdelivr.net/npm/search-insights@2.3.0/dist/search-insights.min.js"
+            src="https://cdn.jsdelivr.net/npm/search-insights@2.4.0/dist/search-insights.min.js"
           />
           <form>
             <input />
@@ -243,7 +243,7 @@ describe('createAlgoliaInsightsPlugin', () => {
       `);
       expect((window as any).AlgoliaAnalyticsObject).toBe('aa');
       expect((window as any).aa).toEqual(expect.any(Function));
-      expect((window as any).aa.version).toBe('2.3.0');
+      expect((window as any).aa.version).toBe('2.4.0');
     });
 
     it('notifies when the script fails to be added', () => {

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -24,7 +24,7 @@ import {
 } from './types';
 
 const VIEW_EVENT_DELAY = 400;
-const ALGOLIA_INSIGHTS_VERSION = '2.3.0';
+const ALGOLIA_INSIGHTS_VERSION = '2.4.0';
 const ALGOLIA_INSIGHTS_SRC = `https://cdn.jsdelivr.net/npm/search-insights@${ALGOLIA_INSIGHTS_VERSION}/dist/search-insights.min.js`;
 
 type SendViewedObjectIDsParams = {


### PR DESCRIPTION
This uses [`search-insights@2.4.0`](https://github.com/algolia/search-insights.js/releases/tag/v2.4.0) with automatic events, which lets us send events to the right app even in multi-client situations (to be implemented in [FX-2276](https://algolia.atlassian.net/browse/FX-2276) and [FX-2277](https://algolia.atlassian.net/browse/FX-2277)).

[FX-2276]: https://algolia.atlassian.net/browse/FX-2276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-2277]: https://algolia.atlassian.net/browse/FX-2277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ