### PR TITLE
chore(examples): use theme package from monorepo

### DIFF
--- a/examples/github-notification-filters/package.json
+++ b/examples/github-notification-filters/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.10.0",
     "@algolia/autocomplete-plugin-tags": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2",
     "qs": "6.11.1"

--- a/examples/github-repositories-custom-plugin/package.json
+++ b/examples/github-repositories-custom-plugin/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@algolia/autocomplete-js": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "preact": "10.13.2",
     "qs": "6.11.1"
   },

--- a/examples/html-templates/package.json
+++ b/examples/html-templates/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@algolia/autocomplete-js": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "algoliasearch": "4.16.0"
   },
   "devDependencies": {

--- a/examples/instantsearch/package.json
+++ b/examples/instantsearch/package.json
@@ -12,7 +12,7 @@
     "@algolia/autocomplete-js": "1.10.0",
     "@algolia/autocomplete-plugin-query-suggestions": "1.10.0",
     "@algolia/autocomplete-plugin-recent-searches": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "@algolia/client-search": "4.16.0",
     "algoliasearch": "4.16.0",
     "instantsearch.js": "4.53.0"

--- a/examples/multiple-datasets-with-headers/package.json
+++ b/examples/multiple-datasets-with-headers/package.json
@@ -12,7 +12,7 @@
     "@algolia/autocomplete-js": "1.10.0",
     "@algolia/autocomplete-plugin-query-suggestions": "1.10.0",
     "@algolia/autocomplete-plugin-recent-searches": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2"
   },

--- a/examples/panel-placement/package.json
+++ b/examples/panel-placement/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@algolia/autocomplete-core": "1.10.0",
     "@algolia/autocomplete-js": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2"
   },

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-plugin-query-suggestions": "1.10.0",
     "@algolia/autocomplete-plugin-recent-searches": "1.10.0",
     "@algolia/autocomplete-preset-algolia": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "@algolia/client-search": "4.16.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2",

--- a/examples/preview-panel-in-modal/package.json
+++ b/examples/preview-panel-in-modal/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@algolia/autocomplete-js": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2",
     "qs": "6.11.1"

--- a/examples/query-suggestions-with-categories/package.json
+++ b/examples/query-suggestions-with-categories/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.10.0",
     "@algolia/autocomplete-plugin-query-suggestions": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2"
   },

--- a/examples/query-suggestions-with-hits/package.json
+++ b/examples/query-suggestions-with-hits/package.json
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-plugin-query-suggestions": "1.10.0",
     "@algolia/autocomplete-plugin-recent-searches": "1.10.0",
     "@algolia/autocomplete-preset-algolia": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "@algolia/client-search": "4.16.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2",

--- a/examples/query-suggestions-with-inline-categories/package.json
+++ b/examples/query-suggestions-with-inline-categories/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.10.0",
     "@algolia/autocomplete-plugin-query-suggestions": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2"
   },

--- a/examples/query-suggestions-with-recent-searches-and-categories/package.json
+++ b/examples/query-suggestions-with-recent-searches-and-categories/package.json
@@ -12,7 +12,7 @@
     "@algolia/autocomplete-js": "1.10.0",
     "@algolia/autocomplete-plugin-query-suggestions": "1.10.0",
     "@algolia/autocomplete-plugin-recent-searches": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "@algolia/client-search": "4.16.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2"

--- a/examples/query-suggestions-with-recent-searches/package.json
+++ b/examples/query-suggestions-with-recent-searches/package.json
@@ -12,7 +12,7 @@
     "@algolia/autocomplete-js": "1.10.0",
     "@algolia/autocomplete-plugin-query-suggestions": "1.10.0",
     "@algolia/autocomplete-plugin-recent-searches": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2"
   },

--- a/examples/query-suggestions/package.json
+++ b/examples/query-suggestions/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.10.0",
     "@algolia/autocomplete-plugin-query-suggestions": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2"
   },

--- a/examples/react-18/package.json
+++ b/examples/react-18/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@algolia/autocomplete-js": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "algoliasearch": "4.16.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react-instantsearch-hooks/package.json
+++ b/examples/react-instantsearch-hooks/package.json
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-js": "1.10.0",
     "@algolia/autocomplete-plugin-query-suggestions": "1.10.0",
     "@algolia/autocomplete-plugin-recent-searches": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "algoliasearch": "4.16.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/examples/react-instantsearch/package.json
+++ b/examples/react-instantsearch/package.json
@@ -12,7 +12,7 @@
     "@algolia/autocomplete-js": "1.10.0",
     "@algolia/autocomplete-plugin-query-suggestions": "1.10.0",
     "@algolia/autocomplete-plugin-recent-searches": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "algoliasearch": "4.16.0",
     "qs": "6.11.1",
     "react": "17.0.2",

--- a/examples/react-renderer/package.json
+++ b/examples/react-renderer/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@algolia/autocomplete-core": "1.10.0",
     "@algolia/autocomplete-preset-algolia": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "@algolia/client-search": "4.16.0",
     "algoliasearch": "4.16.0",
     "react": "17.0.2",

--- a/examples/recently-viewed-items/package.json
+++ b/examples/recently-viewed-items/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.10.0",
     "@algolia/autocomplete-plugin-recent-searches": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "@algolia/client-search": "4.16.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2"

--- a/examples/redirect-url/package.json
+++ b/examples/redirect-url/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.10.0",
     "@algolia/autocomplete-plugin-redirect-url": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2"
   },

--- a/examples/reshape/package.json
+++ b/examples/reshape/package.json
@@ -14,7 +14,7 @@
     "@algolia/autocomplete-plugin-recent-searches": "1.10.0",
     "@algolia/autocomplete-preset-algolia": "1.10.0",
     "@algolia/autocomplete-shared": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "@algolia/client-search": "4.16.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2",

--- a/examples/starter-algolia/package.json
+++ b/examples/starter-algolia/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@algolia/autocomplete-js": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2"
   },

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@algolia/autocomplete-js": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "preact": "10.13.2"
   },
   "devDependencies": {

--- a/examples/tags-in-searchbox/package.json
+++ b/examples/tags-in-searchbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.10.0",
     "@algolia/autocomplete-plugin-tags": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "@algolia/client-search": "4.16.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2",

--- a/examples/tags-with-hits/package.json
+++ b/examples/tags-with-hits/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.10.0",
     "@algolia/autocomplete-plugin-tags": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "@algolia/client-search": "4.16.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2",

--- a/examples/two-column-layout/package.json
+++ b/examples/two-column-layout/package.json
@@ -14,7 +14,7 @@
     "@algolia/autocomplete-plugin-query-suggestions": "1.10.0",
     "@algolia/autocomplete-plugin-recent-searches": "1.10.0",
     "@algolia/autocomplete-shared": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "@algolia/client-search": "4.16.0",
     "algoliasearch": "4.16.0",
     "blurhash": "^1.1.5",

--- a/examples/voice-search/package.json
+++ b/examples/voice-search/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@algolia/autocomplete-js": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2"
   },

--- a/examples/vue-instantsearch/package.json
+++ b/examples/vue-instantsearch/package.json
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-js": "1.10.0",
     "@algolia/autocomplete-plugin-query-suggestions": "1.10.0",
     "@algolia/autocomplete-plugin-recent-searches": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "algoliasearch": "4.16.0",
     "core-js": "^3.6.5",
     "vue": "3.2.47",

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@algolia/autocomplete-js": "1.10.0",
-    "@algolia/autocomplete-theme-classic": "1.9.4",
+    "@algolia/autocomplete-theme-classic": "1.10.0",
     "algoliasearch": "4.16.0",
     "vue": "3.2.47"
   },


### PR DESCRIPTION
**Summary**

Currently examples retrieve a version of @algolia/autocomplete-theme-classic that is not up to date, which makes yarn retrieve it from npm instead of linking it from the monorepo. This PR fixes this.
