### PR TITLE
fix(plugins): support translations in local storage recent searches plugins

### DIFF
--- a/packages/autocomplete-plugin-recent-searches/src/__tests__/createLocalStorageRecentSearchesPlugin.test.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/__tests__/createLocalStorageRecentSearchesPlugin.test.ts
@@ -54,12 +54,21 @@ describe('createLocalStorageRecentSearchesPlugin', () => {
     const plugin = createLocalStorageRecentSearchesPlugin({
       key: 'autocomplete',
       limit: 3,
+      translations: {
+        fillQueryTitle: () => 'TEST',
+      },
     });
 
     expect(plugin.__autocomplete_pluginOptions).toEqual({
       key: expect.any(String),
       limit: expect.any(Number),
+      translations: {
+        fillQueryTitle: expect.any(Function),
+      },
     });
+    expect(
+      plugin.__autocomplete_pluginOptions!.translations.fillQueryTitle()
+    ).toBe('TEST');
   });
 
   test('exposes an API', () => {

--- a/packages/autocomplete-plugin-recent-searches/src/createLocalStorageRecentSearchesPlugin.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/createLocalStorageRecentSearchesPlugin.ts
@@ -58,7 +58,7 @@ export function createLocalStorageRecentSearchesPlugin<
 >(
   options: LocalStorageRecentSearchesPluginOptions<TItem>
 ): AutocompletePlugin<TItem, RecentSearchesPluginData<TItem>> {
-  const { key, limit, transformSource, search, subscribe } =
+  const { key, limit, transformSource, search, subscribe, translations } =
     getOptions(options);
   const storage = createLocalStorage<TItem>({
     key: [LOCAL_STORAGE_KEY, key].join(':'),
@@ -70,6 +70,7 @@ export function createLocalStorageRecentSearchesPlugin<
     transformSource,
     storage,
     subscribe,
+    translations,
   });
 
   return {


### PR DESCRIPTION
Closes #1285

**Summary**

Passes through the translation to the underlying plugin

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
