### PR TITLE
fix(plugins): add translations for query suggestions and recent searches plugins

### DIFF
--- a/packages/autocomplete-plugin-query-suggestions/src/__tests__/createQuerySuggestionsPlugin.test.ts
+++ b/packages/autocomplete-plugin-query-suggestions/src/__tests__/createQuerySuggestionsPlugin.test.ts
@@ -645,4 +645,140 @@ describe('createQuerySuggestionsPlugin', () => {
       },
     ]);
   });
+
+  test('accepts translation', async () => {
+    const querySuggestionsPlugin = createQuerySuggestionsPlugin({
+      searchClient,
+      indexName: 'indexName',
+      translations: {
+        fillQueryTitle: (query) => `TEST FILL "${query}"`,
+      },
+    });
+
+    const container = document.createElement('div');
+    const panelContainer = document.createElement('div');
+
+    document.body.appendChild(panelContainer);
+
+    autocomplete({
+      container,
+      panelContainer,
+      plugins: [querySuggestionsPlugin],
+    });
+
+    const input = container.querySelector<HTMLInputElement>('.aa-Input');
+
+    fireEvent.input(input, { target: { value: 'a' } });
+
+    await waitFor(() => {
+      expect(
+        within(
+          panelContainer.querySelector(
+            '[data-autocomplete-source-id="querySuggestionsPlugin"]'
+          )
+        )
+          .getAllByRole('option')
+          .map((option) => option.children)
+      ).toMatchInlineSnapshot(`
+        Array [
+          HTMLCollection [
+            <div
+              class="aa-ItemWrapper"
+            >
+              <div
+                class="aa-ItemContent"
+              >
+                <div
+                  class="aa-ItemIcon aa-ItemIcon--noBorder"
+                >
+                  <svg
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16.041 15.856c-0.034 0.026-0.067 0.055-0.099 0.087s-0.060 0.064-0.087 0.099c-1.258 1.213-2.969 1.958-4.855 1.958-1.933 0-3.682-0.782-4.95-2.050s-2.050-3.017-2.050-4.95 0.782-3.682 2.050-4.95 3.017-2.050 4.95-2.050 3.682 0.782 4.95 2.050 2.050 3.017 2.050 4.95c0 1.886-0.745 3.597-1.959 4.856zM21.707 20.293l-3.675-3.675c1.231-1.54 1.968-3.493 1.968-5.618 0-2.485-1.008-4.736-2.636-6.364s-3.879-2.636-6.364-2.636-4.736 1.008-6.364 2.636-2.636 3.879-2.636 6.364 1.008 4.736 2.636 6.364 3.879 2.636 6.364 2.636c2.125 0 4.078-0.737 5.618-1.968l3.675 3.675c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="aa-ItemContentBody"
+                >
+                  <div
+                    class="aa-ItemContentTitle"
+                  >
+                    cooktop
+                  </div>
+                </div>
+              </div>
+              <div
+                class="aa-ItemActions"
+              >
+                <button
+                  class="aa-ItemActionButton"
+                  title="TEST FILL \\"cooktop\\""
+                >
+                  <svg
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M8 17v-7.586l8.293 8.293c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-8.293-8.293h7.586c0.552 0 1-0.448 1-1s-0.448-1-1-1h-10c-0.552 0-1 0.448-1 1v10c0 0.552 0.448 1 1 1s1-0.448 1-1z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>,
+          ],
+          HTMLCollection [
+            <div
+              class="aa-ItemWrapper"
+            >
+              <div
+                class="aa-ItemContent"
+              >
+                <div
+                  class="aa-ItemIcon aa-ItemIcon--noBorder"
+                >
+                  <svg
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16.041 15.856c-0.034 0.026-0.067 0.055-0.099 0.087s-0.060 0.064-0.087 0.099c-1.258 1.213-2.969 1.958-4.855 1.958-1.933 0-3.682-0.782-4.95-2.050s-2.050-3.017-2.050-4.95 0.782-3.682 2.050-4.95 3.017-2.050 4.95-2.050 3.682 0.782 4.95 2.050 2.050 3.017 2.050 4.95c0 1.886-0.745 3.597-1.959 4.856zM21.707 20.293l-3.675-3.675c1.231-1.54 1.968-3.493 1.968-5.618 0-2.485-1.008-4.736-2.636-6.364s-3.879-2.636-6.364-2.636-4.736 1.008-6.364 2.636-2.636 3.879-2.636 6.364 1.008 4.736 2.636 6.364 3.879 2.636 6.364 2.636c2.125 0 4.078-0.737 5.618-1.968l3.675 3.675c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="aa-ItemContentBody"
+                >
+                  <div
+                    class="aa-ItemContentTitle"
+                  >
+                    range
+                  </div>
+                </div>
+              </div>
+              <div
+                class="aa-ItemActions"
+              >
+                <button
+                  class="aa-ItemActionButton"
+                  title="TEST FILL \\"range\\""
+                >
+                  <svg
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M8 17v-7.586l8.293 8.293c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-8.293-8.293h7.586c0.552 0 1-0.448 1-1s-0.448-1-1-1h-10c-0.552 0-1 0.448-1 1v10c0 0.552 0.448 1 1 1s1-0.448 1-1z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>,
+          ],
+        ]
+      `);
+    });
+  });
 });

--- a/packages/autocomplete-plugin-query-suggestions/src/constants.ts
+++ b/packages/autocomplete-plugin-query-suggestions/src/constants.ts
@@ -1,0 +1,6 @@
+import { AutocompleteSuggestionsPluginTranslations } from './types';
+
+export const defaultTranslations: Required<AutocompleteSuggestionsPluginTranslations> =
+  {
+    fillQueryTitle: (text: string) => `Fill query with "${text}"`,
+  };

--- a/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
+++ b/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
@@ -8,8 +8,13 @@ import { getAttributeValueByPath } from '@algolia/autocomplete-shared';
 import { SearchOptions } from '@algolia/client-search';
 import { SearchClient } from 'algoliasearch/lite';
 
+import { defaultTranslations } from './constants';
 import { getTemplates } from './getTemplates';
-import { AutocompleteQuerySuggestionsHit, QuerySuggestionsHit } from './types';
+import {
+  AutocompleteQuerySuggestionsHit,
+  AutocompleteSuggestionsPluginTranslations,
+  QuerySuggestionsHit,
+} from './types';
 
 export type CreateQuerySuggestionsPluginParams<
   TItem extends QuerySuggestionsHit
@@ -64,6 +69,13 @@ export type CreateQuerySuggestionsPluginParams<
    * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-query-suggestions/createQuerySuggestionsPlugin/#param-categoriesperitem
    */
   categoriesPerItem?: number;
+
+  /**
+   * A mapping of translation strings.
+   *
+   * Defaults to English values.
+   */
+  translations?: Partial<AutocompleteSuggestionsPluginTranslations>;
 };
 
 export function createQuerySuggestionsPlugin<
@@ -79,6 +91,7 @@ export function createQuerySuggestionsPlugin<
     categoryAttribute,
     itemsWithCategories,
     categoriesPerItem,
+    translations,
   } = getOptions(options);
 
   return {
@@ -156,7 +169,7 @@ export function createQuerySuggestionsPlugin<
                 },
               });
             },
-            templates: getTemplates({ onTapAhead }),
+            templates: getTemplates({ onTapAhead, translations }),
           },
           onTapAhead,
           state: state as AutocompleteState<TItem>,
@@ -176,5 +189,9 @@ function getOptions<TItem extends AutocompleteQuerySuggestionsHit>(
     itemsWithCategories: 1,
     categoriesPerItem: 1,
     ...options,
+    translations: {
+      ...defaultTranslations,
+      ...options.translations,
+    },
   };
 }

--- a/packages/autocomplete-plugin-query-suggestions/src/getTemplates.tsx
+++ b/packages/autocomplete-plugin-query-suggestions/src/getTemplates.tsx
@@ -2,14 +2,19 @@
 /** @jsx createElement */
 import { SourceTemplates } from '@algolia/autocomplete-js';
 
-import { QuerySuggestionsHit } from './types';
+import {
+  AutocompleteSuggestionsPluginTranslations,
+  QuerySuggestionsHit,
+} from './types';
 
 export type GetTemplatesParams<TItem extends QuerySuggestionsHit> = {
   onTapAhead(item: TItem): void;
+  translations: AutocompleteSuggestionsPluginTranslations;
 };
 
 export function getTemplates<TItem extends QuerySuggestionsHit>({
   onTapAhead,
+  translations,
 }: GetTemplatesParams<TItem>): SourceTemplates<TItem> {
   return {
     item({ item, createElement, components }) {
@@ -48,7 +53,7 @@ export function getTemplates<TItem extends QuerySuggestionsHit>({
           <div className="aa-ItemActions">
             <button
               className="aa-ItemActionButton"
-              title={`Fill query with "${item.query}"`}
+              title={translations.fillQueryTitle(item.query)}
               onClick={(event) => {
                 event.preventDefault();
                 event.stopPropagation();

--- a/packages/autocomplete-plugin-query-suggestions/src/types/Translations.ts
+++ b/packages/autocomplete-plugin-query-suggestions/src/types/Translations.ts
@@ -1,0 +1,3 @@
+export type AutocompleteSuggestionsPluginTranslations = {
+  fillQueryTitle: (text: string) => string;
+};

--- a/packages/autocomplete-plugin-query-suggestions/src/types/index.ts
+++ b/packages/autocomplete-plugin-query-suggestions/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './QuerySuggestionsHit';
+export * from './Translations';

--- a/packages/autocomplete-plugin-recent-searches/src/__tests__/createRecentSearchesPlugin.test.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/__tests__/createRecentSearchesPlugin.test.ts
@@ -300,6 +300,223 @@ describe('createRecentSearchesPlugin', () => {
     });
   });
 
+  test('accepts translated strings', async () => {
+    const storage = createInMemoryStorage([
+      {
+        id: 'query',
+        label: 'query',
+      },
+    ]);
+
+    const recentSearchesPlugin = createRecentSearchesPlugin({
+      storage,
+      translations: {
+        removeSearchTitle: 'TEST REMOVE',
+        fillQueryTitle: (text) => `TEST FILL QUERY "${text}"`,
+      },
+    });
+
+    const container = document.createElement('div');
+    const panelContainer = document.createElement('div');
+
+    document.body.appendChild(panelContainer);
+
+    autocomplete({
+      container,
+      panelContainer,
+      openOnFocus: true,
+      plugins: [recentSearchesPlugin],
+    });
+
+    const input = container.querySelector<HTMLInputElement>('.aa-Input');
+
+    fireEvent.input(input, { target: { value: 'a' } });
+
+    await waitFor(() => {
+      expect(
+        within(
+          panelContainer.querySelector(
+            '[data-autocomplete-source-id="recentSearchesPlugin"]'
+          )
+        )
+          .getAllByRole('option')
+          .map((option) => option.children)
+      ).toMatchInlineSnapshot(`
+        Array [
+          HTMLCollection [
+            <div
+              class="aa-ItemWrapper"
+            >
+              <div
+                class="aa-ItemContent"
+              >
+                <div
+                  class="aa-ItemIcon aa-ItemIcon--noBorder"
+                >
+                  <svg
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12.516 6.984v5.25l4.5 2.672-0.75 1.266-5.25-3.188v-6h1.5zM12 20.016q3.281 0 5.648-2.367t2.367-5.648-2.367-5.648-5.648-2.367-5.648 2.367-2.367 5.648 2.367 5.648 5.648 2.367zM12 2.016q4.125 0 7.055 2.93t2.93 7.055-2.93 7.055-7.055 2.93-7.055-2.93-2.93-7.055 2.93-7.055 7.055-2.93z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="aa-ItemContentBody"
+                >
+                  <div
+                    class="aa-ItemContentTitle"
+                  >
+                    query
+                  </div>
+                </div>
+              </div>
+              <div
+                class="aa-ItemActions"
+              >
+                <button
+                  class="aa-ItemActionButton"
+                  title="TEST REMOVE"
+                >
+                  <svg
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M18 7v13c0 0.276-0.111 0.525-0.293 0.707s-0.431 0.293-0.707 0.293h-10c-0.276 0-0.525-0.111-0.707-0.293s-0.293-0.431-0.293-0.707v-13zM17 5v-1c0-0.828-0.337-1.58-0.879-2.121s-1.293-0.879-2.121-0.879h-4c-0.828 0-1.58 0.337-2.121 0.879s-0.879 1.293-0.879 2.121v1h-4c-0.552 0-1 0.448-1 1s0.448 1 1 1h1v13c0 0.828 0.337 1.58 0.879 2.121s1.293 0.879 2.121 0.879h10c0.828 0 1.58-0.337 2.121-0.879s0.879-1.293 0.879-2.121v-13h1c0.552 0 1-0.448 1-1s-0.448-1-1-1zM9 5v-1c0-0.276 0.111-0.525 0.293-0.707s0.431-0.293 0.707-0.293h4c0.276 0 0.525 0.111 0.707 0.293s0.293 0.431 0.293 0.707v1zM9 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1zM13 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  class="aa-ItemActionButton"
+                  title="TEST FILL QUERY \\"query\\""
+                >
+                  <svg
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M8 17v-7.586l8.293 8.293c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-8.293-8.293h7.586c0.552 0 1-0.448 1-1s-0.448-1-1-1h-10c-0.552 0-1 0.448-1 1v10c0 0.552 0.448 1 1 1s1-0.448 1-1z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>,
+          ],
+        ]
+      `);
+    });
+  });
+
+  test('accepts partial translated strings', async () => {
+    const storage = createInMemoryStorage([
+      {
+        id: 'query',
+        label: 'query',
+      },
+    ]);
+
+    const recentSearchesPlugin = createRecentSearchesPlugin({
+      storage,
+      translations: {
+        removeSearchTitle: 'TEST REMOVE',
+      },
+    });
+
+    const container = document.createElement('div');
+    const panelContainer = document.createElement('div');
+
+    document.body.appendChild(panelContainer);
+
+    autocomplete({
+      container,
+      panelContainer,
+      openOnFocus: true,
+      plugins: [recentSearchesPlugin],
+    });
+
+    const input = container.querySelector<HTMLInputElement>('.aa-Input');
+
+    fireEvent.input(input, { target: { value: 'a' } });
+
+    await waitFor(() => {
+      expect(
+        within(
+          panelContainer.querySelector(
+            '[data-autocomplete-source-id="recentSearchesPlugin"]'
+          )
+        )
+          .getAllByRole('option')
+          .map((option) => option.children)
+      ).toMatchInlineSnapshot(`
+        Array [
+          HTMLCollection [
+            <div
+              class="aa-ItemWrapper"
+            >
+              <div
+                class="aa-ItemContent"
+              >
+                <div
+                  class="aa-ItemIcon aa-ItemIcon--noBorder"
+                >
+                  <svg
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12.516 6.984v5.25l4.5 2.672-0.75 1.266-5.25-3.188v-6h1.5zM12 20.016q3.281 0 5.648-2.367t2.367-5.648-2.367-5.648-5.648-2.367-5.648 2.367-2.367 5.648 2.367 5.648 5.648 2.367zM12 2.016q4.125 0 7.055 2.93t2.93 7.055-2.93 7.055-7.055 2.93-7.055-2.93-2.93-7.055 2.93-7.055 7.055-2.93z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="aa-ItemContentBody"
+                >
+                  <div
+                    class="aa-ItemContentTitle"
+                  >
+                    query
+                  </div>
+                </div>
+              </div>
+              <div
+                class="aa-ItemActions"
+              >
+                <button
+                  class="aa-ItemActionButton"
+                  title="TEST REMOVE"
+                >
+                  <svg
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M18 7v13c0 0.276-0.111 0.525-0.293 0.707s-0.431 0.293-0.707 0.293h-10c-0.276 0-0.525-0.111-0.707-0.293s-0.293-0.431-0.293-0.707v-13zM17 5v-1c0-0.828-0.337-1.58-0.879-2.121s-1.293-0.879-2.121-0.879h-4c-0.828 0-1.58 0.337-2.121 0.879s-0.879 1.293-0.879 2.121v1h-4c-0.552 0-1 0.448-1 1s0.448 1 1 1h1v13c0 0.828 0.337 1.58 0.879 2.121s1.293 0.879 2.121 0.879h10c0.828 0 1.58-0.337 2.121-0.879s0.879-1.293 0.879-2.121v-13h1c0.552 0 1-0.448 1-1s-0.448-1-1-1zM9 5v-1c0-0.276 0.111-0.525 0.293-0.707s0.431-0.293 0.707-0.293h4c0.276 0 0.525 0.111 0.707 0.293s0.293 0.431 0.293 0.707v1zM9 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1zM13 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  class="aa-ItemActionButton"
+                  title="Fill query with \\"query\\""
+                >
+                  <svg
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M8 17v-7.586l8.293 8.293c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-8.293-8.293h7.586c0.552 0 1-0.448 1-1s-0.448-1-1-1h-10c-0.552 0-1 0.448-1 1v10c0 0.552 0.448 1 1 1s1-0.448 1-1z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>,
+          ],
+        ]
+      `);
+    });
+  });
+
   test('supports custom templates', async () => {
     const storage = createInMemoryStorage([
       {

--- a/packages/autocomplete-plugin-recent-searches/src/constants.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/constants.ts
@@ -1,3 +1,11 @@
+import { AutocompleteRecentSearchesPluginTranslations } from './types';
+
 export const LOCAL_STORAGE_KEY = 'AUTOCOMPLETE_RECENT_SEARCHES';
 export const LOCAL_STORAGE_KEY_TEST =
   '__AUTOCOMPLETE_RECENT_SEARCHES_PLUGIN_TEST_KEY__';
+
+export const defaultTranslations: AutocompleteRecentSearchesPluginTranslations =
+  {
+    removeSearchTitle: 'Remove this search',
+    fillQueryTitle: (text: string) => `Fill query with "${text}"`,
+  };

--- a/packages/autocomplete-plugin-recent-searches/src/createLocalStorageRecentSearchesPlugin.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/createLocalStorageRecentSearchesPlugin.ts
@@ -1,6 +1,6 @@
 import { AutocompletePlugin } from '@algolia/autocomplete-js';
 
-import { LOCAL_STORAGE_KEY } from './constants';
+import { defaultTranslations, LOCAL_STORAGE_KEY } from './constants';
 import { createLocalStorage } from './createLocalStorage';
 import {
   createRecentSearchesPlugin,
@@ -49,7 +49,7 @@ export type CreateRecentSearchesLocalStorageOptions<
 type LocalStorageRecentSearchesPluginOptions<TItem extends RecentSearchesItem> =
   Pick<
     CreateRecentSearchesPluginParams<TItem>,
-    'transformSource' | 'subscribe'
+    'transformSource' | 'subscribe' | 'translations'
   > &
     CreateRecentSearchesLocalStorageOptions<TItem>;
 
@@ -87,5 +87,9 @@ function getOptions<TItem extends RecentSearchesItem>(
     search: defaultSearch,
     transformSource: ({ source }) => source,
     ...options,
+    translations: {
+      ...defaultTranslations,
+      ...options.translations,
+    },
   };
 }

--- a/packages/autocomplete-plugin-recent-searches/src/createRecentSearchesPlugin.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/createRecentSearchesPlugin.ts
@@ -7,9 +7,15 @@ import {
 import { createRef, MaybePromise, warn } from '@algolia/autocomplete-shared';
 import { SearchOptions } from '@algolia/client-search';
 
+import { defaultTranslations } from './constants';
 import { createStorageApi } from './createStorageApi';
 import { getTemplates } from './getTemplates';
-import { RecentSearchesItem, Storage, StorageApi } from './types';
+import {
+  RecentSearchesItem,
+  Storage,
+  StorageApi,
+  AutocompleteRecentSearchesPluginTranslations,
+} from './types';
 
 export interface RecentSearchesPluginData<TItem extends RecentSearchesItem>
   extends StorageApi<TItem> {
@@ -44,6 +50,13 @@ export type CreateRecentSearchesPluginParams<TItem extends RecentSearchesItem> =
       onTapAhead(item: TItem): void;
     }): AutocompleteSource<TItem>;
     subscribe?(params: PluginSubscribeParams<TItem>): void;
+
+    /**
+     * A mapping of translation strings.
+     *
+     * Defaults to English values.
+     */
+    translations?: Partial<AutocompleteRecentSearchesPluginTranslations>;
   };
 
 function getDefaultSubscribe<TItem extends RecentSearchesItem>(
@@ -68,7 +81,8 @@ function getDefaultSubscribe<TItem extends RecentSearchesItem>(
 export function createRecentSearchesPlugin<TItem extends RecentSearchesItem>(
   options: CreateRecentSearchesPluginParams<TItem>
 ): AutocompletePlugin<TItem, RecentSearchesPluginData<TItem>> {
-  const { storage, transformSource, subscribe } = getOptions(options);
+  const { storage, transformSource, subscribe, translations } =
+    getOptions(options);
   const store = createStorageApi<TItem>(storage);
   const lastItemsRef = createRef<MaybePromise<TItem[]>>([]);
 
@@ -114,7 +128,7 @@ export function createRecentSearchesPlugin<TItem extends RecentSearchesItem>(
               getItems() {
                 return items;
               },
-              templates: getTemplates({ onRemove, onTapAhead }),
+              templates: getTemplates({ onRemove, onTapAhead, translations }),
             },
             onRemove,
             onTapAhead,
@@ -164,5 +178,9 @@ function getOptions<TItem extends RecentSearchesItem>(
   return {
     transformSource: ({ source }) => source,
     ...options,
+    translations: {
+      ...defaultTranslations,
+      ...options.translations,
+    },
   };
 }

--- a/packages/autocomplete-plugin-recent-searches/src/getTemplates.tsx
+++ b/packages/autocomplete-plugin-recent-searches/src/getTemplates.tsx
@@ -2,16 +2,21 @@
 /** @jsx createElement */
 import { SourceTemplates } from '@algolia/autocomplete-js';
 
-import { RecentSearchesItem } from './types';
+import {
+  RecentSearchesItem,
+  AutocompleteRecentSearchesPluginTranslations,
+} from './types';
 
 export type GetTemplatesParams<TItem extends RecentSearchesItem> = {
   onRemove(id: string): void;
   onTapAhead(item: TItem): void;
+  translations: AutocompleteRecentSearchesPluginTranslations;
 };
 
 export function getTemplates<TItem extends RecentSearchesItem>({
   onRemove,
   onTapAhead,
+  translations,
 }: GetTemplatesParams<TItem>): SourceTemplates<TItem> {
   return {
     item({ item, createElement, components }) {
@@ -40,7 +45,7 @@ export function getTemplates<TItem extends RecentSearchesItem>({
           <div className="aa-ItemActions">
             <button
               className="aa-ItemActionButton"
-              title="Remove this search"
+              title={translations.removeSearchTitle}
               onClick={(event) => {
                 event.preventDefault();
                 event.stopPropagation();
@@ -53,7 +58,7 @@ export function getTemplates<TItem extends RecentSearchesItem>({
             </button>
             <button
               className="aa-ItemActionButton"
-              title={`Fill query with "${item.label}"`}
+              title={translations.fillQueryTitle(item.label)}
               onClick={(event) => {
                 event.preventDefault();
                 event.stopPropagation();

--- a/packages/autocomplete-plugin-recent-searches/src/types/Translations.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/types/Translations.ts
@@ -1,0 +1,4 @@
+export type AutocompleteRecentSearchesPluginTranslations = {
+  removeSearchTitle: string;
+  fillQueryTitle: (text: string) => string;
+};

--- a/packages/autocomplete-plugin-recent-searches/src/types/index.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/types/index.ts
@@ -3,3 +3,4 @@ export * from './HistoryItem';
 export * from './RecentSearchesItem';
 export * from './Storage';
 export * from './StorageApi';
+export * from './Translations';


### PR DESCRIPTION
Closes #1282

**Summary**

As discussed in #1282, this PR adds translation configuration for the suggestions and recent searches plugins analogous to what exists in core (although obviously much smaller in scope).

While it is possible to do this via providing entirely custom templates, that is quite heavyweight for _just_ providing translations.

**Result**

See new unit tests