### PR TITLE
fix(fetchAlgoliaResults): safely access searchClient credentials

### DIFF
--- a/packages/autocomplete-preset-algolia/src/search/__tests__/fetchAlgoliaResults.test.ts
+++ b/packages/autocomplete-preset-algolia/src/search/__tests__/fetchAlgoliaResults.test.ts
@@ -199,4 +199,59 @@ describe('fetchAlgoliaResults', () => {
       '1.0.0'
     );
   });
+
+  describe('missing credentials', () => {
+    test('throws dev error when searchClient has no readable appId', () => {
+      const searchClient = {
+        search: createSearchClient().search,
+      };
+
+      expect(() => {
+        fetchAlgoliaResults({
+          // @ts-expect-error
+          searchClient,
+          queries: [],
+          userAgents: [{ segment: 'custom-ua', version: '1.0.0' }],
+        });
+      }).toThrowErrorMatchingInlineSnapshot(
+        `"[Autocomplete] The Algolia \`appId\` was not accessible from the searchClient passed."`
+      );
+    });
+
+    test('throws dev error when searchClient has no readable apiKey', () => {
+      const searchClient = {
+        search: createSearchClient().search,
+        transporter: {
+          headers: {
+            'x-algolia-application-id': 'appId',
+          },
+        },
+      };
+
+      expect(() => {
+        fetchAlgoliaResults({
+          // @ts-expect-error
+          searchClient,
+          queries: [],
+          userAgents: [{ segment: 'custom-ua', version: '1.0.0' }],
+        });
+      }).toThrowErrorMatchingInlineSnapshot(
+        `"[Autocomplete] The Algolia \`apiKey\` was not accessible from the searchClient passed."`
+      );
+    });
+
+    test('does not throw dev error when searchClient is copied', () => {
+      const searchClient = {
+        ...createSearchClient(),
+      };
+
+      expect(() => {
+        fetchAlgoliaResults({
+          searchClient,
+          queries: [],
+          userAgents: [{ segment: 'custom-ua', version: '1.0.0' }],
+        });
+      }).not.toThrow();
+    });
+  });
 });

--- a/packages/autocomplete-preset-algolia/src/search/fetchAlgoliaResults.ts
+++ b/packages/autocomplete-preset-algolia/src/search/fetchAlgoliaResults.ts
@@ -1,6 +1,7 @@
 import {
   userAgents as coreUserAgents,
   UserAgent,
+  invariant,
 } from '@algolia/autocomplete-shared';
 
 import { HIGHLIGHT_PRE_TAG, HIGHLIGHT_POST_TAG } from '../constants';
@@ -27,6 +28,15 @@ export function fetchAlgoliaResults<TRecord>({
   }
 
   const { appId, apiKey } = getAppIdAndApiKey(searchClient);
+
+  invariant(
+    Boolean(appId),
+    'The Algolia `appId` was not accessible from the searchClient passed.'
+  );
+  invariant(
+    Boolean(apiKey),
+    'The Algolia `apiKey` was not accessible from the searchClient passed.'
+  );
 
   return searchClient
     .search<TRecord>(

--- a/packages/autocomplete-preset-algolia/src/utils/__tests__/getAppIdAndApiKey.test.ts
+++ b/packages/autocomplete-preset-algolia/src/utils/__tests__/getAppIdAndApiKey.test.ts
@@ -12,4 +12,14 @@ describe('getAppIdAndApiKey', () => {
     expect(appId).toEqual(APP_ID);
     expect(apiKey).toEqual(API_KEY);
   });
+
+  it('gets undefined appId and apiKey from broken search client', () => {
+    const searchClient = {
+      search: algoliasearchV4(APP_ID, API_KEY).search,
+    };
+    // @ts-expect-error
+    const { appId, apiKey } = getAppIdAndApiKey(searchClient);
+    expect(appId).toEqual(undefined);
+    expect(apiKey).toEqual(undefined);
+  });
 });

--- a/packages/autocomplete-preset-algolia/src/utils/getAppIdAndApiKey.ts
+++ b/packages/autocomplete-preset-algolia/src/utils/getAppIdAndApiKey.ts
@@ -4,7 +4,7 @@ export function getAppIdAndApiKey(searchClient: SearchClient): {
   appId: string;
   apiKey: string;
 } {
-  const { headers, queryParameters } = searchClient.transporter;
+  const { headers = {}, queryParameters = {} } = searchClient.transporter || {};
   const APP_ID = 'x-algolia-application-id';
   const API_KEY = 'x-algolia-api-key';
   const appId = headers[APP_ID] || queryParameters[APP_ID];


### PR DESCRIPTION
It's possible to have a broken / badly copied search client without transporter, and that would throw from 1.9.2 onwards.

This PR makes that access safer and throws a clear error.

CR-3338