### PR TITLE
fix(autocomplete-core): don't update `enterKeyHint` on Samsung Browser

### DIFF
--- a/packages/autocomplete-core/src/utils/__tests__/isSamsung.test.ts
+++ b/packages/autocomplete-core/src/utils/__tests__/isSamsung.test.ts
@@ -70,6 +70,14 @@ describe('isSamsung', () => {
           )
         ).toEqual(true);
       });
+
+      test('returns true with a Samsung Galaxy S9 (mobile) with "Desktop mode" enabled user agent', () => {
+        expect(
+          isSamsung(
+            'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/21.0 Chrome/110.0.5481.154 Safari/537.36'
+          )
+        ).toEqual(true);
+      });
     });
   });
 

--- a/packages/autocomplete-core/src/utils/isSamsung.ts
+++ b/packages/autocomplete-core/src/utils/isSamsung.ts
@@ -1,4 +1,4 @@
-const regex = /((gt|sm)-|galaxy nexus)|samsung[- ]/i;
+const regex = /((gt|sm)-|galaxy nexus)|samsung[- ]|samsungbrowser/i;
 
 export function isSamsung(userAgent: string) {
   return Boolean(userAgent && userAgent.match(regex));


### PR DESCRIPTION
**Summary**

[CR-3619](https://algolia.atlassian.net/browse/CR-3619)

This PR follows https://github.com/algolia/autocomplete/pull/916 and updates the `isSamsung()` util regex to detect Samsung Browsers even if the "Desktop Mode" is enabled.

**Result**

On Samsung Browsers, when the "Desktop Mode" is enabled, [`enterKeyHint`](https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-enterkeyhint-attribute) attribute is not updated, resulting in the input value not being reset.

[CR-3619]: https://algolia.atlassian.net/browse/CR-3619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ