### PR TITLE
fix(insights): do not throw if insightsClient is undefined in server environments

### DIFF
--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -18,14 +18,20 @@ import {
 } from '../../../../test/utils';
 import { createAlgoliaInsightsPlugin } from '../createAlgoliaInsightsPlugin';
 
-beforeEach(() => {
-  (window as any).AlgoliaAnalyticsObject = undefined;
-  (window as any).aa = undefined;
-
-  document.body.innerHTML = '';
-});
-
 describe('createAlgoliaInsightsPlugin', () => {
+  const originalWindow = global.window;
+
+  beforeEach(() => {
+    (window as any).AlgoliaAnalyticsObject = undefined;
+    (window as any).aa = undefined;
+
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    global.window = originalWindow;
+  });
+
   test('has a name', () => {
     const plugin = createAlgoliaInsightsPlugin({ insightsClient });
 
@@ -342,6 +348,17 @@ describe('createAlgoliaInsightsPlugin', () => {
       expect(consoleError).toHaveBeenCalledWith(
         '[Autocomplete]: Could not load search-insights.js. Please load it manually following https://alg.li/insights-autocomplete'
       );
+    });
+
+    it('does not throw in server environments', () => {
+      // @ts-expect-error
+      delete global.window;
+
+      expect(() => {
+        createPlayground(createAutocomplete, {
+          plugins: [createAlgoliaInsightsPlugin({})],
+        });
+      }).not.toThrow();
     });
   });
 

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -131,6 +131,12 @@ export function createAlgoliaInsightsPlugin(
     });
   }
 
+  // We return an empty plugin if `insightsClient` is still undefined at
+  // this stage, which can happen in server environments.
+  if (!insightsClient) {
+    return {};
+  }
+
   const insights = createSearchInsightsApi(insightsClient);
   const previousItems = createRef<AlgoliaInsightsHit[]>([]);
 


### PR DESCRIPTION
**Summary**
The Autocomplete Insights plugin can be initialized without an insights client, which will dynamically retrieve at runtime. This only works in browser environments, but later parts of the plugin init code wrongly assumed the insightsClient to have been retrieved.

This PR fixes this issue by returning an empty Insights plugin in server environments if `insightsClient` hasn't been explicitly provided.

Fixes #1218 