### PR TITLE
feat(insights): support `authenticatedUserToken`

### DIFF
--- a/packages/autocomplete-core/src/__tests__/createAutocomplete.test.ts
+++ b/packages/autocomplete-core/src/__tests__/createAutocomplete.test.ts
@@ -137,7 +137,7 @@ describe('createAutocomplete', () => {
         insights: { insightsClient },
       });
 
-      expect(insightsClient).toHaveBeenCalledTimes(3);
+      expect(insightsClient).toHaveBeenCalledTimes(5);
       expect(insightsClient).toHaveBeenCalledWith(
         'addAlgoliaAgent',
         'insights-plugin'
@@ -168,7 +168,7 @@ describe('createAutocomplete', () => {
       });
 
       expect(defaultInsightsClient).toHaveBeenCalledTimes(0);
-      expect(userInsightsClient).toHaveBeenCalledTimes(3);
+      expect(userInsightsClient).toHaveBeenCalledTimes(5);
       expect(userInsightsClient).toHaveBeenCalledWith(
         'addAlgoliaAgent',
         'insights-plugin'

--- a/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
+++ b/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
@@ -724,6 +724,7 @@ See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocom
               algoliaInsightsPlugin: expect.objectContaining({
                 insights: expect.objectContaining({
                   init: expect.any(Function),
+                  setAuthenticatedUserToken: expect.any(Function),
                   setUserToken: expect.any(Function),
                   clickedObjectIDsAfterSearch: expect.any(Function),
                   clickedObjectIDs: expect.any(Function),
@@ -751,7 +752,7 @@ See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocom
         insights: { insightsClient: defaultInsightsClient },
       });
 
-      expect(defaultInsightsClient).toHaveBeenCalledTimes(3);
+      expect(defaultInsightsClient).toHaveBeenCalledTimes(5);
       expect(userInsightsClient).toHaveBeenCalledTimes(0);
 
       const insightsPlugin = createAlgoliaInsightsPlugin({
@@ -759,8 +760,8 @@ See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocom
       });
       update({ plugins: [insightsPlugin] });
 
-      expect(defaultInsightsClient).toHaveBeenCalledTimes(3);
-      expect(userInsightsClient).toHaveBeenCalledTimes(3);
+      expect(defaultInsightsClient).toHaveBeenCalledTimes(5);
+      expect(userInsightsClient).toHaveBeenCalledTimes(5);
     });
   });
 });

--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -204,6 +204,10 @@ describe('createAlgoliaInsightsPlugin', () => {
   });
 
   describe('user token', () => {
+    afterEach(() => {
+      insightsClient('setAuthenticatedUserToken', undefined);
+    });
+
     test('forwards `userToken` from Search Insights to Algolia API requests', async () => {
       const insightsPlugin = createAlgoliaInsightsPlugin({ insightsClient });
 
@@ -298,8 +302,6 @@ describe('createAlgoliaInsightsPlugin', () => {
           params: expect.objectContaining({ userToken: 'customAuthUserToken' }),
         }),
       ]);
-
-      insightsClient('setAuthenticatedUserToken', undefined);
     });
 
     test('uses `authenticatedUserToken` in priority over `userToken`', async () => {

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -183,11 +183,7 @@ export function createAlgoliaInsightsPlugin(
   return {
     name: 'aa.algoliaInsightsPlugin',
     subscribe({ setContext, onSelect, onActive }) {
-      let preservedUserToken: InsightsEvent['userToken'];
-      function setInsightsContext(
-        userToken?: InsightsEvent['userToken'],
-        preserveUserToken = false
-      ) {
+      function setInsightsContext(userToken?: InsightsEvent['userToken']) {
         setContext({
           algoliaInsightsPlugin: {
             __algoliaSearchParameters: {
@@ -201,10 +197,6 @@ export function createAlgoliaInsightsPlugin(
             insights,
           },
         });
-
-        if (preserveUserToken) {
-          preservedUserToken = userToken;
-        }
       }
 
       insightsClient('addAlgoliaAgent', 'insights-plugin');
@@ -213,10 +205,10 @@ export function createAlgoliaInsightsPlugin(
 
       // Handles user token changes
       insightsClient('onUserTokenChange', (userToken) => {
-        setInsightsContext(userToken, true);
+        setInsightsContext(userToken);
       });
       insightsClient('getUserToken', null, (_error, userToken) => {
-        setInsightsContext(userToken, true);
+        setInsightsContext(userToken);
       });
 
       // Handles authenticated user token changes
@@ -226,7 +218,9 @@ export function createAlgoliaInsightsPlugin(
           if (authenticatedUserToken) {
             setInsightsContext(authenticatedUserToken);
           } else {
-            setInsightsContext(preservedUserToken);
+            insightsClient('getUserToken', null, (_error, userToken) =>
+              setInsightsContext(userToken)
+            );
           }
         }
       );

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -204,9 +204,7 @@ export function createAlgoliaInsightsPlugin(
       setInsightsContext();
 
       // Handles user token changes
-      insightsClient('onUserTokenChange', (userToken) => {
-        setInsightsContext(userToken);
-      });
+      insightsClient('onUserTokenChange', setInsightsContext);
       insightsClient('getUserToken', null, (_error, userToken) => {
         setInsightsContext(userToken);
       });

--- a/packages/autocomplete-plugin-algolia-insights/src/createSearchInsightsApi.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createSearchInsightsApi.ts
@@ -72,6 +72,15 @@ export function createSearchInsightsApi(searchInsights: InsightsClient) {
       searchInsights('init', { appId, apiKey });
     },
     /**
+     * Sets the authenticated user token to attach to events.
+     * Unsets the authenticated token by passing `undefined`.
+     *
+     * @link https://www.algolia.com/doc/api-reference/api-methods/set-authenticated-user-token/
+     */
+    setAuthenticatedUserToken(authenticatedUserToken: string | undefined) {
+      searchInsights('setAuthenticatedUserToken', authenticatedUserToken);
+    },
+    /**
      * Sets the user token to attach to events.
      */
     setUserToken(userToken: string) {

--- a/packages/autocomplete-plugin-algolia-insights/src/types/InsightsClient.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/types/InsightsClient.ts
@@ -9,6 +9,7 @@ export type {
   SetUserToken as InsightsSetUserToken,
   GetUserToken as InsightsGetUserToken,
   OnUserTokenChange as InsightsOnUserTokenChange,
+  InsightsEvent,
 } from 'search-insights';
 
 export type InsightsMethodMap = _InsightsMethodMap;


### PR DESCRIPTION
This PR brings support to `authenticatedUserToken` in Autocomplete's insights plugin.

When provided, its value is sent instead of the `userToken` value. When unset, the value for `userToken` is reverted.

FX-2708