### PR TITLE
feat(insights): re-export insights types from main packages

### DIFF
--- a/packages/autocomplete-core/src/types/index.ts
+++ b/packages/autocomplete-core/src/types/index.ts
@@ -2,12 +2,18 @@ export * from '@algolia/autocomplete-shared/dist/esm/core';
 export * from './AutocompleteStore';
 export * from './AutocompleteSubscribers';
 
-import { CreateAlgoliaInsightsPluginParams } from '@algolia/autocomplete-plugin-algolia-insights';
+import {
+  CreateAlgoliaInsightsPluginParams,
+  AutocompleteInsightsApi as _AutocompleteInsightsApi,
+  AlgoliaInsightsHit as _AlgoliaInsightsHit,
+} from '@algolia/autocomplete-plugin-algolia-insights';
 import {
   AutocompleteOptions as _AutocompleteOptions,
   BaseItem,
 } from '@algolia/autocomplete-shared/dist/esm/core';
 
+export type AutocompleteInsightsApi = _AutocompleteInsightsApi;
+export type AlgoliaInsightsHit = _AlgoliaInsightsHit;
 export interface AutocompleteOptions<TItem extends BaseItem>
   extends _AutocompleteOptions<TItem> {
   /**

--- a/packages/autocomplete-js/src/types/index.ts
+++ b/packages/autocomplete-js/src/types/index.ts
@@ -8,6 +8,11 @@ import {
 } from '@algolia/autocomplete-core';
 import { AutocompleteOptions as AutocompleteJsOptions } from '@algolia/autocomplete-shared/dist/esm/js';
 
+export type {
+  AutocompleteInsightsApi,
+  AlgoliaInsightsHit,
+} from '@algolia/autocomplete-core';
+
 export interface AutocompleteOptions<TItem extends BaseItem>
   extends AutocompleteJsOptions<TItem> {
   insights?: AutocompleteCoreOptions<TItem>['insights'];

--- a/packages/autocomplete-plugin-algolia-insights/src/index.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/index.ts
@@ -1,2 +1,2 @@
-export type { AutocompleteInsightsApi } from './types/AutocompleteInsightsApi';
+export * from './types';
 export * from './createAlgoliaInsightsPlugin';


### PR DESCRIPTION
These types are sometimes needed in implementations, eg. to have `autocomplete.insights` being typed, and to type an AlgoliaInsightsHit