### PR TITLE
fix: ignore composition events with option

### DIFF
--- a/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/dom';
+import { fireEvent, waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 
 import {
@@ -644,6 +644,66 @@ describe('getInputProps', () => {
       await runAllMicroTasks();
 
       expect(environment.clearTimeout).toHaveBeenLastCalledWith(999);
+    });
+
+    test('stops process if IME composition is in progress', () => {
+      const getSources = jest.fn((..._args: any[]) => {
+        return [
+          createSource({
+            getItems() {
+              return [{ label: '1' }, { label: '2' }];
+            },
+          }),
+        ];
+      });
+      const { inputElement } = createPlayground(createAutocomplete, {
+        getSources,
+      });
+
+      // Typing 木 using the Wubihua input method
+      // see:
+      // - https://en.wikipedia.org/wiki/Stroke_count_method
+      // - https://developer.mozilla.org/en-US/docs/Web/API/Element/compositionend_event
+      const character = '木';
+      const strokes = ['一', '丨', '丿', '丶', character];
+
+      strokes.forEach((stroke, index) => {
+        const isFirst = index === 0;
+        const isLast = index === strokes.length - 1;
+        const query = isLast ? stroke : strokes.slice(0, index + 1).join('');
+
+        if (isFirst) {
+          fireEvent.compositionStart(inputElement);
+        }
+
+        fireEvent.compositionUpdate(inputElement, {
+          data: query,
+        });
+
+        fireEvent.input(inputElement, {
+          isComposing: true,
+          target: {
+            value: query,
+          },
+        });
+
+        if (isLast) {
+          fireEvent.compositionEnd(inputElement, {
+            data: query,
+            target: {
+              value: query,
+            },
+          });
+        }
+      });
+
+      expect(inputElement).toHaveValue(character);
+      expect(getSources).toHaveBeenCalledTimes(1);
+      expect(getSources).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          query: character,
+        })
+      );
     });
   });
 

--- a/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
@@ -646,7 +646,7 @@ describe('getInputProps', () => {
       expect(environment.clearTimeout).toHaveBeenLastCalledWith(999);
     });
 
-    test('stops process if IME composition is in progress', () => {
+    test('stops process if IME composition is in progress and `ignoreCompositionEvents: true`', () => {
       const getSources = jest.fn((..._args: any[]) => {
         return [
           createSource({
@@ -657,6 +657,7 @@ describe('getInputProps', () => {
         ];
       });
       const { inputElement } = createPlayground(createAutocomplete, {
+        ignoreCompositionEvents: true,
         getSources,
       });
 
@@ -1974,7 +1975,7 @@ describe('getInputProps', () => {
       });
     });
 
-    test('stops process if IME is in progress', () => {
+    test('stops process if IME composition is in progress`', () => {
       const onStateChange = jest.fn();
       const { inputElement } = createPlayground(createAutocomplete, {
         openOnFocus: true,
@@ -2029,16 +2030,25 @@ describe('getInputProps', () => {
         });
       });
 
-      // 3. Selecting the 3rd suggestion on the IME window
+      // 3. Checking that activeItemId has reverted to null due to input change
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({
+            activeItemId: null,
+          }),
+        })
+      );
+
+      // 4. Selecting the 3rd suggestion on the IME window
       fireEvent.keyDown(inputElement, { key: 'ArrowDown', isComposing: true });
       fireEvent.keyDown(inputElement, { key: 'ArrowDown', isComposing: true });
       fireEvent.keyDown(inputElement, { key: 'ArrowDown', isComposing: true });
 
-      // 4. Checking that activeItemId has not changed
+      // 5. Checking that activeItemId has not changed
       expect(onStateChange).toHaveBeenLastCalledWith(
         expect.objectContaining({
           state: expect.objectContaining({
-            activeItemId: 0,
+            activeItemId: null,
           }),
         })
       );

--- a/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
@@ -1973,6 +1973,76 @@ describe('getInputProps', () => {
         );
       });
     });
+
+    test('stops process if IME is in progress', () => {
+      const onStateChange = jest.fn();
+      const { inputElement } = createPlayground(createAutocomplete, {
+        openOnFocus: true,
+        onStateChange,
+        initialState: {
+          collections: [
+            createCollection({
+              source: { sourceId: 'testSource' },
+              items: [
+                { label: '1' },
+                { label: '2' },
+                { label: '3' },
+                { label: '4' },
+              ],
+            }),
+          ],
+        },
+      });
+
+      inputElement.focus();
+
+      // 1. Pressing Arrow Down to select the first item
+      fireEvent.keyDown(inputElement, { key: 'ArrowDown' });
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({
+            activeItemId: 0,
+          }),
+        })
+      );
+
+      // 2. Typing かくてい with a Japanese IME
+      const strokes = ['か', 'く', 'て', 'い'];
+      strokes.forEach((_stroke, index) => {
+        const isFirst = index === 0;
+        const query = strokes.slice(0, index + 1).join('');
+
+        if (isFirst) {
+          fireEvent.compositionStart(inputElement);
+        }
+
+        fireEvent.compositionUpdate(inputElement, {
+          data: query,
+        });
+
+        fireEvent.input(inputElement, {
+          isComposing: true,
+          data: query,
+          target: {
+            value: query,
+          },
+        });
+      });
+
+      // 3. Selecting the 3rd suggestion on the IME window
+      fireEvent.keyDown(inputElement, { key: 'ArrowDown', isComposing: true });
+      fireEvent.keyDown(inputElement, { key: 'ArrowDown', isComposing: true });
+      fireEvent.keyDown(inputElement, { key: 'ArrowDown', isComposing: true });
+
+      // 4. Checking that activeItemId has not changed
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({
+            activeItemId: 0,
+          }),
+        })
+      );
+    });
   });
 
   describe('onFocus', () => {

--- a/packages/autocomplete-core/src/getDefaultProps.ts
+++ b/packages/autocomplete-core/src/getDefaultProps.ts
@@ -28,6 +28,7 @@ export function getDefaultProps<TItem extends BaseItem>(
     debug: false,
     openOnFocus: false,
     enterKeyHint: undefined,
+    ignoreCompositionEvents: false,
     placeholder: '',
     autoFocus: false,
     defaultActiveItemId: null,

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -224,7 +224,10 @@ export function getPropGetters<
           (event as unknown as Event).currentTarget as HTMLInputElement
         ).value;
 
-        if (getNativeEvent(event as unknown as InputEvent).isComposing) {
+        if (
+          props.ignoreCompositionEvents &&
+          getNativeEvent(event as unknown as InputEvent).isComposing
+        ) {
           setters.setQuery(value);
           return;
         }

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -247,6 +247,10 @@ export function getPropGetters<
         });
       },
       onKeyDown: (event) => {
+        if ((event as unknown as InputEvent).isComposing) {
+          return;
+        }
+
         onKeyDown({
           event: event as unknown as KeyboardEvent,
           props,

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -21,6 +21,7 @@ import {
   getAutocompleteElementId,
   isOrContainsNode,
   isSamsung,
+  getNativeEvent,
 } from './utils';
 
 interface GetPropGettersOptions<TItem extends BaseItem>
@@ -219,22 +220,25 @@ export function getPropGetters<
       maxLength,
       type: 'search',
       onChange: (event) => {
-        if ((event as unknown as InputEvent).isComposing) {
+        const value = (
+          (event as unknown as Event).currentTarget as HTMLInputElement
+        ).value;
+
+        if (getNativeEvent(event as unknown as InputEvent).isComposing) {
+          setters.setQuery(value);
           return;
         }
 
         onInput({
           event,
           props,
-          query: (
-            (event as unknown as Event).currentTarget as HTMLInputElement
-          ).value.slice(0, maxLength),
+          query: value.slice(0, maxLength),
           refresh,
           store,
           ...setters,
         });
       },
-      oncompositionend: (event) => {
+      onCompositionEnd: (event) => {
         onInput({
           event,
           props,
@@ -247,7 +251,7 @@ export function getPropGetters<
         });
       },
       onKeyDown: (event) => {
-        if ((event as unknown as InputEvent).isComposing) {
+        if (getNativeEvent(event as unknown as InputEvent).isComposing) {
           return;
         }
 

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -219,6 +219,22 @@ export function getPropGetters<
       maxLength,
       type: 'search',
       onChange: (event) => {
+        if ((event as unknown as InputEvent).isComposing) {
+          return;
+        }
+
+        onInput({
+          event,
+          props,
+          query: (
+            (event as unknown as Event).currentTarget as HTMLInputElement
+          ).value.slice(0, maxLength),
+          refresh,
+          store,
+          ...setters,
+        });
+      },
+      oncompositionend: (event) => {
         onInput({
           event,
           props,

--- a/packages/autocomplete-core/src/utils/getNativeEvent.ts
+++ b/packages/autocomplete-core/src/utils/getNativeEvent.ts
@@ -1,0 +1,3 @@
+export function getNativeEvent<TEvent>(event: TEvent) {
+  return (event as unknown as { nativeEvent: TEvent }).nativeEvent || event;
+}

--- a/packages/autocomplete-core/src/utils/index.ts
+++ b/packages/autocomplete-core/src/utils/index.ts
@@ -8,3 +8,4 @@ export * from './getAutocompleteElementId';
 export * from './isOrContainsNode';
 export * from './isSamsung';
 export * from './mapToAlgoliaResponse';
+export * from './getNativeEvent';

--- a/packages/autocomplete-js/src/utils/setProperties.ts
+++ b/packages/autocomplete-js/src/utils/setProperties.ts
@@ -110,6 +110,9 @@ function getNormalizedName(name: string): string {
   switch (name) {
     case 'onChange':
       return 'onInput';
+    // see: https://github.com/preactjs/preact/issues/1978
+    case 'onCompositionEnd':
+      return 'oncompositionend';
     default:
       return name;
   }

--- a/packages/autocomplete-shared/src/core/AutocompleteOptions.ts
+++ b/packages/autocomplete-shared/src/core/AutocompleteOptions.ts
@@ -89,6 +89,14 @@ export interface AutocompleteOptions<TItem extends BaseItem> {
    */
   enterKeyHint?: AutocompleteEnterKeyHint;
   /**
+   * Whether to update the search input value in the middle of a
+   * composition session.
+   *
+   * @default false
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-ignorecompositionevents
+   */
+  ignoreCompositionEvents?: boolean;
+  /**
    * The placeholder text to show in the search input when there's no query.
    *
    * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-placeholder
@@ -200,6 +208,7 @@ export interface InternalAutocompleteOptions<TItem extends BaseItem>
   id: string;
   onStateChange(props: OnStateChangeProps<TItem>): void;
   enterKeyHint: AutocompleteEnterKeyHint | undefined;
+  ignoreCompositionEvents: boolean;
   placeholder: string;
   autoFocus: boolean;
   defaultActiveItemId: number | null;

--- a/packages/autocomplete-shared/src/core/AutocompletePropGetters.ts
+++ b/packages/autocomplete-shared/src/core/AutocompletePropGetters.ts
@@ -83,8 +83,7 @@ export type GetInputProps<TEvent, TMouseEvent, TKeyboardEvent> = (props: {
   'aria-controls': string | undefined;
   'aria-labelledby': string;
   onChange(event: TEvent): void;
-  // see: https://github.com/preactjs/preact/issues/1978
-  oncompositionend(event: TEvent): void;
+  onCompositionEnd(event: TEvent): void;
   onKeyDown(event: TKeyboardEvent): void;
   onFocus(event: TEvent): void;
   onBlur(): void;

--- a/packages/autocomplete-shared/src/core/AutocompletePropGetters.ts
+++ b/packages/autocomplete-shared/src/core/AutocompletePropGetters.ts
@@ -83,6 +83,8 @@ export type GetInputProps<TEvent, TMouseEvent, TKeyboardEvent> = (props: {
   'aria-controls': string | undefined;
   'aria-labelledby': string;
   onChange(event: TEvent): void;
+  // see: https://github.com/preactjs/preact/issues/1978
+  oncompositionend(event: TEvent): void;
   onKeyDown(event: TKeyboardEvent): void;
   onFocus(event: TEvent): void;
   onBlur(): void;

--- a/test/utils/createPlayground.ts
+++ b/test/utils/createPlayground.ts
@@ -24,6 +24,7 @@ export function createPlayground<TItem extends Record<string, unknown>>(
   const formProps = autocomplete.getFormProps({ inputElement });
   inputElement.addEventListener('blur', inputProps.onBlur);
   inputElement.addEventListener('input', inputProps.onChange);
+  inputElement.addEventListener('compositionend', inputProps.oncompositionend);
   inputElement.addEventListener('click', inputProps.onClick);
   inputElement.addEventListener('focus', inputProps.onFocus);
   inputElement.addEventListener('keydown', inputProps.onKeyDown);

--- a/test/utils/createPlayground.ts
+++ b/test/utils/createPlayground.ts
@@ -24,7 +24,7 @@ export function createPlayground<TItem extends Record<string, unknown>>(
   const formProps = autocomplete.getFormProps({ inputElement });
   inputElement.addEventListener('blur', inputProps.onBlur);
   inputElement.addEventListener('input', inputProps.onChange);
-  inputElement.addEventListener('compositionend', inputProps.oncompositionend);
+  inputElement.addEventListener('compositionend', inputProps.onCompositionEnd);
   inputElement.addEventListener('click', inputProps.onClick);
   inputElement.addEventListener('focus', inputProps.onFocus);
   inputElement.addEventListener('keydown', inputProps.onKeyDown);


### PR DESCRIPTION
This PR reintegrates https://github.com/algolia/autocomplete/pull/1226 and sets the behaviour behind an option, as in https://github.com/algolia/instantsearch/pull/6009.

---

**Summary**

Characters entered using an IME trigger search requests although the character composition is not done. This should only happen if the character has been fully composed.

This PR stops processing `input` events when composing with an IME and instead rely on the `compositionend` event in that case. This is controled by a new `ignoreCompositionEvents` option.

```js
autocomplete({
  // ...
  ignoreCompositionEvents: true,
})
```

It also prevents keyboard inputs being processed by Autocomplete if the user is currently navigating through suggestions in an IME.

**Result**

Before

![CleanShot 2023-12-14 at 10 45 34](https://github.com/algolia/autocomplete/assets/154633/1e6766cd-fda2-4dfc-afa8-d164bb096017)

After

![CleanShot 2023-12-14 at 10 46 31](https://github.com/algolia/autocomplete/assets/154633/bc8e47dd-497c-4716-a6c3-c8a1097871b1)

Fixes https://github.com/algolia/docsearch/issues/1304  
Fixes https://github.com/algolia/docsearch/issues/1043  
Fixes https://github.com/algolia/autocomplete/issues/1135