### PR TITLE
fix(examples): prevent conflict between recently viewed items and searches plugins

### DIFF
--- a/examples/recently-viewed-items/recentlyViewedItemsPlugin.tsx
+++ b/examples/recently-viewed-items/recentlyViewedItemsPlugin.tsx
@@ -63,6 +63,7 @@ export function createLocalStorageRecentlyViewedItems<
 
         return {
           ...transformedSource,
+          sourceId: 'recentlyViewedItemsPlugin',
           getItemUrl({ item }) {
             return item.url;
           },
@@ -128,6 +129,7 @@ export function createLocalStorageRecentlyViewedItems<
 
   return {
     ...plugin,
+    name: 'aa.localStorageRecentlyViewedItemsPlugin',
     data,
   };
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

CR-4071 has found an issue with autocomplete when a customer adds both the recent searches plugin and the userland recently viewed items plugin we provide as an example. This is because the last is based on the first, and both share the same plugin name and source id.

This PR makes sure the userland code we provide for the recently viewed items plugin sets its own source id and plugin name.