### PR TITLE
fix(core): use updated aria control attribute for root element

### DIFF
--- a/packages/autocomplete-core/src/__tests__/getRootProps.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getRootProps.test.ts
@@ -45,7 +45,7 @@ describe('getRootProps', () => {
     expect(rootProps['aria-haspopup']).toEqual('listbox');
   });
 
-  test('returns undefined aria-owns when panel is closed', () => {
+  test('returns undefined aria-controls when panel is closed', () => {
     const autocomplete = createAutocomplete({
       initialState: {
         isOpen: false,
@@ -53,10 +53,10 @@ describe('getRootProps', () => {
     });
     const rootProps = autocomplete.getRootProps({});
 
-    expect(rootProps['aria-owns']).toBeUndefined();
+    expect(rootProps['aria-controls']).toBeUndefined();
   });
 
-  test('returns list id in aria-owns when panel is open', () => {
+  test('returns list id in aria-controls when panel is open', () => {
     const autocomplete = createAutocomplete({
       id: 'autocomplete',
       initialState: {
@@ -70,7 +70,7 @@ describe('getRootProps', () => {
     });
     const rootProps = autocomplete.getRootProps({});
 
-    expect(rootProps['aria-owns']).toEqual('autocomplete-testSource-list');
+    expect(rootProps['aria-controls']).toEqual('autocomplete-testSource-list');
   });
 
   test('returns label id in aria-labelledby', () => {

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -110,7 +110,7 @@ export function getPropGetters<
       role: 'combobox',
       'aria-expanded': store.getState().isOpen,
       'aria-haspopup': 'listbox',
-      'aria-owns': store.getState().isOpen
+      'aria-controls': store.getState().isOpen
         ? store
             .getState()
             .collections.map(({ source }) =>

--- a/packages/autocomplete-shared/src/core/AutocompletePropGetters.ts
+++ b/packages/autocomplete-shared/src/core/AutocompletePropGetters.ts
@@ -42,7 +42,7 @@ export type GetRootProps = (props?: { [key: string]: unknown }) => {
     | 'listbox'
     | 'tree'
     | undefined;
-  'aria-owns': string | undefined;
+  'aria-controls': string | undefined;
   'aria-labelledby': string;
 };
 


### PR DESCRIPTION
**Summary**

This PR updates `getRootProps()` to return `aria-controls` instead of `aria-owns`, following the latest ARIA specs.

From [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role): 
> When a combobox's popup is displayed, ensure the [`aria-controls`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls) attribute on the combobox element is set to the [`id`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id) of the popup `listbox`, `tree`, `grid`, or `dialog` element. This is how the relationship between the element with the `combobox` role and the popup it controls is indicated. (Note: In older ARIA specs, this was `aria-owns` rather than `aria-controls`, so you may see `aria-owns` in older combobox implementations. The `aria-owns` in the code should be updated to `aria-controls`!)

**Result**

Assistive technologies correctly link the combobox with the listbox it controls. Accessibility tools like WAVE and axe stop reporting errors relevant to this.


Closes #1271 