### PR TITLE
feat: allow extra arguments in Insights API

### DIFF
--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createSearchInsightsApi.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createSearchInsightsApi.test.ts
@@ -252,6 +252,42 @@ describe('createSearchInsightsApi', () => {
     });
   });
 
+  test('allows arbitrary additional data to be sent', () => {
+    const insightsClient = jest.fn();
+    const insightsApi = createSearchInsightsApi(insightsClient);
+
+    insightsApi.convertedObjectIDsAfterSearch({
+      // Regular properties
+      eventName: 'Items Added to cart',
+      index: 'index1',
+      items: getAlgoliaItems(1),
+      queryID: 'queryID',
+      // Extra additional properties
+      eventSubtype: 'purchase',
+      objectData: [
+        { discount: 0, price: 100, quantity: 1, queryID: 'queryID' },
+      ],
+      value: 100,
+      currency: 'USD',
+    });
+
+    expect(insightsClient).toHaveBeenCalledWith(
+      'convertedObjectIDsAfterSearch',
+      {
+        eventName: 'Items Added to cart',
+        index: 'index1',
+        objectIDs: ['0'],
+        queryID: 'queryID',
+        eventSubtype: 'purchase',
+        objectData: [
+          { discount: 0, price: 100, quantity: 1, queryID: 'queryID' },
+        ],
+        value: 100,
+        currency: 'USD',
+      }
+    );
+  });
+
   test('viewedObjectIDs() splits large payloads into multiple chunks', () => {
     const insightsClient = jest.fn();
     const insightsApi = createSearchInsightsApi(insightsClient);

--- a/packages/autocomplete-plugin-algolia-insights/src/createSearchInsightsApi.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createSearchInsightsApi.ts
@@ -11,6 +11,7 @@ import {
   ConvertedObjectIDsParams,
   InsightsClient,
   InsightsClientMethod,
+  WithArbitraryParams,
   InsightsParamsWithItems,
   ViewedFiltersParams,
   ViewedObjectIDsParams,
@@ -83,13 +84,17 @@ export function createSearchInsightsApi(searchInsights: InsightsClient) {
      */
     clickedObjectIDsAfterSearch(
       ...params: Array<
-        InsightsParamsWithItems<ClickedObjectIDsAfterSearchParams>
+        WithArbitraryParams<
+          InsightsParamsWithItems<ClickedObjectIDsAfterSearchParams>
+        >
       >
     ) {
       if (params.length > 0) {
         sendToInsights(
           'clickedObjectIDsAfterSearch',
-          mapToInsightsParamsApi(params),
+          mapToInsightsParamsApi<
+            InsightsParamsWithItems<ClickedObjectIDsAfterSearchParams>
+          >(params),
           params[0].items
         );
       }
@@ -100,12 +105,16 @@ export function createSearchInsightsApi(searchInsights: InsightsClient) {
      * @link https://www.algolia.com/doc/api-reference/api-methods/clicked-object-ids/
      */
     clickedObjectIDs(
-      ...params: Array<InsightsParamsWithItems<ClickedObjectIDsParams>>
+      ...params: Array<
+        WithArbitraryParams<InsightsParamsWithItems<ClickedObjectIDsParams>>
+      >
     ) {
       if (params.length > 0) {
         sendToInsights(
           'clickedObjectIDs',
-          mapToInsightsParamsApi(params),
+          mapToInsightsParamsApi<
+            InsightsParamsWithItems<ClickedObjectIDsParams>
+          >(params),
           params[0].items
         );
       }
@@ -115,7 +124,9 @@ export function createSearchInsightsApi(searchInsights: InsightsClient) {
      *
      * @link https://www.algolia.com/doc/api-reference/api-methods/clicked-filters/
      */
-    clickedFilters(...params: ClickedFiltersParams[]) {
+    clickedFilters(
+      ...params: Array<WithArbitraryParams<ClickedFiltersParams>>
+    ) {
       if (params.length > 0) {
         searchInsights('clickedFilters', ...params);
       }
@@ -127,13 +138,17 @@ export function createSearchInsightsApi(searchInsights: InsightsClient) {
      */
     convertedObjectIDsAfterSearch(
       ...params: Array<
-        InsightsParamsWithItems<ConvertedObjectIDsAfterSearchParams>
+        WithArbitraryParams<
+          InsightsParamsWithItems<ConvertedObjectIDsAfterSearchParams>
+        >
       >
     ) {
       if (params.length > 0) {
         sendToInsights(
           'convertedObjectIDsAfterSearch',
-          mapToInsightsParamsApi(params),
+          mapToInsightsParamsApi<
+            InsightsParamsWithItems<ConvertedObjectIDsAfterSearchParams>
+          >(params),
           params[0].items
         );
       }
@@ -144,12 +159,16 @@ export function createSearchInsightsApi(searchInsights: InsightsClient) {
      * @link https://www.algolia.com/doc/api-reference/api-methods/converted-object-ids/
      */
     convertedObjectIDs(
-      ...params: Array<InsightsParamsWithItems<ConvertedObjectIDsParams>>
+      ...params: Array<
+        WithArbitraryParams<InsightsParamsWithItems<ConvertedObjectIDsParams>>
+      >
     ) {
       if (params.length > 0) {
         sendToInsights(
           'convertedObjectIDs',
-          mapToInsightsParamsApi(params),
+          mapToInsightsParamsApi<
+            InsightsParamsWithItems<ConvertedObjectIDsParams>
+          >(params),
           params[0].items
         );
       }
@@ -159,7 +178,9 @@ export function createSearchInsightsApi(searchInsights: InsightsClient) {
      *
      * @link https://www.algolia.com/doc/api-reference/api-methods/converted-filters/
      */
-    convertedFilters(...params: ConvertedFiltersParams[]) {
+    convertedFilters(
+      ...params: Array<WithArbitraryParams<ConvertedFiltersParams>>
+    ) {
       if (params.length > 0) {
         searchInsights('convertedFilters', ...params);
       }
@@ -170,7 +191,9 @@ export function createSearchInsightsApi(searchInsights: InsightsClient) {
      * @link https://www.algolia.com/doc/api-reference/api-methods/viewed-object-ids/
      */
     viewedObjectIDs(
-      ...params: Array<InsightsParamsWithItems<ViewedObjectIDsParams>>
+      ...params: Array<
+        WithArbitraryParams<InsightsParamsWithItems<ViewedObjectIDsParams>>
+      >
     ) {
       if (params.length > 0) {
         params
@@ -202,7 +225,7 @@ export function createSearchInsightsApi(searchInsights: InsightsClient) {
      *
      * @link https://www.algolia.com/doc/api-reference/api-methods/viewed-filters/
      */
-    viewedFilters(...params: ViewedFiltersParams[]) {
+    viewedFilters(...params: Array<WithArbitraryParams<ViewedFiltersParams>>) {
       if (params.length > 0) {
         searchInsights('viewedFilters', ...params);
       }

--- a/packages/autocomplete-plugin-algolia-insights/src/types/AutocompleteInsightsApi.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/types/AutocompleteInsightsApi.ts
@@ -6,6 +6,9 @@ export type AutocompleteInsightsApi = ReturnType<
   typeof createSearchInsightsApi
 >;
 
+export type WithArbitraryParams<TParams extends Record<string, unknown>> =
+  Record<string, unknown> & TParams;
+
 export type InsightsParamsWithItems<TParams extends { objectIDs: string[] }> =
   Omit<TParams, 'objectIDs'> & {
     items: AlgoliaInsightsHit[];


### PR DESCRIPTION
## Summary

This types and tests the exposed Insights API to allow passing extra arguments in the payload.

This was already possible, but would have resulted in typing violations for TypeScript users.

[FX-2652](https://algolia.atlassian.net/browse/FX-2652)

[FX-2652]: https://algolia.atlassian.net/browse/FX-2652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ