### PR TITLE
fix(types): correct type for SearchClient

### DIFF
--- a/packages/autocomplete-shared/src/preset-algolia/algoliasearch.ts
+++ b/packages/autocomplete-shared/src/preset-algolia/algoliasearch.ts
@@ -2,7 +2,10 @@ import * as ClientSearch from '@algolia/client-search';
 import type * as AlgoliaSearch from 'algoliasearch/lite';
 
 // turns any to unknown, so it can be used as a conditional
-type AnyToUnknown<TSubject> = (any extends TSubject ? true : false) extends true
+// https://github.com/algolia/instantsearch/blob/18959b47f2f541f410e091a0cb7140f40e0956c2/packages/algoliasearch-helper/types/algoliasearch.d.ts#L14-L18
+type AnyToUnknown<TSubject> = (
+  0 extends 1 & TSubject ? true : false
+) extends true
   ? unknown
   : TSubject;
 


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

in some cases this was inferred to `any` instead of the right type, after TS 5.1.3.

This fix was also done in the helper: https://github.com/algolia/algoliasearch-helper-js/pull/943

this would have been caught if it was moved in the JS monorepo so the code could be in a shared package, or if we had updated to TS 5.1.3

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues, references or RFCs?
-->

**Result**

no `any` inferred for SearchClient type

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
