### PR TITLE
fix(insights): retrieve index name from query if not returned by response

### DIFF
--- a/packages/autocomplete-core/src/utils/__tests__/mapToAlgoliaResponse.test.ts
+++ b/packages/autocomplete-core/src/utils/__tests__/mapToAlgoliaResponse.test.ts
@@ -76,14 +76,10 @@ describe('mapToAlgoliaResponse', () => {
       expect.objectContaining({
         hits: [
           {
-            __autocomplete_indexName: 'indexName',
-            __autocomplete_queryID: 'queryID',
             label: 'Label 1',
             objectID: '1',
           },
           {
-            __autocomplete_indexName: 'indexName',
-            __autocomplete_queryID: 'queryID',
             label: 'Label 2',
             objectID: '2',
           },
@@ -92,14 +88,10 @@ describe('mapToAlgoliaResponse', () => {
       expect.objectContaining({
         hits: [
           {
-            __autocomplete_indexName: 'indexName',
-            __autocomplete_queryID: 'queryID',
             label: 'Label 3',
             objectID: '3',
           },
           {
-            __autocomplete_indexName: 'indexName',
-            __autocomplete_queryID: 'queryID',
             label: 'Label 4',
             objectID: '4',
           },
@@ -143,28 +135,20 @@ describe('mapToAlgoliaResponse', () => {
     expect(hits).toEqual([
       [
         {
-          __autocomplete_indexName: 'indexName',
-          __autocomplete_queryID: 'queryID',
           label: 'Label 1',
           objectID: '1',
         },
         {
-          __autocomplete_indexName: 'indexName',
-          __autocomplete_queryID: 'queryID',
           label: 'Label 2',
           objectID: '2',
         },
       ],
       [
         {
-          __autocomplete_indexName: 'indexName',
-          __autocomplete_queryID: 'queryID',
           label: 'Label 3',
           objectID: '3',
         },
         {
-          __autocomplete_indexName: 'indexName',
-          __autocomplete_queryID: 'queryID',
           label: 'Label 4',
           objectID: '4',
         },

--- a/packages/autocomplete-core/src/utils/mapToAlgoliaResponse.ts
+++ b/packages/autocomplete-core/src/utils/mapToAlgoliaResponse.ts
@@ -6,27 +6,12 @@ import type {
 export function mapToAlgoliaResponse<THit>(
   rawResults: Array<SearchResponse<THit> | SearchForFacetValuesResponse>
 ) {
-  const results: Array<SearchResponse<THit> | SearchForFacetValuesResponse> =
-    rawResults.map((result) => {
-      return {
-        ...result,
-        hits: (result as SearchResponse<THit>).hits?.map((hit) => {
-          // Bring support for the Insights plugin.
-          return {
-            ...hit,
-            __autocomplete_indexName: (result as SearchResponse<THit>).index,
-            __autocomplete_queryID: (result as SearchResponse<THit>).queryID,
-          };
-        }),
-      };
-    });
-
   return {
-    results,
-    hits: results
+    results: rawResults,
+    hits: rawResults
       .map((result) => (result as SearchResponse<THit>).hits)
       .filter(Boolean),
-    facetHits: results
+    facetHits: rawResults
       .map((result) =>
         (result as SearchForFacetValuesResponse).facetHits?.map((facetHit) => {
           // Bring support for the highlighting components.

--- a/packages/autocomplete-js/src/__tests__/requester.test.ts
+++ b/packages/autocomplete-js/src/__tests__/requester.test.ts
@@ -265,7 +265,7 @@ describe('requester', () => {
           .map((node) => node.textContent)
       ).toMatchInlineSnapshot(`
         Array [
-          "{\\"objectID\\":\\"1\\",\\"label\\":\\"Hit 1\\",\\"__autocomplete_algoliaCredentials\\":{\\"appId\\":\\"algoliaAppId\\",\\"apiKey\\":\\"algoliaApiKey\\"},\\"__autocomplete_id\\":0}",
+          "{\\"objectID\\":\\"1\\",\\"label\\":\\"Hit 1\\",\\"__autocomplete_indexName\\":\\"indexName\\",\\"__autocomplete_algoliaCredentials\\":{\\"appId\\":\\"algoliaAppId\\",\\"apiKey\\":\\"algoliaApiKey\\"},\\"__autocomplete_id\\":0}",
         ]
       `);
 
@@ -304,7 +304,7 @@ describe('requester', () => {
           .map((node) => node.textContent)
       ).toMatchInlineSnapshot(`
         Array [
-          "{\\"objectID\\":\\"7\\",\\"label\\":\\"Hit 7\\",\\"__autocomplete_algoliaCredentials\\":{\\"appId\\":\\"algoliaAppId\\",\\"apiKey\\":\\"algoliaApiKey\\"},\\"__autocomplete_id\\":4}",
+          "{\\"objectID\\":\\"7\\",\\"label\\":\\"Hit 7\\",\\"__autocomplete_indexName\\":\\"indexName\\",\\"__autocomplete_algoliaCredentials\\":{\\"appId\\":\\"algoliaAppId\\",\\"apiKey\\":\\"algoliaApiKey\\"},\\"__autocomplete_id\\":4}",
         ]
       `);
 
@@ -316,8 +316,8 @@ describe('requester', () => {
           .map((node) => node.textContent)
       ).toMatchInlineSnapshot(`
         Array [
-          "{\\"objectID\\":\\"3\\",\\"label\\":\\"Hit 3\\",\\"__autocomplete_algoliaCredentials\\":{\\"appId\\":\\"algoliaAppId\\",\\"apiKey\\":\\"algoliaApiKey\\"},\\"__autocomplete_id\\":5}",
-          "{\\"objectID\\":\\"4\\",\\"label\\":\\"Hit 4\\",\\"__autocomplete_algoliaCredentials\\":{\\"appId\\":\\"algoliaAppId\\",\\"apiKey\\":\\"algoliaApiKey\\"},\\"__autocomplete_id\\":6}",
+          "{\\"objectID\\":\\"3\\",\\"label\\":\\"Hit 3\\",\\"__autocomplete_indexName\\":\\"indexName\\",\\"__autocomplete_algoliaCredentials\\":{\\"appId\\":\\"algoliaAppId\\",\\"apiKey\\":\\"algoliaApiKey\\"},\\"__autocomplete_id\\":5}",
+          "{\\"objectID\\":\\"4\\",\\"label\\":\\"Hit 4\\",\\"__autocomplete_indexName\\":\\"indexName2\\",\\"__autocomplete_algoliaCredentials\\":{\\"appId\\":\\"algoliaAppId\\",\\"apiKey\\":\\"algoliaApiKey\\"},\\"__autocomplete_id\\":6}",
         ]
       `);
 
@@ -331,7 +331,7 @@ describe('requester', () => {
           .map((node) => node.textContent)
       ).toMatchInlineSnapshot(`
         Array [
-          "{\\"objectID\\":\\"5\\",\\"label\\":\\"Hit 5\\",\\"__autocomplete_algoliaCredentials\\":{\\"appId\\":\\"algoliaAppId\\",\\"apiKey\\":\\"algoliaApiKey\\"},\\"__autocomplete_id\\":7}",
+          "{\\"objectID\\":\\"5\\",\\"label\\":\\"Hit 5\\",\\"__autocomplete_indexName\\":\\"indexName\\",\\"__autocomplete_algoliaCredentials\\":{\\"appId\\":\\"algoliaAppId\\",\\"apiKey\\":\\"algoliaApiKey\\"},\\"__autocomplete_id\\":7}",
         ]
       `);
 
@@ -561,7 +561,7 @@ describe('requester', () => {
           .map((node) => node.textContent)
       ).toMatchInlineSnapshot(`
         Array [
-          "{\\"0\\":{\\"objectID\\":\\"1\\",\\"label\\":\\"Hit 1\\",\\"__autocomplete_algoliaCredentials\\":{\\"appId\\":\\"algoliaAppId\\",\\"apiKey\\":\\"algoliaApiKey\\"}},\\"hitsPerPage\\":20,\\"__autocomplete_id\\":0}",
+          "{\\"0\\":{\\"objectID\\":\\"1\\",\\"label\\":\\"Hit 1\\",\\"__autocomplete_indexName\\":\\"indexName\\",\\"__autocomplete_algoliaCredentials\\":{\\"appId\\":\\"algoliaAppId\\",\\"apiKey\\":\\"algoliaApiKey\\"}},\\"hitsPerPage\\":20,\\"__autocomplete_id\\":0}",
         ]
       `);
 
@@ -675,7 +675,7 @@ describe('requester', () => {
           .map((node) => node.textContent)
       ).toMatchInlineSnapshot(`
         Array [
-          "{\\"0\\":{\\"objectID\\":\\"1\\",\\"label\\":\\"Hit 1\\",\\"__autocomplete_algoliaCredentials\\":{\\"appId\\":\\"algoliaAppId\\",\\"apiKey\\":\\"algoliaApiKey\\"}},\\"results\\":[{\\"page\\":0,\\"hitsPerPage\\":20,\\"nbHits\\":1,\\"nbPages\\":1,\\"processingTimeMS\\":0,\\"hits\\":[{\\"objectID\\":\\"1\\",\\"label\\":\\"Hit 1\\",\\"__autocomplete_algoliaCredentials\\":{\\"appId\\":\\"algoliaAppId\\",\\"apiKey\\":\\"algoliaApiKey\\"}}],\\"query\\":\\"\\",\\"params\\":\\"\\",\\"exhaustiveNbHits\\":true,\\"exhaustiveFacetsCount\\":true}],\\"facetHits\\":[],\\"__autocomplete_id\\":0}",
+          "{\\"0\\":{\\"objectID\\":\\"1\\",\\"label\\":\\"Hit 1\\",\\"__autocomplete_indexName\\":\\"indexName\\",\\"__autocomplete_algoliaCredentials\\":{\\"appId\\":\\"algoliaAppId\\",\\"apiKey\\":\\"algoliaApiKey\\"}},\\"results\\":[{\\"page\\":0,\\"hitsPerPage\\":20,\\"nbHits\\":1,\\"nbPages\\":1,\\"processingTimeMS\\":0,\\"hits\\":[{\\"objectID\\":\\"1\\",\\"label\\":\\"Hit 1\\",\\"__autocomplete_indexName\\":\\"indexName\\",\\"__autocomplete_algoliaCredentials\\":{\\"appId\\":\\"algoliaAppId\\",\\"apiKey\\":\\"algoliaApiKey\\"}}],\\"query\\":\\"\\",\\"params\\":\\"\\",\\"exhaustiveNbHits\\":true,\\"exhaustiveFacetsCount\\":true}],\\"facetHits\\":[],\\"__autocomplete_id\\":0}",
         ]
       `);
 

--- a/packages/autocomplete-preset-algolia/src/search/__tests__/fetchAlgoliaResults.test.ts
+++ b/packages/autocomplete-preset-algolia/src/search/__tests__/fetchAlgoliaResults.test.ts
@@ -12,8 +12,16 @@ function createTestSearchClient() {
     search: jest.fn(() =>
       Promise.resolve(
         createMultiSearchResponse<{ label: string }>(
-          { hits: [{ objectID: '1', label: 'Hit 1' }] },
-          { hits: [{ objectID: '2', label: 'Hit 2' }] }
+          {
+            index: 'indexName',
+            hits: [{ objectID: '1', label: 'Hit 1' }],
+            queryID: 'queryID1',
+          },
+          {
+            index: 'indexName2',
+            hits: [{ objectID: '2', label: 'Hit 2' }],
+            queryID: 'queryID2',
+          }
         )
       )
     ),
@@ -49,6 +57,10 @@ describe('fetchAlgoliaResults', () => {
           indexName: 'indexName',
           query: 'query',
         },
+        {
+          indexName: 'indexName2',
+          query: 'query',
+        },
       ],
     });
 
@@ -63,6 +75,15 @@ describe('fetchAlgoliaResults', () => {
           highlightPostTag: '__/aa-highlight__',
         },
       },
+      {
+        indexName: 'indexName2',
+        query: 'query',
+        params: {
+          hitsPerPage: 5,
+          highlightPreTag: '__aa-highlight__',
+          highlightPostTag: '__/aa-highlight__',
+        },
+      },
     ]);
     expect(results).toEqual([
       expect.objectContaining({
@@ -70,6 +91,8 @@ describe('fetchAlgoliaResults', () => {
           {
             objectID: '1',
             label: 'Hit 1',
+            __autocomplete_indexName: 'indexName',
+            __autocomplete_queryID: 'queryID1',
             __autocomplete_algoliaCredentials: {
               appId: 'algoliaAppId',
               apiKey: 'algoliaApiKey',
@@ -82,6 +105,8 @@ describe('fetchAlgoliaResults', () => {
           {
             objectID: '2',
             label: 'Hit 2',
+            __autocomplete_indexName: 'indexName2',
+            __autocomplete_queryID: 'queryID2',
             __autocomplete_algoliaCredentials: {
               appId: 'algoliaAppId',
               apiKey: 'algoliaApiKey',
@@ -108,6 +133,16 @@ describe('fetchAlgoliaResults', () => {
             page: 2,
           },
         },
+        {
+          indexName: 'indexName2',
+          query: 'query',
+          params: {
+            hitsPerPage: 10,
+            highlightPreTag: '<em>',
+            highlightPostTag: '</em>',
+            page: 2,
+          },
+        },
       ],
     });
 
@@ -123,6 +158,16 @@ describe('fetchAlgoliaResults', () => {
           page: 2,
         },
       },
+      {
+        indexName: 'indexName2',
+        query: 'query',
+        params: {
+          hitsPerPage: 10,
+          highlightPreTag: '<em>',
+          highlightPostTag: '</em>',
+          page: 2,
+        },
+      },
     ]);
     expect(results).toEqual([
       expect.objectContaining({
@@ -130,6 +175,8 @@ describe('fetchAlgoliaResults', () => {
           {
             objectID: '1',
             label: 'Hit 1',
+            __autocomplete_indexName: 'indexName',
+            __autocomplete_queryID: 'queryID1',
             __autocomplete_algoliaCredentials: {
               appId: 'algoliaAppId',
               apiKey: 'algoliaApiKey',
@@ -142,6 +189,48 @@ describe('fetchAlgoliaResults', () => {
           {
             objectID: '2',
             label: 'Hit 2',
+            __autocomplete_indexName: 'indexName2',
+            __autocomplete_queryID: 'queryID2',
+            __autocomplete_algoliaCredentials: {
+              appId: 'algoliaAppId',
+              apiKey: 'algoliaApiKey',
+            },
+          },
+        ],
+      }),
+    ]);
+  });
+
+  test('retrieves index name from query when not returned by response', async () => {
+    const searchClient = createSearchClient({
+      search: jest.fn(() =>
+        Promise.resolve(
+          createMultiSearchResponse<{ label: string }>({
+            hits: [{ objectID: '1', label: 'Hit 1' }],
+            queryID: 'queryID1',
+          })
+        )
+      ),
+    });
+
+    const results = await fetchAlgoliaResults({
+      searchClient,
+      queries: [
+        {
+          indexName: 'indexName',
+          query: 'query',
+        },
+      ],
+    });
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        hits: [
+          {
+            objectID: '1',
+            label: 'Hit 1',
+            __autocomplete_indexName: 'indexName',
+            __autocomplete_queryID: 'queryID1',
             __autocomplete_algoliaCredentials: {
               appId: 'algoliaAppId',
               apiKey: 'algoliaApiKey',
@@ -157,18 +246,7 @@ describe('fetchAlgoliaResults', () => {
 
     await fetchAlgoliaResults({
       searchClient,
-      queries: [
-        {
-          indexName: 'indexName',
-          query: 'query',
-          params: {
-            hitsPerPage: 10,
-            highlightPreTag: '<em>',
-            highlightPostTag: '</em>',
-            page: 2,
-          },
-        },
-      ],
+      queries: [{ indexName: 'indexName' }, { indexName: 'indexName2' }],
     });
 
     expect(searchClient.addAlgoliaAgent).toHaveBeenCalledTimes(1);
@@ -183,7 +261,7 @@ describe('fetchAlgoliaResults', () => {
 
     await fetchAlgoliaResults({
       searchClient,
-      queries: [],
+      queries: [{ indexName: 'indexName1' }, { indexName: 'indexName2' }],
       userAgents: [{ segment: 'custom-ua', version: '1.0.0' }],
     });
 

--- a/packages/autocomplete-preset-algolia/src/search/fetchAlgoliaResults.ts
+++ b/packages/autocomplete-preset-algolia/src/search/fetchAlgoliaResults.ts
@@ -55,10 +55,14 @@ export function fetchAlgoliaResults<TRecord>({
       })
     )
     .then((response) => {
-      return response.results.map((result) => ({
+      return response.results.map((result, resultIndex) => ({
         ...result,
         hits: result.hits?.map((hit) => ({
           ...hit,
+          // Bring support for the Insights plugin.
+          __autocomplete_indexName:
+            result.index || queries[resultIndex].indexName,
+          __autocomplete_queryID: result.queryID,
           __autocomplete_algoliaCredentials: {
             appId,
             apiKey,


### PR DESCRIPTION
This PR fixes an issue that occurs when the Insights plugin tries to determine whether a source item is coming from Algolia or not, to prepare an Insights event if necessary.

When an Algolia index is configured to restrict the fields returned from the API (with [`responseFields`](https://www.algolia.com/doc/api-reference/api-parameters/responseFields/)) and doesn't return the `index` property, our code falsely assumes that the item is not coming from Algolia, so it doesn't have an Insights payload generated.

Because we know at query time which index we are targeting, we can at response time resolve this issue by retrieving the index name from the list of queries as a fallback.