### PR TITLE
fix(autocomplete): filter out empty collections in aria-controls

### DIFF
--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -202,7 +202,8 @@ export function getPropGetters<
       'aria-controls': store.getState().isOpen
         ? store
             .getState()
-            .collections.map(({ source }) =>
+            .collections.filter((collection) => collection.items.length > 0)
+            .map(({ source }) =>
               getAutocompleteElementId(props.id, 'list', source)
             )
             .join(' ')


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR fixes an issue that the `aria-controls` value was filled with a reference to empty collections. We can make an assumption to skip them, since recent/favorite collections don't get rendered for 0 size collections. See https://github.com/algolia/docsearch/pull/2485 for more information.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues, references or RFCs?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

Its covered with tests in https://github.com/algolia/docsearch/pull/2485.