### PR TITLE
fix(insights): declare automatic source

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "packages/autocomplete-core/dist/umd/index.production.js",
-      "maxSize": "8.75 kB"
+      "maxSize": "9 kB"
     },
     {
       "path": "packages/autocomplete-js/dist/umd/index.production.js",

--- a/packages/autocomplete-core/src/__tests__/createAutocomplete.test.ts
+++ b/packages/autocomplete-core/src/__tests__/createAutocomplete.test.ts
@@ -197,7 +197,7 @@ describe('createAutocomplete', () => {
               createMultiSearchResponse<{ label: string }>(
                 ...requests.map(({ indexName, query = '' }, index) => ({
                   hits: Array.from({ length: 2 }).map((_, i, arr) => ({
-                    objectID: String(index * arr.length + i + 1),
+                    objectID: `${String(index * arr.length + i + 1)}-${query}`,
                     label: query,
                   })),
                   index: indexName,
@@ -279,6 +279,7 @@ describe('createAutocomplete', () => {
         // Typing to change hits and trigger `view` events
         userEvent.type(inputElement, 'a');
         await runAllMicroTasks();
+        jest.runAllTimers();
 
         // Subsequent requests don't send `clickAnalytics`
         expect(searchClient.search).toHaveBeenLastCalledWith([
@@ -302,7 +303,12 @@ describe('createAutocomplete', () => {
           expect.objectContaining({
             eventName: 'Items Viewed',
             index: 'indexName',
-            objectIDs: ['1', '2'],
+            objectIDs: ['1-a', '2-a'],
+            algoliaSource: [
+              'autocomplete',
+              'autocomplete-internal',
+              'autocomplete-automatic',
+            ],
           })
         );
         expect(insightsClient).toHaveBeenCalledWith(
@@ -310,7 +316,12 @@ describe('createAutocomplete', () => {
           expect.objectContaining({
             eventName: 'Items Viewed',
             index: 'indexName2',
-            objectIDs: ['3', '4'],
+            objectIDs: ['3-a', '4-a'],
+            algoliaSource: [
+              'autocomplete',
+              'autocomplete-internal',
+              'autocomplete-automatic',
+            ],
           })
         );
       });
@@ -324,7 +335,7 @@ describe('createAutocomplete', () => {
               createMultiSearchResponse<{ label: string }>(
                 ...requests.map(({ indexName, query = '' }, index) => ({
                   hits: Array.from({ length: 2 }).map((_, i, arr) => ({
-                    objectID: String(index * arr.length + i + 1),
+                    objectID: `${String(index * arr.length + i + 1)}-${query}`,
                     label: query,
                   })),
                   index: indexName,
@@ -341,7 +352,9 @@ describe('createAutocomplete', () => {
               createMultiSearchResponse<{ label: string }>(
                 ...requests.map(({ indexName, query = '' }, index) => ({
                   hits: Array.from({ length: 2 }).map((_, i, arr) => ({
-                    objectID: String((index + 1) * arr.length + i + 1),
+                    objectID: `${String(
+                      (index + 1) * arr.length + i + 1
+                    )}-${query}`,
                     label: query,
                   })),
                   index: indexName,
@@ -423,6 +436,7 @@ describe('createAutocomplete', () => {
         // Typing to change hits and trigger `view` events
         userEvent.type(inputElement, 'a');
         await runAllMicroTasks();
+        jest.runAllTimers();
 
         // Subsequent requests don't send `clickAnalytics`
         expect(searchClient.search).toHaveBeenLastCalledWith([
@@ -448,7 +462,12 @@ describe('createAutocomplete', () => {
           expect.objectContaining({
             eventName: 'Items Viewed',
             index: 'indexName',
-            objectIDs: ['1', '2'],
+            objectIDs: ['1-a', '2-a'],
+            algoliaSource: [
+              'autocomplete',
+              'autocomplete-internal',
+              'autocomplete-automatic',
+            ],
           })
         );
         // Default `view` events are sent for the second set of items
@@ -457,7 +476,12 @@ describe('createAutocomplete', () => {
           expect.objectContaining({
             eventName: 'Items Viewed',
             index: 'indexName2',
-            objectIDs: ['3', '4'],
+            objectIDs: ['3-a', '4-a'],
+            algoliaSource: [
+              'autocomplete',
+              'autocomplete-internal',
+              'autocomplete-automatic',
+            ],
           })
         );
       });

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -240,24 +240,32 @@ export function createAlgoliaInsightsPlugin(
 
 function getOptions(options: CreateAlgoliaInsightsPluginParams) {
   return {
-    onItemsChange({ insights, insightsEvents }: OnItemsChangeParams) {
+    onItemsChange({ insights, insightsEvents, state }: OnItemsChangeParams) {
       insights.viewedObjectIDs(
         ...insightsEvents.map((event) => ({
           ...event,
           algoliaSource: [
             ...(event.algoliaSource || []),
             'autocomplete-internal',
+            ...((state.context.algoliaInsightsPlugin as Record<string, unknown>)
+              ?.__automaticInsights
+              ? ['autocomplete-automatic']
+              : []),
           ],
         }))
       );
     },
-    onSelect({ insights, insightsEvents }: OnSelectParams) {
+    onSelect({ insights, insightsEvents, state }: OnSelectParams) {
       insights.clickedObjectIDsAfterSearch(
         ...insightsEvents.map((event) => ({
           ...event,
           algoliaSource: [
             ...(event.algoliaSource || []),
             'autocomplete-internal',
+            ...((state.context.algoliaInsightsPlugin as Record<string, unknown>)
+              ?.__automaticInsights
+              ? ['autocomplete-automatic']
+              : []),
           ],
         }))
       );

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -7,7 +7,10 @@ import {
   noop,
   safelyRunOnBrowser,
 } from '@algolia/autocomplete-shared';
-import { AutocompleteReshapeSource } from '@algolia/autocomplete-shared/dist/esm/core';
+import {
+  AutocompleteContext,
+  AutocompleteReshapeSource,
+} from '@algolia/autocomplete-shared/dist/esm/core';
 
 import { createClickedEvent } from './createClickedEvent';
 import { createSearchInsightsApi } from './createSearchInsightsApi';
@@ -238,20 +241,27 @@ export function createAlgoliaInsightsPlugin(
   };
 }
 
+function getAlgoliaSources(
+  algoliaSourceBase: string[] = [],
+  context: AutocompleteContext
+) {
+  return [
+    ...algoliaSourceBase,
+    'autocomplete-internal',
+    ...((context.algoliaInsightsPlugin as Record<string, unknown>)
+      ?.__automaticInsights
+      ? ['autocomplete-automatic']
+      : []),
+  ];
+}
+
 function getOptions(options: CreateAlgoliaInsightsPluginParams) {
   return {
     onItemsChange({ insights, insightsEvents, state }: OnItemsChangeParams) {
       insights.viewedObjectIDs(
         ...insightsEvents.map((event) => ({
           ...event,
-          algoliaSource: [
-            ...(event.algoliaSource || []),
-            'autocomplete-internal',
-            ...((state.context.algoliaInsightsPlugin as Record<string, unknown>)
-              ?.__automaticInsights
-              ? ['autocomplete-automatic']
-              : []),
-          ],
+          algoliaSource: getAlgoliaSources(event.algoliaSource, state.context),
         }))
       );
     },
@@ -259,14 +269,7 @@ function getOptions(options: CreateAlgoliaInsightsPluginParams) {
       insights.clickedObjectIDsAfterSearch(
         ...insightsEvents.map((event) => ({
           ...event,
-          algoliaSource: [
-            ...(event.algoliaSource || []),
-            'autocomplete-internal',
-            ...((state.context.algoliaInsightsPlugin as Record<string, unknown>)
-              ?.__automaticInsights
-              ? ['autocomplete-automatic']
-              : []),
-          ],
+          algoliaSource: getAlgoliaSources(event.algoliaSource, state.context),
         }))
       );
     },


### PR DESCRIPTION
**Summary**

This PR (similar to https://github.com/algolia/instantsearch/pull/5901 for InstantSearch) adds an entry in the `algoliaSource` payload data sent with events, to declare when they are sent from an Insights plugin initialized from the dashboard.
