### PR TITLE
docs(readme): Fix dead links in autocomplete-query-suggestions plugin

### DIFF
--- a/packages/autocomplete-plugin-query-suggestions/README.md
+++ b/packages/autocomplete-plugin-query-suggestions/README.md
@@ -1,6 +1,6 @@
 # @algolia/autocomplete-plugin-query-suggestions
 
-The Query Suggestions plugin adds [Query Suggestions](https://www.algolia.com/doc/doc/guides/building-search-ui/ui-and-ux-patterns/query-suggestions/js) to your autocomplete.
+The Query Suggestions plugin adds [Query Suggestions](https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/query-suggestions/js) to your autocomplete.
 
 ## Installation
 


### PR DESCRIPTION
A link pointing to the autocomplete query suggestion plugin documentation is dead. This PR updates it with what I think is the relevant link.