### PR TITLE
fix(js): better accessibility for submit button label

### DIFF
--- a/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
+++ b/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
@@ -89,6 +89,7 @@ See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocom
               class="aa-InputWrapperPrefix"
             >
               <label
+                arialabel="Submit"
                 class="aa-Label"
                 for="autocomplete-input"
                 id="autocomplete-label"

--- a/packages/autocomplete-js/src/createAutocompleteDom.ts
+++ b/packages/autocomplete-js/src/createAutocompleteDom.ts
@@ -78,9 +78,13 @@ export function createAutocompleteDom<TItem extends BaseItem>({
     title: translations.submitButtonTitle,
     children: [SearchIcon({ environment })],
   });
+  // @MAJOR Remove the label wrapper for the submit button.
+  // The submit button is sufficient for accessibility purposes, and
+  // wrapping it with the label actually makes it less accessible (see CR-6077).
   const label = createDomElement('label', {
     class: classNames.label,
     children: [submitButton],
+    ariaLabel: translations.submitButtonTitle,
     ...labelProps,
   });
   const clearButton = createDomElement('button', {


### PR DESCRIPTION
**Summary**

This PR adds an explicit `aria-label` on the label wrapping the submit button to pass accessibility tests.

Ultimately we should determine whether the label is useful, if not it should be removed in the next major as the button is sufficient for accessibility purposes.

**Before**

![localhost_1234_ (1)](https://github.com/algolia/autocomplete/assets/154633/86b12aea-86fa-4be8-b324-6ebcc2e09d53)

**After**

![localhost_1234_](https://github.com/algolia/autocomplete/assets/154633/794f60a1-55cd-435a-8aa7-f1e6421691b1)



[CR-6077](https://algolia.atlassian.net/browse/CR-6077)


[CR-6077]: https://algolia.atlassian.net/browse/CR-6077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ