### PR TITLE
feat(insights): update default version to support `authenticatedUserToken`

### DIFF
--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -17,7 +17,7 @@
     "@algolia/client-search": "4.16.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2",
-    "search-insights": "2.6.0"
+    "search-insights": "2.13.0"
   },
   "devDependencies": {
     "parcel": "2.8.3"

--- a/examples/query-suggestions-with-hits/package.json
+++ b/examples/query-suggestions-with-hits/package.json
@@ -17,7 +17,7 @@
     "@algolia/client-search": "4.16.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2",
-    "search-insights": "2.6.0"
+    "search-insights": "2.13.0"
   },
   "devDependencies": {
     "parcel": "2.8.3"

--- a/examples/reshape/package.json
+++ b/examples/reshape/package.json
@@ -19,7 +19,7 @@
     "algoliasearch": "4.16.0",
     "preact": "10.13.2",
     "ramda": "0.27.1",
-    "search-insights": "2.6.0"
+    "search-insights": "2.13.0"
   },
   "devDependencies": {
     "@algolia/autocomplete-core": "1.12.2",

--- a/examples/tags-in-searchbox/package.json
+++ b/examples/tags-in-searchbox/package.json
@@ -16,7 +16,7 @@
     "algoliasearch": "4.16.0",
     "preact": "10.13.2",
     "ramda": "0.27.1",
-    "search-insights": "2.6.0"
+    "search-insights": "2.13.0"
   },
   "devDependencies": {
     "parcel": "2.8.3"

--- a/examples/tags-with-hits/package.json
+++ b/examples/tags-with-hits/package.json
@@ -16,7 +16,7 @@
     "algoliasearch": "4.16.0",
     "preact": "10.13.2",
     "ramda": "0.27.1",
-    "search-insights": "2.6.0"
+    "search-insights": "2.13.0"
   },
   "devDependencies": {
     "parcel": "2.8.3"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "rollup-plugin-license": "2.9.1",
     "rollup-plugin-terser": "7.0.2",
     "shipjs": "0.26.1",
-    "search-insights": "2.6.0",
+    "search-insights": "2.13.0",
     "start-server-and-test": "1.15.2",
     "stylelint": "13.13.1",
     "stylelint-a11y": "1.2.3",

--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -294,7 +294,7 @@ describe('createAlgoliaInsightsPlugin', () => {
       expect(document.body).toMatchInlineSnapshot(`
         <body>
           <script
-            src="https://cdn.jsdelivr.net/npm/search-insights@2.6.0/dist/search-insights.min.js"
+            src="https://cdn.jsdelivr.net/npm/search-insights@2.13.0/dist/search-insights.min.js"
           />
           <form>
             <input />
@@ -306,7 +306,7 @@ describe('createAlgoliaInsightsPlugin', () => {
       `);
       expect((window as any).AlgoliaAnalyticsObject).toBe('aa');
       expect((window as any).aa).toEqual(expect.any(Function));
-      expect((window as any).aa.version).toBe('2.6.0');
+      expect((window as any).aa.version).toBe('2.13.0');
     });
 
     it('notifies when the script fails to be added', () => {
@@ -867,7 +867,7 @@ describe('createAlgoliaInsightsPlugin', () => {
     test('sends a `clickedObjectIDsAfterSearch` event with additional parameters if client supports it', async () => {
       const insightsClient = jest.fn();
       // @ts-ignore
-      insightsClient.version = '2.6.0';
+      insightsClient.version = '2.13.0';
       const insightsPlugin = createAlgoliaInsightsPlugin({ insightsClient });
 
       const { inputElement } = createPlayground(createAutocomplete, {

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -311,10 +311,6 @@ function loadInsights(environment: typeof window) {
  * While `search-insights` supports both string and number user tokens,
  * the Search API only accepts strings. This function normalizes the user token.
  */
-function normalizeUserToken(userToken?: string | number): string | undefined {
-  if (!userToken) {
-    return undefined;
-  }
-
+function normalizeUserToken(userToken: string | number): string {
   return typeof userToken === 'number' ? userToken.toString() : userToken;
 }

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -26,7 +26,7 @@ import {
 } from './types';
 
 const VIEW_EVENT_DELAY = 400;
-const ALGOLIA_INSIGHTS_VERSION = '2.6.0';
+const ALGOLIA_INSIGHTS_VERSION = '2.13.0';
 const ALGOLIA_INSIGHTS_SRC = `https://cdn.jsdelivr.net/npm/search-insights@${ALGOLIA_INSIGHTS_VERSION}/dist/search-insights.min.js`;
 
 type SendViewedObjectIDsParams = {
@@ -170,14 +170,16 @@ export function createAlgoliaInsightsPlugin(
   return {
     name: 'aa.algoliaInsightsPlugin',
     subscribe({ setContext, onSelect, onActive }) {
-      function setInsightsContext(userToken?: string) {
+      function setInsightsContext(userToken?: string | number) {
         setContext({
           algoliaInsightsPlugin: {
             __algoliaSearchParameters: {
               ...(__autocomplete_clickAnalytics
                 ? { clickAnalytics: true }
                 : {}),
-              ...(userToken ? { userToken } : {}),
+              ...(userToken
+                ? { userToken: normalizeUserToken(userToken) }
+                : {}),
             },
             insights,
           },
@@ -303,4 +305,16 @@ function loadInsights(environment: typeof window) {
     // eslint-disable-next-line no-console
     console.error(errorMessage);
   }
+}
+
+/**
+ * While `search-insights` supports both string and number user tokens,
+ * the Search API only accepts strings. This function normalizes the user token.
+ */
+function normalizeUserToken(userToken?: string | number): string | undefined {
+  if (!userToken) {
+    return undefined;
+  }
+
+  return typeof userToken === 'number' ? userToken.toString() : userToken;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17380,10 +17380,10 @@ schema-utils@^3.0.0, schema-utils@^3.1.1:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
-search-insights@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.6.0.tgz#bb8771a73b83c4a0f1f207c2f64fea01acd3e7d0"
-  integrity sha512-vU2/fJ+h/Mkm/DJOe+EaM5cafJv/1rRTZpGJTuFPf/Q5LjzgMDsqPdSaZsAe+GAWHHsfsu+rQSAn6c8IGtBEVw==
+search-insights@2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.13.0.tgz#a79fdcf4b5dad2fba8975b06f2ebc37a865032b7"
+  integrity sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==
 
 search-insights@^2.1.0:
   version "2.2.1"


### PR DESCRIPTION
This PR sets updates the `search-insights` dependency and the version retrieved at runtime to the current latest. This gives the ability to set `authenticatedUserToken` subsequently without requiring users to manually load the library.