### PR TITLE
fix(insights): bump embedded search-insights version

### DIFF
--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -234,7 +234,7 @@ describe('createAlgoliaInsightsPlugin', () => {
       expect(document.body).toMatchInlineSnapshot(`
         <body>
           <script
-            src="https://cdn.jsdelivr.net/npm/search-insights@2.4.0/dist/search-insights.min.js"
+            src="https://cdn.jsdelivr.net/npm/search-insights@2.6.0/dist/search-insights.min.js"
           />
           <form>
             <input />
@@ -243,7 +243,7 @@ describe('createAlgoliaInsightsPlugin', () => {
       `);
       expect((window as any).AlgoliaAnalyticsObject).toBe('aa');
       expect((window as any).aa).toEqual(expect.any(Function));
-      expect((window as any).aa.version).toBe('2.4.0');
+      expect((window as any).aa.version).toBe('2.6.0');
     });
 
     it('notifies when the script fails to be added', () => {
@@ -736,7 +736,7 @@ describe('createAlgoliaInsightsPlugin', () => {
     test('sends a `clickedObjectIDsAfterSearch` event with additional parameters if client supports it', async () => {
       const insightsClient = jest.fn();
       // @ts-ignore
-      insightsClient.version = '2.4.0';
+      insightsClient.version = '2.6.0';
       const insightsPlugin = createAlgoliaInsightsPlugin({ insightsClient });
 
       const { inputElement } = createPlayground(createAutocomplete, {

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -22,7 +22,7 @@ import {
 } from './types';
 
 const VIEW_EVENT_DELAY = 400;
-const ALGOLIA_INSIGHTS_VERSION = '2.4.0';
+const ALGOLIA_INSIGHTS_VERSION = '2.6.0';
 const ALGOLIA_INSIGHTS_SRC = `https://cdn.jsdelivr.net/npm/search-insights@${ALGOLIA_INSIGHTS_VERSION}/dist/search-insights.min.js`;
 
 type SendViewedObjectIDsParams = {

--- a/packages/autocomplete-plugin-algolia-insights/src/createSearchInsightsApi.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createSearchInsightsApi.ts
@@ -57,7 +57,7 @@ export function createSearchInsightsApi(searchInsights: InsightsClient) {
         'X-Algolia-API-Key': apiKey,
       };
 
-      searchInsights(method, ...payloads, { headers } as any);
+      searchInsights(method, ...payloads, { headers });
     } else {
       searchInsights(method, ...payloads);
     }


### PR DESCRIPTION
This PR updates the default insights client that's loaded to the latest version.