### PR TITLE
feat(insights): forward insights usertoken to algolia api calls

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "packages/autocomplete-core/dist/umd/index.production.js",
-      "maxSize": "8.5 kB"
+      "maxSize": "8.75 kB"
     },
     {
       "path": "packages/autocomplete-js/dist/umd/index.production.js",

--- a/packages/autocomplete-core/src/__tests__/createAutocomplete.test.ts
+++ b/packages/autocomplete-core/src/__tests__/createAutocomplete.test.ts
@@ -129,7 +129,7 @@ describe('createAutocomplete', () => {
         insights: { insightsClient },
       });
 
-      expect(insightsClient).toHaveBeenCalledTimes(1);
+      expect(insightsClient).toHaveBeenCalledTimes(3);
       expect(insightsClient).toHaveBeenCalledWith(
         'addAlgoliaAgent',
         'insights-plugin'
@@ -160,7 +160,7 @@ describe('createAutocomplete', () => {
       });
 
       expect(defaultInsightsClient).toHaveBeenCalledTimes(0);
-      expect(userInsightsClient).toHaveBeenCalledTimes(1);
+      expect(userInsightsClient).toHaveBeenCalledTimes(3);
       expect(userInsightsClient).toHaveBeenCalledWith(
         'addAlgoliaAgent',
         'insights-plugin'

--- a/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
+++ b/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
@@ -751,7 +751,7 @@ See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocom
         insights: { insightsClient: defaultInsightsClient },
       });
 
-      expect(defaultInsightsClient).toHaveBeenCalledTimes(1);
+      expect(defaultInsightsClient).toHaveBeenCalledTimes(3);
       expect(userInsightsClient).toHaveBeenCalledTimes(0);
 
       const insightsPlugin = createAlgoliaInsightsPlugin({
@@ -759,8 +759,8 @@ See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocom
       });
       update({ plugins: [insightsPlugin] });
 
-      expect(defaultInsightsClient).toHaveBeenCalledTimes(1);
-      expect(userInsightsClient).toHaveBeenCalledTimes(1);
+      expect(defaultInsightsClient).toHaveBeenCalledTimes(3);
+      expect(userInsightsClient).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -156,15 +156,24 @@ export function createAlgoliaInsightsPlugin(
   return {
     name: 'aa.algoliaInsightsPlugin',
     subscribe({ setContext, onSelect, onActive }) {
+      function setInsightsContext(userToken?: string) {
+        setContext({
+          algoliaInsightsPlugin: {
+            __algoliaSearchParameters: {
+              clickAnalytics: true,
+              ...(userToken ? { userToken } : {}),
+            },
+            insights,
+          },
+        });
+      }
+
       insightsClient('addAlgoliaAgent', 'insights-plugin');
 
-      setContext({
-        algoliaInsightsPlugin: {
-          __algoliaSearchParameters: {
-            clickAnalytics: true,
-          },
-          insights,
-        },
+      setInsightsContext();
+      insightsClient('onUserTokenChange', setInsightsContext);
+      insightsClient('getUserToken', null, (_error, userToken) => {
+        setInsightsContext(userToken);
       });
 
       onSelect(({ item, state, event, source }) => {


### PR DESCRIPTION
This PR forwards generated or explicitly set user tokens from the Insights library to Algolia queries sent through `getAlgoliaResults()`.