### PR TITLE
fix: focus detached input on iOS (#653)

### DIFF
--- a/packages/autocomplete-js/src/__tests__/detached.test.ts
+++ b/packages/autocomplete-js/src/__tests__/detached.test.ts
@@ -62,15 +62,16 @@ describe('detached', () => {
     // Open detached overlay
     searchButton.click();
 
-    await waitFor(() => {
-      const input = document.querySelector<HTMLInputElement>('.aa-Input')!;
+    const input = document.querySelector<HTMLInputElement>('.aa-Input')!;
 
-      expect(document.querySelector('.aa-DetachedOverlay')).toBeInTheDocument();
-      expect(document.body).toHaveClass('aa-Detached');
-      expect(input).toHaveFocus();
+    expect(document.querySelector('.aa-DetachedOverlay')).toBeInTheDocument();
+    expect(document.body).toHaveClass('aa-Detached');
 
-      fireEvent.input(input, { target: { value: 'a' } });
-    });
+    // Input should immediately be focused, to ensure the keyboard is shown on mobile
+    expect(input).toHaveFocus();
+
+    // Type a query in the focused input
+    fireEvent.input(input, { target: { value: 'a' } });
 
     // Wait for the panel to open
     await waitFor(() => {
@@ -391,16 +392,15 @@ describe('detached', () => {
     // Open detached overlay
     searchButton.click();
 
+    const input = document.querySelector<HTMLInputElement>('.aa-Input')!;
+
+    expect(document.querySelector('.aa-DetachedOverlay')).toBeInTheDocument();
+    expect(document.body).toHaveClass('aa-Detached');
+    // Input should immediately be focused, to ensure the keyboard is shown on mobile
+    expect(input).toHaveFocus();
+
     // Type a query in the focused input
-    await waitFor(() => {
-      const input = document.querySelector<HTMLInputElement>('.aa-Input')!;
-
-      expect(document.querySelector('.aa-DetachedOverlay')).toBeInTheDocument();
-      expect(document.body).toHaveClass('aa-Detached');
-      expect(input).toHaveFocus();
-
-      fireEvent.input(input, { target: { value: 'a' } });
-    });
+    fireEvent.input(input, { target: { value: 'a' } });
 
     // Wait for the panel to open
     await waitFor(() => {

--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -375,30 +375,28 @@ export function autocomplete<TItem extends BaseItem>(
   }
 
   function setIsModalOpen(value: boolean) {
-    requestAnimationFrame(() => {
-      const prevValue = props.value.core.environment.document.body.contains(
+    const prevValue = props.value.core.environment.document.body.contains(
+      dom.value.detachedOverlay
+    );
+
+    if (value === prevValue) {
+      return;
+    }
+
+    if (value) {
+      props.value.core.environment.document.body.appendChild(
         dom.value.detachedOverlay
       );
-
-      if (value === prevValue) {
-        return;
-      }
-
-      if (value) {
-        props.value.core.environment.document.body.appendChild(
-          dom.value.detachedOverlay
-        );
-        props.value.core.environment.document.body.classList.add('aa-Detached');
-        dom.value.input.focus();
-      } else {
-        props.value.core.environment.document.body.removeChild(
-          dom.value.detachedOverlay
-        );
-        props.value.core.environment.document.body.classList.remove(
-          'aa-Detached'
-        );
-      }
-    });
+      props.value.core.environment.document.body.classList.add('aa-Detached');
+      dom.value.input.focus();
+    } else {
+      props.value.core.environment.document.body.removeChild(
+        dom.value.detachedOverlay
+      );
+      props.value.core.environment.document.body.classList.remove(
+        'aa-Detached'
+      );
+    }
   }
 
   warn(


### PR DESCRIPTION
Originally the focusing code was in a requestAnimationFrame to ensure it wasn't blocking other potentially more important browser work. However, this causes the input not to get focused on iOS, as the focus call isn't related to a user action anymore.

As the `requestAnimationFrame` doesn't have any real use case, removing it doesn't break any experiences, nor tests.

A test can be written by ensuring the input is immediately focused, not delayed in any way. 

fixes #653