### PR TITLE
fix(insights): guard against user token override while auth token is set

### DIFF
--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -304,7 +304,7 @@ describe('createAlgoliaInsightsPlugin', () => {
       ]);
     });
 
-    test.only('uses `authenticatedUserToken` in priority over `userToken`', async () => {
+    test('uses `authenticatedUserToken` in priority over `userToken`', async () => {
       const insightsPlugin = createAlgoliaInsightsPlugin({
         insightsClient,
         insightsInitParams: {

--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -304,7 +304,7 @@ describe('createAlgoliaInsightsPlugin', () => {
       ]);
     });
 
-    test('uses `authenticatedUserToken` in priority over `userToken`', async () => {
+    test.only('uses `authenticatedUserToken` in priority over `userToken`', async () => {
       const insightsPlugin = createAlgoliaInsightsPlugin({
         insightsClient,
         insightsInitParams: {
@@ -322,6 +322,7 @@ describe('createAlgoliaInsightsPlugin', () => {
         ),
       });
 
+      // Setting an authenticated user token should replace the user token
       insightsClient('setAuthenticatedUserToken', 'customAuthUserToken');
 
       const playground = createPlayground(createAutocomplete, {
@@ -356,7 +357,9 @@ describe('createAlgoliaInsightsPlugin', () => {
         }),
       ]);
 
-      insightsClient('setAuthenticatedUserToken', undefined);
+      // Updating a user token should have no effect if there is
+      // an authenticated user token already set
+      insightsClient('setUserToken', 'customUserToken2');
 
       userEvent.type(playground.inputElement, 'b');
       await runAllMicroTasks();
@@ -364,7 +367,21 @@ describe('createAlgoliaInsightsPlugin', () => {
       expect(searchClient.search).toHaveBeenCalledTimes(2);
       expect(searchClient.search).toHaveBeenLastCalledWith([
         expect.objectContaining({
-          params: expect.objectContaining({ userToken: 'customUserToken' }),
+          params: expect.objectContaining({ userToken: 'customAuthUserToken' }),
+        }),
+      ]);
+
+      // Removing the authenticated user token should revert to
+      // the latest user token set
+      insightsClient('setAuthenticatedUserToken', undefined);
+
+      userEvent.type(playground.inputElement, 'c');
+      await runAllMicroTasks();
+
+      expect(searchClient.search).toHaveBeenCalledTimes(3);
+      expect(searchClient.search).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          params: expect.objectContaining({ userToken: 'customUserToken2' }),
         }),
       ]);
     });

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -183,6 +183,7 @@ export function createAlgoliaInsightsPlugin(
   return {
     name: 'aa.algoliaInsightsPlugin',
     subscribe({ setContext, onSelect, onActive }) {
+      let isAuthenticatedToken = false;
       function setInsightsContext(userToken?: InsightsEvent['userToken']) {
         setContext({
           algoliaInsightsPlugin: {
@@ -204,9 +205,15 @@ export function createAlgoliaInsightsPlugin(
       setInsightsContext();
 
       // Handles user token changes
-      insightsClient('onUserTokenChange', setInsightsContext);
+      insightsClient('onUserTokenChange', (userToken) => {
+        if (!isAuthenticatedToken) {
+          setInsightsContext(userToken);
+        }
+      });
       insightsClient('getUserToken', null, (_error, userToken) => {
-        setInsightsContext(userToken);
+        if (!isAuthenticatedToken) {
+          setInsightsContext(userToken);
+        }
       });
 
       // Handles authenticated user token changes
@@ -214,8 +221,10 @@ export function createAlgoliaInsightsPlugin(
         'onAuthenticatedUserTokenChange',
         (authenticatedUserToken) => {
           if (authenticatedUserToken) {
+            isAuthenticatedToken = true;
             setInsightsContext(authenticatedUserToken);
           } else {
+            isAuthenticatedToken = false;
             insightsClient('getUserToken', null, (_error, userToken) =>
               setInsightsContext(userToken)
             );
@@ -227,6 +236,7 @@ export function createAlgoliaInsightsPlugin(
         null,
         (_error, authenticatedUserToken) => {
           if (authenticatedUserToken) {
+            isAuthenticatedToken = true;
             setInsightsContext(authenticatedUserToken);
           }
         }


### PR DESCRIPTION
**Summary**

Follow-up for #1233 to ensure the Insights plugin still sends the **authenticated user token** with search requests if users mistakingly update the (regular/unauthenticated) user token before removing the authenticated user token.
