### PR TITLE
feat(insights): only send events if algolia response allows it

### DIFF
--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -221,7 +221,6 @@ export function createAlgoliaInsightsPlugin(
       onResolve(({ results }) => {
         if (
           !analyticsEnabled &&
-          verifyEventPermission &&
           Array.isArray(results) &&
           results.some(
             (result) =>


### PR DESCRIPTION
### [FX-2297](https://algolia.atlassian.net/browse/FX-2297)

Similarly as https://github.com/algolia/instantsearch/pull/5557 it's still a POC and assumes it's OK to have the plugin still loaded and have `search-insights` be pulled no matter what.

The solution is a bit more complex than for InstantSearch as results can be something else than a `SearchResponse`, and we have to keep track of the response via `onResolve` as it's not present out of the box like in InstantSearch.

We also don't have a wrapper around insights like `sendEventToInsights` so I added early returns for `onActive`, `onSelect` and `onStateChange`.

[FX-2297]: https://algolia.atlassian.net/browse/FX-2297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ