### PR TITLE
fix(insights-plugin): prevent authenticated token being set as the userToken 

### DIFF
--- a/packages/autocomplete-core/src/__tests__/createAutocomplete.test.ts
+++ b/packages/autocomplete-core/src/__tests__/createAutocomplete.test.ts
@@ -137,7 +137,7 @@ describe('createAutocomplete', () => {
         insights: { insightsClient },
       });
 
-      expect(insightsClient).toHaveBeenCalledTimes(5);
+      expect(insightsClient).toHaveBeenCalledTimes(3);
       expect(insightsClient).toHaveBeenCalledWith(
         'addAlgoliaAgent',
         'insights-plugin'
@@ -168,7 +168,7 @@ describe('createAutocomplete', () => {
       });
 
       expect(defaultInsightsClient).toHaveBeenCalledTimes(0);
-      expect(userInsightsClient).toHaveBeenCalledTimes(5);
+      expect(userInsightsClient).toHaveBeenCalledTimes(3);
       expect(userInsightsClient).toHaveBeenCalledWith(
         'addAlgoliaAgent',
         'insights-plugin'

--- a/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
+++ b/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
@@ -131,8 +131,8 @@ See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocom
                     stroke-dasharray="164.93361431346415 56.97787143782138"
                     stroke-width="6"
                   >
-
-
+                    
+        
                     <animatetransform
                       attributeName="transform"
                       dur="1s"
@@ -141,7 +141,7 @@ See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocom
                       type="rotate"
                       values="0 50 50;90 50 50;180 50 50;360 50 50"
                     />
-
+                    
 
                   </circle>
                 </svg>

--- a/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
+++ b/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
@@ -131,8 +131,8 @@ See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocom
                     stroke-dasharray="164.93361431346415 56.97787143782138"
                     stroke-width="6"
                   >
-                    
-        
+
+
                     <animatetransform
                       attributeName="transform"
                       dur="1s"
@@ -141,7 +141,7 @@ See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocom
                       type="rotate"
                       values="0 50 50;90 50 50;180 50 50;360 50 50"
                     />
-                    
+
 
                   </circle>
                 </svg>
@@ -753,7 +753,7 @@ See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocom
         insights: { insightsClient: defaultInsightsClient },
       });
 
-      expect(defaultInsightsClient).toHaveBeenCalledTimes(5);
+      expect(defaultInsightsClient).toHaveBeenCalledTimes(3);
       expect(userInsightsClient).toHaveBeenCalledTimes(0);
 
       const insightsPlugin = createAlgoliaInsightsPlugin({
@@ -761,8 +761,8 @@ See: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocom
       });
       update({ plugins: [insightsPlugin] });
 
-      expect(defaultInsightsClient).toHaveBeenCalledTimes(5);
-      expect(userInsightsClient).toHaveBeenCalledTimes(5);
+      expect(defaultInsightsClient).toHaveBeenCalledTimes(3);
+      expect(userInsightsClient).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -92,7 +92,7 @@ describe('createAlgoliaInsightsPlugin', () => {
 
     createPlayground(createAutocomplete, { plugins: [insightsPlugin] });
 
-    expect(insightsClient).toHaveBeenCalledTimes(5);
+    expect(insightsClient).toHaveBeenCalledTimes(3);
     expect(insightsClient).toHaveBeenCalledWith(
       'addAlgoliaAgent',
       'insights-plugin'
@@ -302,88 +302,6 @@ describe('createAlgoliaInsightsPlugin', () => {
           params: expect.not.objectContaining({
             userToken: 'customAuthUserToken',
           }),
-        }),
-      ]);
-    });
-
-    test('uses `authenticatedUserToken` in priority over `userToken`', async () => {
-      const insightsPlugin = createAlgoliaInsightsPlugin({
-        insightsClient,
-        insightsInitParams: {
-          userToken: 'customUserToken',
-        },
-      });
-
-      const searchClient = createSearchClient({
-        search: jest.fn(() =>
-          Promise.resolve(
-            createMultiSearchResponse({
-              hits: [{ objectID: '1' }],
-            })
-          )
-        ),
-      });
-
-      // Setting an authenticated user token should replace the user token
-      insightsClient('setAuthenticatedUserToken', 'customAuthUserToken');
-
-      const playground = createPlayground(createAutocomplete, {
-        plugins: [insightsPlugin],
-        getSources({ query }) {
-          return [
-            {
-              sourceId: 'hits',
-              getItems() {
-                return getAlgoliaResults({
-                  searchClient,
-                  queries: [{ indexName: 'indexName', query }],
-                });
-              },
-              templates: {
-                item({ item }) {
-                  return item.objectID;
-                },
-              },
-            },
-          ];
-        },
-      });
-
-      userEvent.type(playground.inputElement, 'a');
-      await runAllMicroTasks();
-
-      expect(searchClient.search).toHaveBeenCalledTimes(1);
-      expect(searchClient.search).toHaveBeenCalledWith([
-        expect.objectContaining({
-          params: expect.objectContaining({ userToken: 'customAuthUserToken' }),
-        }),
-      ]);
-
-      // Updating a user token should have no effect if there is
-      // an authenticated user token already set
-      insightsClient('setUserToken', 'customUserToken2');
-
-      userEvent.type(playground.inputElement, 'b');
-      await runAllMicroTasks();
-
-      expect(searchClient.search).toHaveBeenCalledTimes(2);
-      expect(searchClient.search).toHaveBeenLastCalledWith([
-        expect.objectContaining({
-          params: expect.objectContaining({ userToken: 'customAuthUserToken' }),
-        }),
-      ]);
-
-      // Removing the authenticated user token should revert to
-      // the latest user token set
-      insightsClient('setAuthenticatedUserToken', undefined);
-
-      userEvent.type(playground.inputElement, 'c');
-      await runAllMicroTasks();
-
-      expect(searchClient.search).toHaveBeenCalledTimes(3);
-      expect(searchClient.search).toHaveBeenLastCalledWith([
-        expect.objectContaining({
-          params: expect.objectContaining({ userToken: 'customUserToken2' }),
         }),
       ]);
     });

--- a/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/__tests__/createAlgoliaInsightsPlugin.test.ts
@@ -256,7 +256,7 @@ describe('createAlgoliaInsightsPlugin', () => {
       ]);
     });
 
-    test('forwards `authenticatedUserToken` from Search Insights to Algolia API requests', async () => {
+    test('does not forward `authenticatedUserToken` from Search Insights to Algolia API requests', async () => {
       const insightsPlugin = createAlgoliaInsightsPlugin({ insightsClient });
 
       const searchClient = createSearchClient({
@@ -299,7 +299,9 @@ describe('createAlgoliaInsightsPlugin', () => {
       expect(searchClient.search).toHaveBeenCalledTimes(1);
       expect(searchClient.search).toHaveBeenCalledWith([
         expect.objectContaining({
-          params: expect.objectContaining({ userToken: 'customAuthUserToken' }),
+          params: expect.not.objectContaining({
+            userToken: 'customAuthUserToken',
+          }),
         }),
       ]);
     });

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -183,7 +183,6 @@ export function createAlgoliaInsightsPlugin(
   return {
     name: 'aa.algoliaInsightsPlugin',
     subscribe({ setContext, onSelect, onActive }) {
-      let isAuthenticatedToken = false;
       function setInsightsContext(userToken?: InsightsEvent['userToken']) {
         setContext({
           algoliaInsightsPlugin: {
@@ -206,41 +205,11 @@ export function createAlgoliaInsightsPlugin(
 
       // Handles user token changes
       insightsClient('onUserTokenChange', (userToken) => {
-        if (!isAuthenticatedToken) {
-          setInsightsContext(userToken);
-        }
+        setInsightsContext(userToken);
       });
       insightsClient('getUserToken', null, (_error, userToken) => {
-        if (!isAuthenticatedToken) {
-          setInsightsContext(userToken);
-        }
+        setInsightsContext(userToken);
       });
-
-      // Handles authenticated user token changes
-      insightsClient(
-        'onAuthenticatedUserTokenChange',
-        (authenticatedUserToken) => {
-          if (authenticatedUserToken) {
-            isAuthenticatedToken = true;
-            setInsightsContext(authenticatedUserToken);
-          } else {
-            isAuthenticatedToken = false;
-            insightsClient('getUserToken', null, (_error, userToken) =>
-              setInsightsContext(userToken)
-            );
-          }
-        }
-      );
-      insightsClient(
-        'getAuthenticatedUserToken',
-        null,
-        (_error, authenticatedUserToken) => {
-          if (authenticatedUserToken) {
-            isAuthenticatedToken = true;
-            setInsightsContext(authenticatedUserToken);
-          }
-        }
-      );
 
       onSelect(({ item, state, event, source }) => {
         if (!isAlgoliaInsightsHit(item)) {


### PR DESCRIPTION
**Summary**
The authenticated user token from insights should no longer be used as the `userToken` for the search API. This PR removes all listeners and usage of `authenticatedUserToken` in the insights plugin.

Does the same thing as its parallel for instantsearch: https://github.com/algolia/instantsearch/pull/6443

[FX-3159]



[FX-3159]: https://algolia.atlassian.net/browse/FX-3159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ