### PR TITLE
fix(behaviour): clear completion on "reset"

### DIFF
--- a/packages/autocomplete-core/src/__tests__/completion.test.ts
+++ b/packages/autocomplete-core/src/__tests__/completion.test.ts
@@ -161,4 +161,35 @@ describe('completion', () => {
       })
     );
   });
+
+  test('clears completion on "reset"', () => {
+    const { inputElement, resetElement } = createPlayground(
+      createAutocomplete,
+      {
+        openOnFocus: true,
+        initialState: {
+          collections: [
+            createCollection({
+              source: {
+                getItemInputValue({ item }) {
+                  return item.label;
+                },
+              },
+              items: [{ label: '1' }, { label: '2' }],
+            }),
+          ],
+        },
+      }
+    );
+    inputElement.focus();
+
+    userEvent.type(inputElement, 'Some text to make sure reset shows');
+    expect(inputElement).toHaveValue('Some text to make sure reset shows');
+
+    userEvent.type(inputElement, '{arrowdown}');
+    expect(inputElement).toHaveValue('1');
+
+    resetElement.click();
+    expect(inputElement).toHaveValue('');
+  });
 });

--- a/packages/autocomplete-core/src/__tests__/debouncing.test.ts
+++ b/packages/autocomplete-core/src/__tests__/debouncing.test.ts
@@ -49,12 +49,24 @@ describe('debouncing', () => {
       onStateChange,
       openOnFocus: true,
       getSources: () => debounced([createSource({ getItems })]),
-      // Despite the panel being open, if we don't force this to true, the panel won't open
-      shouldPanelOpen: () => true,
     });
 
     inputElement.focus();
-    userEvent.type(inputElement, 'abc{esc}');
+    userEvent.type(inputElement, 'ab');
+    await defer(noop, delay);
+
+    expect(onStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        state: expect.objectContaining({
+          status: 'idle',
+          isOpen: true,
+        }),
+      })
+    );
+    expect(getItems).toHaveBeenCalledTimes(1);
+    expect(inputElement).toHaveValue('ab');
+
+    userEvent.type(inputElement, 'c{esc}');
 
     expect(onStateChange).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -64,7 +76,7 @@ describe('debouncing', () => {
         }),
       })
     );
-    expect(getItems).toHaveBeenCalledTimes(0);
+    expect(getItems).toHaveBeenCalledTimes(1);
     expect(inputElement).toHaveValue('abc');
 
     userEvent.type(inputElement, 'def');
@@ -85,7 +97,7 @@ describe('debouncing', () => {
         }),
       })
     );
-    expect(getItems).toHaveBeenCalledTimes(1);
+    expect(getItems).toHaveBeenCalledTimes(2);
     expect(inputElement).toHaveValue('abcdef');
   });
 });

--- a/packages/autocomplete-core/src/__tests__/metadata.test.ts
+++ b/packages/autocomplete-core/src/__tests__/metadata.test.ts
@@ -73,7 +73,7 @@ describe('metadata', () => {
         ).content
       )
     ).toEqual({
-      options: { 'autocomplete-core': ['environment'] },
+      options: { 'autocomplete-core': ['environment', 'onStateChange'] },
       plugins: [],
       ua: [{ segment: 'autocomplete-core', version }],
     });
@@ -111,7 +111,12 @@ describe('metadata', () => {
         ).content
       ).options
     ).toEqual({
-      'autocomplete-core': ['openOnFocus', 'placeholder', 'environment'],
+      'autocomplete-core': [
+        'openOnFocus',
+        'placeholder',
+        'environment',
+        'onStateChange',
+      ],
     });
   });
 

--- a/packages/autocomplete-core/src/onKeyDown.ts
+++ b/packages/autocomplete-core/src/onKeyDown.ts
@@ -114,7 +114,7 @@ export function onKeyDown<TItem extends BaseItem>({
   } else if (event.key === 'Tab') {
     store.dispatch('blur', null);
 
-    // Hitting the `Escape` key signals the end of a user interaction with the
+    // Hitting the `Tab` key signals the end of a user interaction with the
     // autocomplete. At this point, we should ignore any requests that are still
     // pending and could reopen the panel once they resolve, because that would
     // result in an unsolicited UI behavior.

--- a/packages/autocomplete-core/src/stateReducer.ts
+++ b/packages/autocomplete-core/src/stateReducer.ts
@@ -129,6 +129,7 @@ export const stateReducer: Reducer = (state, action) => {
             ? action.props.defaultActiveItemId
             : null,
         status: 'idle',
+        completion: null,
         query: '',
       };
     }

--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -242,6 +242,9 @@ describe('createAlgoliaInsightsPlugin', () => {
         <body>
           <form>
             <input />
+            <button
+              type="reset"
+            />
           </form>
         </body>
       `);
@@ -264,6 +267,9 @@ describe('createAlgoliaInsightsPlugin', () => {
         <body>
           <form>
             <input />
+            <button
+              type="reset"
+            />
           </form>
         </body>
       `);
@@ -286,6 +292,9 @@ describe('createAlgoliaInsightsPlugin', () => {
           />
           <form>
             <input />
+            <button
+              type="reset"
+            />
           </form>
         </body>
       `);

--- a/test/utils/createPlayground.ts
+++ b/test/utils/createPlayground.ts
@@ -1,4 +1,5 @@
 import {
+  AutocompleteApi,
   AutocompleteOptions,
   createAutocomplete as createAutocompleteCore,
 } from '@algolia/autocomplete-core';
@@ -7,9 +8,18 @@ export function createPlayground<TItem extends Record<string, unknown>>(
   createAutocomplete: typeof createAutocompleteCore,
   props: AutocompleteOptions<TItem>
 ) {
-  const autocomplete = createAutocomplete<TItem>(props);
   const inputElement = document.createElement('input');
+  const resetElement = document.createElement('button');
+  resetElement.type = 'reset';
   const formElement = document.createElement('form');
+  let autocomplete: AutocompleteApi<TItem> | null = null;
+  autocomplete = createAutocomplete<TItem>({
+    ...props,
+    onStateChange(p) {
+      props.onStateChange?.(p);
+      simplifiedRender();
+    },
+  });
   const inputProps = autocomplete.getInputProps({ inputElement });
   const formProps = autocomplete.getFormProps({ inputElement });
   inputElement.addEventListener('blur', inputProps.onBlur);
@@ -20,11 +30,30 @@ export function createPlayground<TItem extends Record<string, unknown>>(
   formElement.addEventListener('reset', formProps.onReset);
   formElement.addEventListener('submit', formProps.onSubmit);
   formElement.appendChild(inputElement);
+  formElement.appendChild(resetElement);
   document.body.appendChild(formElement);
+
+  function simplifiedRender() {
+    // early exit if the autocomplete instance is not ready yet (eg. through plugins)
+    if (!autocomplete) {
+      return;
+    }
+
+    Object.entries(autocomplete.getInputProps({ inputElement })).forEach(
+      ([key, value]) => {
+        if (key.startsWith('on')) {
+          return;
+        }
+
+        inputElement[key as any] = value;
+      }
+    );
+  }
 
   return {
     ...autocomplete,
     inputElement,
+    resetElement,
     formElement,
     inputProps,
     formProps,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

When `reset` is called when a completion is active, it should also be reset.

Review notes: https://github.com/algolia/autocomplete/commit/9f07965fb80a4cef203ca3c94243074f34d57e71 is the main implementation, other commits will be rebased and came up through writing a test for it.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues, references or RFCs?
-->

**Result**

- improved tests
- reset clears completion too


https://github.com/algolia/autocomplete/assets/6270048/c0f66f0c-bb20-429d-b980-9849dacbae74 

https://github.com/algolia/autocomplete/assets/6270048/57b16c5e-bfd5-4ec3-8db1-d37e24f8fe34



<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
