### PR TITLE
feat(insights): allow to pass init params

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "packages/autocomplete-js/dist/umd/index.production.js",
-      "maxSize": "21 kB"
+      "maxSize": "21.25 kB"
     },
     {
       "path": "packages/autocomplete-preset-algolia/dist/umd/index.production.js",
@@ -14,7 +14,7 @@
     },
     {
       "path": "packages/autocomplete-plugin-algolia-insights/dist/umd/index.production.js",
-      "maxSize": "3.25 kB"
+      "maxSize": "3.5 kB"
     },
     {
       "path": "packages/autocomplete-plugin-redirect-url/dist/umd/index.production.js",

--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -228,6 +228,28 @@ describe('createAlgoliaInsightsPlugin', () => {
     ]);
   });
 
+  test('does not call `init` if `insightsInitParams` not passed', () => {
+    const insightsClient = jest.fn();
+    createAlgoliaInsightsPlugin({
+      insightsClient,
+    });
+
+    expect(insightsClient).not.toHaveBeenCalled();
+  });
+
+  test('initializes insights with `insightsInitParams` if passed', () => {
+    const insightsClient = jest.fn();
+    createAlgoliaInsightsPlugin({
+      insightsClient,
+      insightsInitParams: { userToken: 'user' },
+    });
+
+    expect(insightsClient).toHaveBeenCalledWith('init', {
+      partial: true,
+      userToken: 'user',
+    });
+  });
+
   describe('automatic pulling', () => {
     const consoleError = jest
       .spyOn(console, 'error')

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -20,6 +20,7 @@ import {
   AlgoliaInsightsHit,
   AutocompleteInsightsApi,
   InsightsClient,
+  InsightsMethodMap,
   OnActiveParams,
   OnItemsChangeParams,
   OnSelectParams,
@@ -58,6 +59,10 @@ export type CreateAlgoliaInsightsPluginParams = {
    */
   insightsClient?: InsightsClient;
   /**
+   * Insights parameters to forward to the Insights client’s init method.
+   */
+  insightsInitParams?: Partial<InsightsMethodMap['init'][0]>;
+  /**
    * Hook to send an Insights event when the items change.
    *
    * By default, it sends a `viewedObjectIDs` event.
@@ -94,6 +99,7 @@ export function createAlgoliaInsightsPlugin(
 ): AutocompletePlugin<any, undefined> {
   const {
     insightsClient: providedInsightsClient,
+    insightsInitParams,
     onItemsChange,
     onSelect: onSelectEvent,
     onActive: onActiveEvent,
@@ -135,6 +141,10 @@ export function createAlgoliaInsightsPlugin(
   // this stage, which can happen in server environments.
   if (!insightsClient) {
     return {};
+  }
+
+  if (insightsInitParams) {
+    insightsClient('init', { partial: true, ...insightsInitParams });
   }
 
   const insights = createSearchInsightsApi(insightsClient);

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -60,6 +60,8 @@ export type CreateAlgoliaInsightsPluginParams = {
   insightsClient?: InsightsClient;
   /**
    * Insights parameters to forward to the Insights client’s init method.
+   *
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-algolia-insights/createAlgoliaInsightsPlugin/#param-insightsinitparams
    */
   insightsInitParams?: Partial<InsightsMethodMap['init'][0]>;
   /**

--- a/packages/autocomplete-plugin-algolia-insights/src/types/InsightsClient.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/types/InsightsClient.ts
@@ -1,5 +1,5 @@
 import type {
-  InsightsMethodMap,
+  InsightsMethodMap as _InsightsMethodMap,
   InsightsClient as _InsightsClient,
 } from 'search-insights';
 
@@ -11,6 +11,7 @@ export type {
   OnUserTokenChange as InsightsOnUserTokenChange,
 } from 'search-insights';
 
+export type InsightsMethodMap = _InsightsMethodMap;
 export type InsightsClientMethod = keyof InsightsMethodMap;
 
 export type InsightsClientPayload = {


### PR DESCRIPTION
**Summary**

### [FX-2699](https://algolia.atlassian.net/browse/FX-2699)

**Result**

No need for changes in `autocomplete-core` as it takes types from the plugin

Tested it on playground with `useCookie` and `userToken` and it works well


[FX-2699]: https://algolia.atlassian.net/browse/FX-2699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ