### PR TITLE
chore(examples): disable host check for vue-instantsearch example

### DIFF
--- a/examples/vue-instantsearch/vue.config.js
+++ b/examples/vue-instantsearch/vue.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  devServer: {
+    disableHostCheck: true,
+  },
+};


### PR DESCRIPTION
**Summary**

Now that most sandboxes in Codesandbox are using cloud microvms, this example fails to be previewed in Codesandbox because the dev server is proxied. This setting disables host check and returns the sandbox experience to what is expected.

Before: https://codesandbox.io/p/sandbox/github/algolia/autocomplete/tree/next/examples/vue-instantsearch
After: https://codesandbox.io/p/sandbox/github/algolia/autocomplete/tree/chore/example-vue-instantsearch/examples/vue-instantsearch