### PR TITLE
feat: pass `insights` option default to `undefined`

### DIFF
--- a/packages/autocomplete-core/src/createAutocomplete.ts
+++ b/packages/autocomplete-core/src/createAutocomplete.ts
@@ -69,11 +69,11 @@ export function createAutocomplete<
   }
 
   if (
-    options.insights &&
+    props.insights &&
     !props.plugins.some((plugin) => plugin.name === 'aa.algoliaInsightsPlugin')
   ) {
     const insightsParams =
-      typeof options.insights === 'boolean' ? {} : options.insights;
+      typeof props.insights === 'boolean' ? {} : props.insights;
     props.plugins.push(createAlgoliaInsightsPlugin(insightsParams));
   }
 

--- a/packages/autocomplete-core/src/getDefaultProps.ts
+++ b/packages/autocomplete-core/src/getDefaultProps.ts
@@ -32,7 +32,7 @@ export function getDefaultProps<TItem extends BaseItem>(
     autoFocus: false,
     defaultActiveItemId: null,
     stallThreshold: 300,
-    insights: false,
+    insights: undefined,
     environment,
     shouldPanelOpen: ({ state }) => getItemsCount(state) > 0,
     reshape: ({ sources }) => sources,

--- a/packages/autocomplete-core/src/types/index.ts
+++ b/packages/autocomplete-core/src/types/index.ts
@@ -22,7 +22,7 @@ type InsightsOption = {
    *
    * See [**autocomplete-plugin-algolia-insights**](https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-algolia-insights/) for more information.
    *
-   * @default false
+   * @default undefined
    * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-insights
    */
   insights?: CreateAlgoliaInsightsPluginParams | boolean | undefined;

--- a/packages/autocomplete-core/src/types/index.ts
+++ b/packages/autocomplete-core/src/types/index.ts
@@ -15,8 +15,8 @@ import {
 
 export type AutocompleteInsightsApi = _AutocompleteInsightsApi;
 export type AlgoliaInsightsHit = _AlgoliaInsightsHit;
-export interface AutocompleteOptions<TItem extends BaseItem>
-  extends _AutocompleteOptions<TItem> {
+
+type InsightsOption = {
   /**
    * Whether to enable the Insights plugin and load the Insights library if it has not been loaded yet.
    *
@@ -26,6 +26,11 @@ export interface AutocompleteOptions<TItem extends BaseItem>
    * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-insights
    */
   insights?: CreateAlgoliaInsightsPluginParams | boolean | undefined;
-}
-export type InternalAutocompleteOptions<TItem extends BaseItem> =
-  AutocompleteOptions<TItem> & _InternalAutocompleteOptions<TItem>;
+};
+
+export interface AutocompleteOptions<TItem extends BaseItem>
+  extends _AutocompleteOptions<TItem>,
+    InsightsOption {}
+export interface InternalAutocompleteOptions<TItem extends BaseItem>
+  extends _InternalAutocompleteOptions<TItem>,
+    InsightsOption {}

--- a/packages/autocomplete-core/src/types/index.ts
+++ b/packages/autocomplete-core/src/types/index.ts
@@ -9,6 +9,7 @@ import {
 } from '@algolia/autocomplete-plugin-algolia-insights';
 import {
   AutocompleteOptions as _AutocompleteOptions,
+  InternalAutocompleteOptions as _InternalAutocompleteOptions,
   BaseItem,
 } from '@algolia/autocomplete-shared/dist/esm/core';
 
@@ -24,5 +25,7 @@ export interface AutocompleteOptions<TItem extends BaseItem>
    * @default false
    * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-insights
    */
-  insights?: CreateAlgoliaInsightsPluginParams | boolean;
+  insights?: CreateAlgoliaInsightsPluginParams | boolean | undefined;
 }
+export type InternalAutocompleteOptions<TItem extends BaseItem> =
+  AutocompleteOptions<TItem> & _InternalAutocompleteOptions<TItem>;


### PR DESCRIPTION
This PR updates the `insights` option's default value to `undefined`. This doesn't change any existing behavior, but lets us differentiate between an explicit `false` value and the option being unset.

https://algolia.atlassian.net/browse/FX-2642