### PR TITLE
feat(dom): Add labels to buttons

### DIFF
--- a/packages/autocomplete-js/src/createAutocompleteDom.ts
+++ b/packages/autocomplete-js/src/createAutocompleteDom.ts
@@ -161,6 +161,7 @@ export function createAutocompleteDom<TItem extends BaseItem>({
     const detachedSearchButton = createDomElement('button', {
       type: 'button',
       class: classNames.detachedSearchButton,
+      title: 'Search',
       onClick() {
         setIsModalOpen(true);
       },
@@ -172,6 +173,7 @@ export function createAutocompleteDom<TItem extends BaseItem>({
     });
     const detachedCancelButton = createDomElement('button', {
       type: 'button',
+      title: 'Cancel',
       class: classNames.detachedCancelButton,
       textContent: translations.detachedCancelButtonText,
       // Prevent `onTouchStart` from closing the panel

--- a/packages/autocomplete-js/src/createAutocompleteDom.ts
+++ b/packages/autocomplete-js/src/createAutocompleteDom.ts
@@ -174,7 +174,6 @@ export function createAutocompleteDom<TItem extends BaseItem>({
     });
     const detachedCancelButton = createDomElement('button', {
       type: 'button',
-      title: 'Cancel',
       class: classNames.detachedCancelButton,
       textContent: translations.detachedCancelButtonText,
       // Prevent `onTouchStart` from closing the panel

--- a/packages/autocomplete-js/src/createAutocompleteDom.ts
+++ b/packages/autocomplete-js/src/createAutocompleteDom.ts
@@ -161,7 +161,8 @@ export function createAutocompleteDom<TItem extends BaseItem>({
     const detachedSearchButton = createDomElement('button', {
       type: 'button',
       class: classNames.detachedSearchButton,
-      title: 'Search',
+      title: translations.detachedSearchButtonTitle,
+      id: labelProps.id,
       onClick() {
         setIsModalOpen(true);
       },

--- a/packages/autocomplete-js/src/getDefaultOptions.ts
+++ b/packages/autocomplete-js/src/getDefaultOptions.ts
@@ -138,6 +138,7 @@ export function getDefaultOptions<TItem extends BaseItem>(
   const defaultTranslations: AutocompleteTranslations = {
     clearButtonTitle: 'Clear',
     detachedCancelButtonText: 'Cancel',
+    detachedSearchButtonTitle: 'Search',
     submitButtonTitle: 'Submit',
   };
 

--- a/packages/autocomplete-shared/src/js/AutocompleteTranslations.ts
+++ b/packages/autocomplete-shared/src/js/AutocompleteTranslations.ts
@@ -2,4 +2,5 @@ export type AutocompleteTranslations = {
   detachedCancelButtonText: string;
   clearButtonTitle: string;
   submitButtonTitle: string;
+  detachedSearchButtonTitle:string;
 };

--- a/packages/autocomplete-shared/src/js/AutocompleteTranslations.ts
+++ b/packages/autocomplete-shared/src/js/AutocompleteTranslations.ts
@@ -2,5 +2,5 @@ export type AutocompleteTranslations = {
   detachedCancelButtonText: string;
   clearButtonTitle: string;
   submitButtonTitle: string;
-  detachedSearchButtonTitle:string;
+  detachedSearchButtonTitle: string;
 };


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

fixes https://github.com/algolia/autocomplete/issues/1183

<!--
aria-labelledby on the input element fails WCAG checks because the target button has no text #1183
So i have added title property to resolve issue.
-->

**Result**

<!--
  It will resolve below issue:
  Buttons do not have an accessible name
-->

![image](https://github.com/algolia/autocomplete/assets/64833787/2f957429-9752-43c5-bcbc-5c36ec47a898)
