### PR TITLE
chore(deps): update search-insights and instantsearch dependencies

### DIFF
--- a/examples/instantsearch/package.json
+++ b/examples/instantsearch/package.json
@@ -15,7 +15,7 @@
     "@algolia/autocomplete-theme-classic": "1.17.3",
     "@algolia/client-search": "4.16.0",
     "algoliasearch": "4.16.0",
-    "instantsearch.js": "4.53.0"
+    "instantsearch.js": "4.73.1"
   },
   "devDependencies": {
     "parcel": "2.8.3"

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -17,7 +17,7 @@
     "@algolia/client-search": "4.16.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2",
-    "search-insights": "2.13.0"
+    "search-insights": "^2.15.0"
   },
   "devDependencies": {
     "parcel": "2.8.3"

--- a/examples/query-suggestions-with-hits/package.json
+++ b/examples/query-suggestions-with-hits/package.json
@@ -17,7 +17,7 @@
     "@algolia/client-search": "4.16.0",
     "algoliasearch": "4.16.0",
     "preact": "10.13.2",
-    "search-insights": "2.13.0"
+    "search-insights": "^2.15.0"
   },
   "devDependencies": {
     "parcel": "2.8.3"

--- a/examples/react-instantsearch/package.json
+++ b/examples/react-instantsearch/package.json
@@ -17,7 +17,7 @@
     "algoliasearch": "4.16.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-instantsearch": "7.11.3"
+    "react-instantsearch": "7.12.1"
   },
   "devDependencies": {
     "@types/react": "^18.0.26",

--- a/examples/reshape/package.json
+++ b/examples/reshape/package.json
@@ -19,7 +19,7 @@
     "algoliasearch": "4.16.0",
     "preact": "10.13.2",
     "ramda": "0.27.1",
-    "search-insights": "2.13.0"
+    "search-insights": "^2.15.0"
   },
   "devDependencies": {
     "@algolia/autocomplete-core": "1.17.3",

--- a/examples/tags-in-searchbox/package.json
+++ b/examples/tags-in-searchbox/package.json
@@ -16,7 +16,7 @@
     "algoliasearch": "4.16.0",
     "preact": "10.13.2",
     "ramda": "0.27.1",
-    "search-insights": "2.13.0"
+    "search-insights": "^2.15.0"
   },
   "devDependencies": {
     "parcel": "2.8.3"

--- a/examples/tags-with-hits/package.json
+++ b/examples/tags-with-hits/package.json
@@ -16,7 +16,7 @@
     "algoliasearch": "4.16.0",
     "preact": "10.13.2",
     "ramda": "0.27.1",
-    "search-insights": "2.13.0"
+    "search-insights": "^2.15.0"
   },
   "devDependencies": {
     "parcel": "2.8.3"

--- a/examples/vue-instantsearch/package.json
+++ b/examples/vue-instantsearch/package.json
@@ -17,7 +17,7 @@
     "@algolia/autocomplete-theme-classic": "1.17.3",
     "algoliasearch": "4.16.0",
     "vue": "3.2.47",
-    "vue-instantsearch": "4.8.8"
+    "vue-instantsearch": "4.18.1"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
     "rollup-plugin-filesize": "9.1.2",
     "rollup-plugin-license": "2.9.1",
     "rollup-plugin-terser": "7.0.2",
+    "search-insights": "^2.15.0",
     "shipjs": "0.26.1",
-    "search-insights": "2.13.0",
     "start-server-and-test": "1.15.2",
     "stylelint": "13.13.1",
     "stylelint-a11y": "1.2.3",
@@ -96,5 +96,6 @@
   },
   "resolutions": {
     "bundlesize/brotli-size": "4.0.0"
-  }
+  },
+  "dependencies": {}
 }

--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -453,7 +453,7 @@ describe('createAlgoliaInsightsPlugin', () => {
       expect(document.body).toMatchInlineSnapshot(`
         <body>
           <script
-            src="https://cdn.jsdelivr.net/npm/search-insights@2.13.0/dist/search-insights.min.js"
+            src="https://cdn.jsdelivr.net/npm/search-insights@2.15.0/dist/search-insights.min.js"
           />
           <form>
             <input />
@@ -465,7 +465,7 @@ describe('createAlgoliaInsightsPlugin', () => {
       `);
       expect((window as any).AlgoliaAnalyticsObject).toBe('aa');
       expect((window as any).aa).toEqual(expect.any(Function));
-      expect((window as any).aa.version).toBe('2.13.0');
+      expect((window as any).aa.version).toBe('2.15.0');
     });
 
     it('notifies when the script fails to be added', () => {
@@ -1026,7 +1026,7 @@ describe('createAlgoliaInsightsPlugin', () => {
     test('sends a `clickedObjectIDsAfterSearch` event with additional parameters if client supports it', async () => {
       const insightsClient = jest.fn();
       // @ts-ignore
-      insightsClient.version = '2.13.0';
+      insightsClient.version = '2.15.0';
       const insightsPlugin = createAlgoliaInsightsPlugin({ insightsClient });
 
       const { inputElement } = createPlayground(createAutocomplete, {

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -28,7 +28,7 @@ import {
 } from './types';
 
 const VIEW_EVENT_DELAY = 400;
-const ALGOLIA_INSIGHTS_VERSION = '2.13.0';
+const ALGOLIA_INSIGHTS_VERSION = '2.15.0';
 const ALGOLIA_INSIGHTS_SRC = `https://cdn.jsdelivr.net/npm/search-insights@${ALGOLIA_INSIGHTS_VERSION}/dist/search-insights.min.js`;
 
 type SendViewedObjectIDsParams = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,19 +180,6 @@
     "@algolia/logger-common" "4.16.0"
     "@algolia/requester-common" "4.16.0"
 
-"@algolia/ui-components-highlight-vdom@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@algolia/ui-components-highlight-vdom/-/ui-components-highlight-vdom-1.2.1.tgz#c430c9f090ef8c68477ef4b685324ed231ce0c13"
-  integrity sha512-IlYgIaCUEkz9ezNbwugwKv991oOHhveyq6nzL0F1jDzg1p3q5Yj/vO4KpNG910r2dwGCG3nEm5GtChcLnarhFA==
-  dependencies:
-    "@algolia/ui-components-shared" "1.2.1"
-    "@babel/runtime" "^7.0.0"
-
-"@algolia/ui-components-shared@1.2.1", "@algolia/ui-components-shared@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@algolia/ui-components-shared/-/ui-components-shared-1.2.1.tgz#62e3a04fc11623f149312942cd764d4528dd994c"
-  integrity sha512-a7mYHf/GVQfhAx/HRiMveKkFvHspQv/REdG+C/FIOosiSmNZxX7QebDwJkrGSmDWdXO12D0Qv1xn3AytFcEDlQ==
-
 "@ampproject/remapping@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -1187,7 +1174,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.8", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.8", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
@@ -4228,17 +4215,10 @@ ajv@^8.0.1:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-algoliasearch-helper@3.22.1:
-  version "3.22.1"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.22.1.tgz#c4b91265aa2e58eea4413bc57c4611eaf391e597"
-  integrity sha512-fSxJ4YreH4kOME9CnKazbAn2tK/rvBoV37ETd6nTt4j7QfkcnW+c+F22WfuE9Q/sRpvOMnUwU/BXAVEiwW7p/w==
-  dependencies:
-    "@algolia/events" "^4.0.1"
-
-algoliasearch-helper@^3.11.3:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.12.0.tgz#0fe39d49b0290e4aa5e1fe733bd24d857d258e94"
-  integrity sha512-/j1U3PEwdan0n6P/QqSnSpNSLC5+cEMvyljd5CnmNmUjDlGrys+vFEOwjVEnqELIiAGMHEA/Nl3CiKVFBUYqyQ==
+algoliasearch-helper@3.22.2:
+  version "3.22.2"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.22.2.tgz#e351833f3bbace34751e239d5a82b5696e561ae8"
+  integrity sha512-3YQ6eo7uYOCHeQ2ZpD+OoT3aJJwMNKEnwtu8WMzm81XmBOSCwRjQditH9CeSOQ38qhHkuGw23pbq+kULkIJLcw==
   dependencies:
     "@algolia/events" "^4.0.1"
 
@@ -5162,15 +5142,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001179, caniuse-lite@^1.0.30001449:
-  version "1.0.30001473"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz#3859898b3cab65fc8905bb923df36ad35058153c"
-  integrity sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==
-
-caniuse-lite@^1.0.30001464:
-  version "1.0.30001474"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001474.tgz#13b6fe301a831fe666cce8ca4ef89352334133d5"
-  integrity sha512-iaIZ8gVrWfemh5DG3T9/YqarVZoYf0r188IjaGwx68j4Pf0SGY6CQkmJUIE+NZHkkecQGohzXmBGEwWDr9aM3Q==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001179, caniuse-lite@^1.0.30001449, caniuse-lite@^1.0.30001464:
+  version "1.0.30001640"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001640.tgz"
+  integrity sha512-lA4VMpW0PSUrFnkmVuEKBUovSWKhj7puyCg8StBChgu298N1AtuF1sKWEvfDuimSEDbhlb/KqPKC3fs1HbuQUA==
 
 capital-case@^1.0.3, capital-case@^1.0.4:
   version "1.0.4"
@@ -8496,42 +8471,23 @@ instantsearch-ui-components@0.7.0:
   dependencies:
     "@babel/runtime" "^7.1.2"
 
-instantsearch.js@4.53.0:
-  version "4.53.0"
-  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.53.0.tgz#8dffe121681f514363762a4c70bc4c4344b9775d"
-  integrity sha512-YsKZo8yF/2/lc1FHwyP73k8IoIMPesP+8R4VSmWDf/No8EgELgpC7qgZOlQl/vLIoAAaDrKD/BfstposfMF8KQ==
-  dependencies:
-    "@algolia/events" "^4.0.1"
-    "@algolia/ui-components-highlight-vdom" "^1.2.1"
-    "@algolia/ui-components-shared" "^1.2.1"
-    "@types/dom-speech-recognition" "^0.0.1"
-    "@types/google.maps" "^3.45.3"
-    "@types/hogan.js" "^3.0.0"
-    "@types/qs" "^6.5.3"
-    algoliasearch-helper "^3.11.3"
-    hogan.js "^3.0.2"
-    htm "^3.0.0"
-    preact "^10.10.0"
-    qs "^6.5.1 < 6.10"
-    search-insights "^2.1.0"
-
-instantsearch.js@4.72.1:
-  version "4.72.1"
-  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.72.1.tgz#75130e43f684464363d5c1753b4a0d04182b534b"
-  integrity sha512-NcSZPKmBBzvg2TWgucRVl9d+L/Pht909PwE0SUNcniQiIA0FXtE85sHjYhqWswnEr6pO2545c2uz7xIiTvBjOA==
+instantsearch.js@4.73.1:
+  version "4.73.1"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.73.1.tgz#bf0d1aa5a2bf6fa40b0eab79e5d6d7fc6547af32"
+  integrity sha512-sO+eck5STiHiDFaNNoYzd62RDJwINgoi3yyOcEBi7PCs0rrpcj4hw0lTuw30cqloNjcM63exGdcRXX5r7Hl49g==
   dependencies:
     "@algolia/events" "^4.0.1"
     "@types/dom-speech-recognition" "^0.0.1"
     "@types/google.maps" "^3.45.3"
     "@types/hogan.js" "^3.0.0"
     "@types/qs" "^6.5.3"
-    algoliasearch-helper "3.22.1"
+    algoliasearch-helper "3.22.2"
     hogan.js "^3.0.2"
     htm "^3.0.0"
     instantsearch-ui-components "0.7.0"
     preact "^10.10.0"
     qs "^6.5.1 < 6.10"
-    search-insights "^2.13.0"
+    search-insights "^2.15.0"
 
 internal-slot@^1.0.3, internal-slot@^1.0.5:
   version "1.0.5"
@@ -12508,25 +12464,25 @@ react-error-overlay@6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
-react-instantsearch-core@7.11.3:
-  version "7.11.3"
-  resolved "https://registry.yarnpkg.com/react-instantsearch-core/-/react-instantsearch-core-7.11.3.tgz#6fe3ead508457e3232df74171e5a51d852d16068"
-  integrity sha512-c5/odLJVc8hZgTzOXhC+IfXmC/M4UALZ2vvF9ts5TNbn7KB2M+AexmJt4g279X57sBSeUXHhOzFLrj3jAKvYvQ==
+react-instantsearch-core@7.12.1:
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/react-instantsearch-core/-/react-instantsearch-core-7.12.1.tgz#dc3d60d7edcf611eb9bde7fe337e7530b9b26a24"
+  integrity sha512-nbA6bj1qL+fJfldxOlbbfbCbIGlB/X4qGHEAuQQBI20zMwR+nMa0qDXjre7N0nmoMt7Oyx5ijNxpwP/LRTVOgA==
   dependencies:
     "@babel/runtime" "^7.1.2"
-    algoliasearch-helper "3.22.1"
-    instantsearch.js "4.72.1"
+    algoliasearch-helper "3.22.2"
+    instantsearch.js "4.73.1"
     use-sync-external-store "^1.0.0"
 
-react-instantsearch@7.11.3:
-  version "7.11.3"
-  resolved "https://registry.yarnpkg.com/react-instantsearch/-/react-instantsearch-7.11.3.tgz#6bb168155e6bf566561dc0430aeb140a9f1d95d6"
-  integrity sha512-zGFITpZYHdlUlrOsbSNHJY4OD4ZBZKFD+a+DCPDwlR8y0cO2mOlOnlB3IWOXvK3gOT7ckDB4ndcfFVDRTVtLDg==
+react-instantsearch@7.12.1:
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/react-instantsearch/-/react-instantsearch-7.12.1.tgz#5e677dedd22b0046e2efc29278964b701f191ea2"
+  integrity sha512-CCJGWEPo4qVQ8LY3M9VlcgGJjF87/msJf7D0kVDRPLX/obPFtH8T6P2wOqPj7GJR8QGGdM15NlbQPbJAjPeadg==
   dependencies:
     "@babel/runtime" "^7.1.2"
     instantsearch-ui-components "0.7.0"
-    instantsearch.js "4.72.1"
-    react-instantsearch-core "7.11.3"
+    instantsearch.js "4.73.1"
+    react-instantsearch-core "7.12.1"
 
 react-is@^16.13.1:
   version "16.13.1"
@@ -13264,20 +13220,10 @@ schema-utils@^2.6.5:
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
 
-search-insights@2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.13.0.tgz#a79fdcf4b5dad2fba8975b06f2ebc37a865032b7"
-  integrity sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==
-
-search-insights@^2.1.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.2.1.tgz#9c93344fbae5fbf2f88c1a81b46b4b5d888c11f7"
-  integrity sha512-JDfVGZbKqTtiKVZjAVbkNw9C9f0ib80yx6Ea17M3z4RvPmuD0GYWXuFwA9++dpbreBEMH4TC3lQ29Zq7O4b5oA==
-
-search-insights@^2.13.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.14.0.tgz#212626f1c5ee8d8e232af1f35c9afaa760a56d24"
-  integrity sha512-OLN6MsPMCghDOqlCtsIsYgtsC0pnwVTyT9Mu6A3ewOj1DxvzZF6COrn2g86E/c05xbktB0XN04m/t1Z+n+fTGw==
+search-insights@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.15.0.tgz#61c7db9d13218ee966937ad2462385b05c0df624"
+  integrity sha512-ch2sPCUDD4sbPQdknVl9ALSi9H7VyoeVbsxznYz6QV55jJ8CI3EtwpO1i84keN4+hF5IeHWIeGvc08530JkVXQ==
 
 "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
@@ -14989,12 +14935,13 @@ vite@2.8.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vue-instantsearch@4.8.8:
-  version "4.8.8"
-  resolved "https://registry.yarnpkg.com/vue-instantsearch/-/vue-instantsearch-4.8.8.tgz#68350799b9c9a6d953ba2aaa60ada9c0439a8995"
-  integrity sha512-cQylbVL5sdtSe1ZSh8BfuHtIXqMscI5dXvMs+i88ZaDLdNf+TZ9sWQ1dnl5fZUqRKMEYrjGuOLc/+UiR8GF6jg==
+vue-instantsearch@4.18.1:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/vue-instantsearch/-/vue-instantsearch-4.18.1.tgz#5db1409ae3d11426a49d181f74b7307f27c96498"
+  integrity sha512-wjoawHpSnI6IVjoS2BfASIQhvOzaA0lTX39ZmllFBrBTxaK7FDLzOjGHPlyreSH8HEzE+pCpuprOTaKlFWyEXg==
   dependencies:
-    instantsearch.js "4.53.0"
+    instantsearch-ui-components "0.7.0"
+    instantsearch.js "4.73.1"
     mitt "^2.1.0"
 
 vue@3.2.47:


### PR DESCRIPTION
**Summary**

Updates search-insights to 2.15.0 which contains features to simplify query id tracking from clicks for use in conversion events, and updates instantsearch components which also use the updated search-insights.

**Result**

Updated usages in the examples as well as the local dependency.