### PR TITLE
revert: stop processing input when composing with an IME (#1226)

### DIFF
--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -21,7 +21,6 @@ import {
   getAutocompleteElementId,
   isOrContainsNode,
   isSamsung,
-  getNativeEvent,
 } from './utils';
 
 interface GetPropGettersOptions<TItem extends BaseItem>
@@ -220,25 +219,6 @@ export function getPropGetters<
       maxLength,
       type: 'search',
       onChange: (event) => {
-        const value = (
-          (event as unknown as Event).currentTarget as HTMLInputElement
-        ).value;
-
-        if (getNativeEvent(event as unknown as InputEvent).isComposing) {
-          setters.setQuery(value);
-          return;
-        }
-
-        onInput({
-          event,
-          props,
-          query: value.slice(0, maxLength),
-          refresh,
-          store,
-          ...setters,
-        });
-      },
-      onCompositionEnd: (event) => {
         onInput({
           event,
           props,
@@ -251,10 +231,6 @@ export function getPropGetters<
         });
       },
       onKeyDown: (event) => {
-        if (getNativeEvent(event as unknown as InputEvent).isComposing) {
-          return;
-        }
-
         onKeyDown({
           event: event as unknown as KeyboardEvent,
           props,

--- a/packages/autocomplete-core/src/utils/getNativeEvent.ts
+++ b/packages/autocomplete-core/src/utils/getNativeEvent.ts
@@ -1,3 +1,0 @@
-export function getNativeEvent<TEvent>(event: TEvent) {
-  return (event as unknown as { nativeEvent: TEvent }).nativeEvent || event;
-}

--- a/packages/autocomplete-core/src/utils/index.ts
+++ b/packages/autocomplete-core/src/utils/index.ts
@@ -8,4 +8,3 @@ export * from './getAutocompleteElementId';
 export * from './isOrContainsNode';
 export * from './isSamsung';
 export * from './mapToAlgoliaResponse';
-export * from './getNativeEvent';

--- a/packages/autocomplete-js/src/utils/setProperties.ts
+++ b/packages/autocomplete-js/src/utils/setProperties.ts
@@ -110,9 +110,6 @@ function getNormalizedName(name: string): string {
   switch (name) {
     case 'onChange':
       return 'onInput';
-    // see: https://github.com/preactjs/preact/issues/1978
-    case 'onCompositionEnd':
-      return 'oncompositionend';
     default:
       return name;
   }

--- a/packages/autocomplete-shared/src/core/AutocompletePropGetters.ts
+++ b/packages/autocomplete-shared/src/core/AutocompletePropGetters.ts
@@ -83,7 +83,6 @@ export type GetInputProps<TEvent, TMouseEvent, TKeyboardEvent> = (props: {
   'aria-controls': string | undefined;
   'aria-labelledby': string;
   onChange(event: TEvent): void;
-  onCompositionEnd(event: TEvent): void;
   onKeyDown(event: TKeyboardEvent): void;
   onFocus(event: TEvent): void;
   onBlur(): void;

--- a/test/utils/createPlayground.ts
+++ b/test/utils/createPlayground.ts
@@ -24,7 +24,6 @@ export function createPlayground<TItem extends Record<string, unknown>>(
   const formProps = autocomplete.getFormProps({ inputElement });
   inputElement.addEventListener('blur', inputProps.onBlur);
   inputElement.addEventListener('input', inputProps.onChange);
-  inputElement.addEventListener('compositionend', inputProps.onCompositionEnd);
   inputElement.addEventListener('click', inputProps.onClick);
   inputElement.addEventListener('focus', inputProps.onFocus);
   inputElement.addEventListener('keydown', inputProps.onKeyDown);


### PR DESCRIPTION
This reverts commit 7f5ba08fde5278cfbb944cfde5d78bda0f3855e1 to allow a release while we're figuring out how to handle a potential issue with Samsung virtual keyboards.
