### PR TITLE
ci: check that monorepo versions are in sync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,15 @@ jobs:
       - run:
           name: Linting CSS
           command: yarn run lint:css
+  test_metadata:
+    <<: *defaults
+    steps:
+      - checkout
+      - *attach_workspace
+      - run: *install_yarn_version
+      - run:
+          name: Test package versions
+          command: yarn run test:versions
   test_types:
     <<: *defaults
     steps:
@@ -177,6 +186,7 @@ workflows:
   ci:
     jobs:
       - build
+      - test_metadata
       - test_lint:
           requires:
             - build

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "start": "yarn run watch",
     "test:size": "bundlesize",
     "test:types": "tsc --noEmit",
+    "test:versions": "./test/versions/index.js",
     "test": "jest",
     "watch": "lerna run watch --parallel --no-private"
   },

--- a/test/versions/index.js
+++ b/test/versions/index.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/* eslint-disable no-process-exit, no-console, import/no-commonjs */
+const fs = require('fs');
+const path = require('path');
+
+// This file does not use any dependencies, so that it can be ran before installing
+
+// It checks whether the versions of packages that should be versioned synchronously
+// are actually in sync. We need this as long as Lerna doesn't have a mixed mode.
+// see: https://github.com/lerna/lerna/issues/1159
+
+let hasError = false;
+const expectedVersion = require('../../lerna.json').version;
+const packages = fs.readdirSync(path.join(__dirname, '../../packages'));
+
+const results = packages.map((package) => {
+  const version = require(path.join(
+    __dirname,
+    `../../packages/${package}/package.json`
+  )).version;
+  return { isValid: version === expectedVersion, package, version };
+});
+
+if (results.some(({ isValid }) => !isValid)) {
+  console.error(
+    [
+      'Package version mismatch detected!',
+      `- Expected: ${expectedVersion}`,
+      '- Received:',
+    ].join('\n')
+  );
+  console.error(results.filter(({ isValid }) => !isValid));
+  hasError = true;
+} else {
+  console.log('Package versions are in sync.');
+}
+
+console.log('');
+
+const sharedVersion = fs.readFileSync(
+  path.join(__dirname, '../../packages/autocomplete-shared/src/version.ts'),
+  { encoding: 'utf-8' }
+);
+
+if (sharedVersion !== `export const version = '${expectedVersion}';\n`) {
+  console.error(
+    [
+      'Shared version mismatch detected!',
+      `- Expected: ${expectedVersion}`,
+      `- Received: ${sharedVersion}`,
+    ].join('\n')
+  );
+  hasError = true;
+} else {
+  console.log('Shared version file is in sync.');
+}
+
+if (hasError) {
+  process.exit(1);
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR introduces a new step in the CI pipeline that ensures versions for all packages of the monorepo are the same, to prevent issues during release.

The logic used is similar to the one we have for InstantSearch, albeit simplified (we don't have to scope for groups of packages).

**Result**

Release pipeline will fail if versions are not in sync, allowing maintainers to take action preventively.
