### PR TITLE
feat(insights): add plugin automatically based on server response

### DIFF
--- a/packages/autocomplete-preset-algolia/src/search/fetchAlgoliaResults.ts
+++ b/packages/autocomplete-preset-algolia/src/search/fetchAlgoliaResults.ts
@@ -60,6 +60,14 @@ export function fetchAlgoliaResults<TRecord>({
       })
     )
     .then((response) => {
-      return response.results;
+      return response.results.map((result) => ({
+        ...result,
+        hits: result.hits.map((hit) => ({
+          ...hit,
+          __autocomplete_algoliaResultsMetadata: {
+            analytics: (result.renderingContent as any)?.analytics || true,
+          },
+        })),
+      }));
     });
 }


### PR DESCRIPTION
This POC tests the feasibility of adding the Insights plugin conditionally, based on server data exposed through Algolia items.

I mocked adding the plugin, since there are circular dependency issues that will be solved in another task.

Here's a sandbox for testing the code: https://codesandbox.io/s/algolia-autocomplete-example-starter-algolia-forked-6od2yc.

It contains a static source and an Algolia source that gets returned if the query starts with "iPhone".

FX-2295