### PR TITLE
fix(css): hide empty panel layout in detached mode

### DIFF
--- a/packages/autocomplete-theme-classic/src/theme.scss
+++ b/packages/autocomplete-theme-classic/src/theme.scss
@@ -892,6 +892,10 @@ body {
       max-height: var(--aa-detached-modal-max-height);
       padding-bottom: var(--aa-spacing-half);
       position: static;
+
+      &:empty {
+        display: none;
+      }
     }
   }
 }


### PR DESCRIPTION
**Summary**

In detached mode, typing a query that returns no results and for which the source does not include a `noResults` template shows an empty element with odd vertical space.

This is because `shouldPanelOpen` always returns `true` in detached mode, and while empty, the panel layout element has padding, which causes the issue.

This PR hides this element if it does not have children.

**Before**

<img width="706" alt="CleanShot 2023-09-13 at 17 49 57@2x" src="https://github.com/algolia/autocomplete/assets/154633/1f86c3e4-5730-447b-8d0a-ca06ffdfd6a4">

**After**

<img width="708" alt="CleanShot 2023-09-13 at 17 51 15@2x" src="https://github.com/algolia/autocomplete/assets/154633/898f1ff5-fd96-4fc6-ade5-801265989abd">



Fixes https://github.com/algolia/autocomplete/issues/1191