### PR TITLE
ci: assign reviewers and disable slack hook on prepare pr

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -22,6 +22,7 @@ module.exports = {
   publishCommand({ tag }) {
     return `yarn publish --access public --tag ${tag}`;
   },
+  pullRequestTeamReviewers: ['frontend-experiences-web'],
   versionUpdated({ exec, dir, version }) {
     // Update package dependencies
     exec(
@@ -55,6 +56,11 @@ module.exports = {
     }
 
     return true;
+  },
+  slack: {
+    // disable slack notification for `prepared` lifecycle.
+    // Ship.js will send slack message only for `releaseSuccess`.
+    prepared: null,
   },
 };
 


### PR DESCRIPTION
**Summary**

This PR automatically assigns reviewers from the FX team and updates the Slack integration so that it doesn't send a message for the prepare PR.