### PR TITLE
fix(insights): position gets computed per source 

### DIFF
--- a/examples/query-suggestions-with-hits/app.tsx
+++ b/examples/query-suggestions-with-hits/app.tsx
@@ -92,7 +92,7 @@ type ProductItemProps = {
 
 function ProductItem({ hit, insights, components }: ProductItemProps) {
   return (
-    <>
+    <a href={hit.url} className="aa-ItemLink">
       <div className="aa-ItemContent">
         <div className="aa-ItemIcon aa-ItemIcon--picture aa-ItemIcon--alignTop">
           <img src={hit.image} alt={hit.name} width="40" height="40" />
@@ -167,6 +167,6 @@ function ProductItem({ hit, insights, components }: ProductItemProps) {
           </svg>
         </button>
       </div>
-    </>
+    </a>
   );
 }

--- a/examples/query-suggestions-with-hits/app.tsx
+++ b/examples/query-suggestions-with-hits/app.tsx
@@ -92,7 +92,7 @@ type ProductItemProps = {
 
 function ProductItem({ hit, insights, components }: ProductItemProps) {
   return (
-    <a href={hit.url} className="aa-ItemLink">
+    <>
       <div className="aa-ItemContent">
         <div className="aa-ItemIcon aa-ItemIcon--picture aa-ItemIcon--alignTop">
           <img src={hit.image} alt={hit.name} width="40" height="40" />
@@ -167,6 +167,6 @@ function ProductItem({ hit, insights, components }: ProductItemProps) {
           </svg>
         </button>
       </div>
-    </a>
+    </>
   );
 }

--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -726,7 +726,7 @@ describe('createAlgoliaInsightsPlugin', () => {
           eventName: 'Item Selected',
           index: 'index1',
           objectIDs: ['1'],
-          positions: [0],
+          positions: [1],
           queryID: 'queryID1',
           algoliaSource: ['autocomplete', 'autocomplete-internal'],
         }
@@ -783,7 +783,7 @@ describe('createAlgoliaInsightsPlugin', () => {
           eventName: 'Item Selected',
           index: 'index1',
           objectIDs: ['1'],
-          positions: [0],
+          positions: [1],
           queryID: 'queryID1',
           algoliaSource: ['autocomplete', 'autocomplete-internal'],
         }
@@ -890,7 +890,7 @@ describe('createAlgoliaInsightsPlugin', () => {
           eventName: 'Product Selected from Autocomplete',
           index: 'index1',
           objectIDs: ['1'],
-          positions: [0],
+          positions: [1],
           queryID: 'queryID1',
           algoliaSource: ['autocomplete'],
         }
@@ -1055,7 +1055,7 @@ describe('createAlgoliaInsightsPlugin', () => {
             __autocomplete_queryID: 'queryID1',
           }),
         ],
-        positions: [0],
+        positions: [1],
         queryID: 'queryID1',
         algoliaSource: ['autocomplete'],
       });

--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -733,6 +733,63 @@ describe('createAlgoliaInsightsPlugin', () => {
       );
     });
 
+    test('sends a `clickedObjectIDsAfterSearch` event on non-first source by default', async () => {
+      const insightsClient = jest.fn();
+      const insightsPlugin = createAlgoliaInsightsPlugin({ insightsClient });
+
+      const { inputElement } = createPlayground(createAutocomplete, {
+        plugins: [insightsPlugin],
+        defaultActiveItemId: 0,
+        openOnFocus: true,
+        getSources() {
+          return [
+            createSource({
+              sourceId: 'not clicked',
+              getItems: () => [
+                {
+                  label: '1',
+                  objectID: '1',
+                  __autocomplete_indexName: 'index0',
+                  __autocomplete_queryID: 'queryID1',
+                },
+              ],
+            }),
+            createSource({
+              getItems: () => [
+                {
+                  label: '1',
+                  objectID: '1',
+                  __autocomplete_indexName: 'index1',
+                  __autocomplete_queryID: 'queryID1',
+                },
+              ],
+            }),
+          ];
+        },
+      });
+
+      inputElement.focus();
+
+      await runAllMicroTasks();
+
+      // select second item
+      userEvent.type(inputElement, '{arrowdown}{enter}');
+
+      await runAllMicroTasks();
+
+      expect(insightsClient).toHaveBeenCalledWith(
+        'clickedObjectIDsAfterSearch',
+        {
+          eventName: 'Item Selected',
+          index: 'index1',
+          objectIDs: ['1'],
+          positions: [0],
+          queryID: 'queryID1',
+          algoliaSource: ['autocomplete', 'autocomplete-internal'],
+        }
+      );
+    });
+
     test('sends a `clickedObjectIDsAfterSearch` event with additional parameters if client supports it', async () => {
       const insightsClient = jest.fn();
       // @ts-ignore

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -143,7 +143,7 @@ export function createAlgoliaInsightsPlugin(
       return acc;
     }, {});
 
-    const itemsToSendViewFor: AlgoliaInsightsHit[] = [];
+    const viewedItems: AlgoliaInsightsHit[] = [];
 
     Object.entries(nextItems).forEach(([id, items]) => {
       if (
@@ -153,14 +153,14 @@ export function createAlgoliaInsightsPlugin(
         )
       ) {
         previousItems.current[id] = items;
-        itemsToSendViewFor.push(...items);
+        viewedItems.push(...items);
       }
     });
 
-    if (itemsToSendViewFor.length > 0) {
+    if (viewedItems.length > 0) {
       sendViewedObjectIDs({
         onItemsChange,
-        items: itemsToSendViewFor,
+        items: viewedItems,
         insights,
         state,
       });
@@ -185,8 +185,6 @@ export function createAlgoliaInsightsPlugin(
         if (!isAlgoliaInsightsHit(item)) {
           return;
         }
-
-        console.log(source.getItems)
 
         onSelectEvent({
           state: state as AutocompleteState<any>,

--- a/packages/autocomplete-plugin-algolia-insights/src/createClickedEvent.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createClickedEvent.ts
@@ -11,7 +11,7 @@ type CreateClickedEventParams = {
 
 export function createClickedEvent({
   item,
-  items,
+  items = [],
 }: CreateClickedEventParams): Omit<
   InsightsParamsWithItems<ClickedObjectIDsAfterSearchParams>,
   'eventName'


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

The insights "position" parameter refers to the absolute position of the item, within its set of hits. Using the entire set of autocomplete items is thus wrong.

Now the position is calculated from the source directly.


One thing I found interesting is that using `source.getItems()` directly in onSelect or onActive did not work, I think that's because those functions are not debounced, unlike the onStateChange. I did not investigate that option further.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues, references or RFCs?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

Insights view / click / etc. events get sent with the absolute position, within their source.

fixes [CR-3699](https://algolia.atlassian.net/browse/CR-3699)


[CR-3699]: https://algolia.atlassian.net/browse/CR-3699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ