### PR TITLE
ci(shipjs): define git user before trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,10 @@ jobs:
       - run: *restore_dist_folders
       - run:
           name: Release if needed
-          command: yarn run shipjs trigger
+          command: |
+            git config --global user.email "autocomplete-bot@algolia.com"
+            git config --global user.name "Autocomplete[bot]"
+            yarn run shipjs trigger
 
 workflows:
   version: 2.1


### PR DESCRIPTION
To merge https://github.com/algolia/autocomplete/pull/887, we first need to define a git user (as documented in the release notes) since the subsequent versions of Ship.js use annotated tags.