### PR TITLE
fix(js): allow body scroll when detached mode responsively disabled

### DIFF
--- a/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
+++ b/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
@@ -257,6 +257,32 @@ See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocom
     );
   });
 
+  test('removes scroll blocker from body when detached mode toggled off', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: createMatchMedia({ matches: true }),
+    });
+
+    const container = document.createElement('div');
+
+    document.body.appendChild(container);
+    const { update } = autocomplete<{ label: string }>({
+      container,
+      detachedMediaQuery: ''
+    });
+
+    await waitFor(() => expect(document.body).toHaveClass('aa-Detached'));
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: createMatchMedia({}),
+    });
+
+    update({ detachedMediaQuery: null });
+
+    await waitFor(() => expect(document.body).not.toHaveClass('aa-Detached'));
+  });
+
   test('renders noResults template on no results', async () => {
     const container = document.createElement('div');
     const panelContainer = document.createElement('div');

--- a/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
+++ b/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
@@ -257,32 +257,6 @@ See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocom
     );
   });
 
-  test('removes scroll blocker from body when detached mode toggled off', () => {
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: createMatchMedia({ matches: true }),
-    });
-
-    const container = document.createElement('div');
-
-    document.body.appendChild(container);
-    const { update } = autocomplete<{ label: string }>({
-      container,
-      detachedMediaQuery: ''
-    });
-
-    await waitFor(() => expect(document.body).toHaveClass('aa-Detached'));
-
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: createMatchMedia({}),
-    });
-
-    update({ detachedMediaQuery: null });
-
-    await waitFor(() => expect(document.body).not.toHaveClass('aa-Detached'));
-  });
-
   test('renders noResults template on no results', async () => {
     const container = document.createElement('div');
     const panelContainer = document.createElement('div');

--- a/packages/autocomplete-js/src/__tests__/detached.test.ts
+++ b/packages/autocomplete-js/src/__tests__/detached.test.ts
@@ -466,4 +466,38 @@ describe('detached', () => {
       ).toHaveAttribute('hidden');
     });
   });
+
+  test('removes aa-Detached when no longer matching', async () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: createMatchMedia({ matches: true }),
+    });
+
+    const container = document.createElement('div');
+
+    document.body.appendChild(container);
+    const { update } = autocomplete<{ label: string }>({
+      container,
+      detachedMediaQuery: 'something',
+    });
+
+    const searchButton = container.querySelector<HTMLButtonElement>(
+      '.aa-DetachedSearchButton'
+    )!;
+
+    // Open detached overlay
+    searchButton.click();
+
+    await waitFor(() => expect(document.body).toHaveClass('aa-Detached'));
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: createMatchMedia({ matches: false }),
+    });
+
+    // schedule a render (normally this is done by the matchMedia listener, but that's not accessible here)
+    update({ detachedMediaQuery: 'something' });
+
+    await waitFor(() => expect(document.body).not.toHaveClass('aa-Detached'));
+  });
 });

--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -217,6 +217,7 @@ export function autocomplete<TItem extends BaseItem>(
     return () => {
       if (panelContainerElement.contains(panelElement)) {
         panelContainerElement.removeChild(panelElement);
+        panelContainerElement.classList.remove('aa-Detached');
       }
     };
   });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
- Fixes #1250

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues, references or RFCs?
-->

**Result**
- See codesandbox example playground
- I can now scroll the body in my local app after transitioning in/out of detached mode:
![algolia-result](https://github.com/algolia/autocomplete/assets/2145098/57478173-37b3-4409-b37a-0925c05dc94b)

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

**Tech Notes**
- I also tried this, but it did not work, and I'm not exactly sure why:
```ts
    return () => {
      if (panelContainerElement.contains(panelElement)) {
        if (isDetached.value) {
          setIsModalOpen(false);
        } else {
          panelContainerElement.removeChild(panelElement);
        }
      }
    };
```