### PR TITLE
feat(insights): annotate events with algoliaSource

### DIFF
--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -330,6 +330,7 @@ describe('createAlgoliaInsightsPlugin', () => {
         eventName: 'Items Viewed',
         index: 'index1',
         objectIDs: ['1'],
+        algoliaSource: ['autocomplete', 'autocomplete-internal'],
       });
     });
 
@@ -381,11 +382,13 @@ describe('createAlgoliaInsightsPlugin', () => {
         eventName: 'Items Viewed',
         index: 'index1',
         objectIDs: ['1'],
+        algoliaSource: ['autocomplete', 'autocomplete-internal'],
       });
       expect(insightsClient).toHaveBeenNthCalledWith(2, 'viewedObjectIDs', {
         eventName: 'Items Viewed',
         index: 'index2',
         objectIDs: ['2'],
+        algoliaSource: ['autocomplete', 'autocomplete-internal'],
       });
     });
 
@@ -431,6 +434,7 @@ describe('createAlgoliaInsightsPlugin', () => {
         eventName: 'Product Viewed from Autocomplete',
         index: 'index1',
         objectIDs: ['1'],
+        algoliaSource: ['autocomplete'],
       });
     });
 
@@ -529,6 +533,7 @@ describe('createAlgoliaInsightsPlugin', () => {
         eventName: 'Items Viewed',
         index: 'index1',
         objectIDs: ['1', '3'],
+        algoliaSource: ['autocomplete', 'autocomplete-internal'],
       });
 
       // The call triggered with "help" occurred after the timeout, so the item
@@ -537,6 +542,7 @@ describe('createAlgoliaInsightsPlugin', () => {
         eventName: 'Items Viewed',
         index: 'index1',
         objectIDs: ['3'],
+        algoliaSource: ['autocomplete', 'autocomplete-internal'],
       });
     });
 
@@ -638,6 +644,7 @@ describe('createAlgoliaInsightsPlugin', () => {
           objectIDs: ['1'],
           positions: [0],
           queryID: 'queryID1',
+          algoliaSource: ['autocomplete', 'autocomplete-internal'],
         }
       );
     });
@@ -692,6 +699,7 @@ describe('createAlgoliaInsightsPlugin', () => {
           objectIDs: ['1'],
           positions: [0],
           queryID: 'queryID1',
+          algoliaSource: ['autocomplete'],
         }
       );
     });
@@ -849,6 +857,7 @@ describe('createAlgoliaInsightsPlugin', () => {
         objectIDs: ['1'],
         positions: [0],
         queryID: 'queryID1',
+        algoliaSource: ['autocomplete'],
       });
     });
 

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -216,10 +216,26 @@ export function createAlgoliaInsightsPlugin(
 function getOptions(options: CreateAlgoliaInsightsPluginParams) {
   return {
     onItemsChange({ insights, insightsEvents }: OnItemsChangeParams) {
-      insights.viewedObjectIDs(...insightsEvents);
+      insights.viewedObjectIDs(
+        ...insightsEvents.map((event) => ({
+          ...event,
+          algoliaSource: [
+            ...(event.algoliaSource || []),
+            'autocomplete-internal',
+          ],
+        }))
+      );
     },
     onSelect({ insights, insightsEvents }: OnSelectParams) {
-      insights.clickedObjectIDsAfterSearch(...insightsEvents);
+      insights.clickedObjectIDsAfterSearch(
+        ...insightsEvents.map((event) => ({
+          ...event,
+          algoliaSource: [
+            ...(event.algoliaSource || []),
+            'autocomplete-internal',
+          ],
+        }))
+      );
     },
     onActive: noop,
     ...options,

--- a/packages/autocomplete-plugin-algolia-insights/src/createClickedEvent.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createClickedEvent.ts
@@ -11,11 +11,12 @@ export function createClickedEvent({
 }: CreateClickedEventParams): Omit<
   ClickedObjectIDsAfterSearchParams,
   'eventName'
-> {
+> & { algoliaSource?: string[] } {
   return {
     index: item.__autocomplete_indexName,
     objectIDs: [item.objectID],
     positions: [1 + items.findIndex((x) => x.objectID === item.objectID)],
     queryID: item.__autocomplete_queryID,
+    algoliaSource: ['autocomplete'],
   };
 }

--- a/packages/autocomplete-plugin-algolia-insights/src/createViewedEvents.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createViewedEvents.ts
@@ -24,6 +24,7 @@ export function createViewedEvents({
     return {
       index: indexName,
       objectIDs,
+      algoliaSource: ['autocomplete'],
     };
   });
 }

--- a/packages/autocomplete-plugin-algolia-insights/src/types/EventParams.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/types/EventParams.ts
@@ -9,7 +9,9 @@ import { AlgoliaInsightsHit, AutocompleteInsightsApi } from '.';
 
 export type OnSelectParams = {
   insights: AutocompleteInsightsApi;
-  insightsEvents: ClickedObjectIDsAfterSearchParams[];
+  insightsEvents: Array<
+    ClickedObjectIDsAfterSearchParams & { algoliaSource?: string[] }
+  >;
   item: AlgoliaInsightsHit;
   state: AutocompleteState<any>;
   event: any;
@@ -19,6 +21,6 @@ export type OnActiveParams = OnSelectParams;
 
 export type OnItemsChangeParams = {
   insights: AutocompleteInsightsApi;
-  insightsEvents: ViewedObjectIDsParams[];
+  insightsEvents: Array<ViewedObjectIDsParams & { algoliaSource?: string[] }>;
   state: AutocompleteState<any>;
 };


### PR DESCRIPTION
Default events get `autocomplete, autocomplete-internal`, custom events only get `autocomplete`.

FX-2288