### PR TITLE
fix(shared): import adequate FacetHit types for v4 and v5 search client

### DIFF
--- a/packages/autocomplete-shared/src/core/AutocompleteSource.ts
+++ b/packages/autocomplete-shared/src/core/AutocompleteSource.ts
@@ -1,7 +1,10 @@
-import type { FacetHit, Hit } from '@algolia/client-search';
+import type { Hit } from '@algolia/client-search';
 
 import type { MaybePromise } from '../MaybePromise';
-import type { SearchForFacetValuesResponse } from '../preset-algolia/algoliasearch';
+import type {
+  FacetHit,
+  SearchForFacetValuesResponse,
+} from '../preset-algolia/algoliasearch';
 import type { RequesterDescription } from '../preset-algolia/createRequester';
 import type { SearchResponse } from '../SearchResponse';
 

--- a/packages/autocomplete-shared/src/preset-algolia/algoliasearch.ts
+++ b/packages/autocomplete-shared/src/preset-algolia/algoliasearch.ts
@@ -71,3 +71,10 @@ export type SnippetResult<THit> = PickForClient<{
   /** @ts-ignore */
   v5: AlgoliaSearch.SnippetResult; // should be generic, but isn't yet in the client
 }>;
+
+export type FacetHit = PickForClient<{
+  /** @ts-ignore */
+  v4: ClientSearch.FacetHit;
+  /** @ts-ignore */
+  v5: AlgoliaSearch.FacetHits;
+}>;


### PR DESCRIPTION
**Summary**

This PR changes how `FacetHit` is imported by conditionally returning the proper exported name, as algolia search v5 changed this to `FacetHits`.

See [Slack convo](https://algolia.slack.com/archives/C07RZ112T6G/p1728985471953039) for more information.

**Result**

Projects that depend on autocomplete and which use algoliasearch@5 can now successfully build.