### PR TITLE
fix(redirect): race condition with mismatched query

### DIFF
--- a/packages/autocomplete-plugin-redirect-url/src/__tests__/createRedirectUrlPlugin.test.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/__tests__/createRedirectUrlPlugin.test.ts
@@ -225,7 +225,7 @@ describe('createRedirectUrlPlugin', () => {
         Array [
           HTMLCollection [
             <a>
-              My custom option: 
+              My custom option:
               redirect item
             </a>,
           ],
@@ -234,7 +234,7 @@ describe('createRedirectUrlPlugin', () => {
     });
   });
 
-  test('renders a redirect item when a custom expected payload is returned', async () => {
+  test('does not render a redirect item when the query from the state does not match the response', async () => {
     const redirectUrlPlugin = createRedirectUrlPlugin({
       transformResponse(response) {
         return (response as Record<string, any>).customRedirect?.url;
@@ -270,7 +270,7 @@ describe('createRedirectUrlPlugin', () => {
 
     await waitFor(() => {
       expect(findHitsSection(panelContainer)).not.toBeInTheDocument();
-      expect(findRedirectSection(panelContainer)).toBeInTheDocument();
+      expect(findRedirectSection(panelContainer)).not.toBeInTheDocument();
     });
   });
 

--- a/packages/autocomplete-plugin-redirect-url/src/__tests__/createRedirectUrlPlugin.test.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/__tests__/createRedirectUrlPlugin.test.ts
@@ -176,8 +176,9 @@ describe('createRedirectUrlPlugin', () => {
     const redirectUrlPlugin = createRedirectUrlPlugin({
       transformResponse(response) {
         return {
-          queryUsed: REDIRECT_QUERY,
-          redirectUrl: (response as Record<string, any>).customRedirect?.url,
+          queryUsed: 'different query',
+          redirectUrl: (response as Record<string, any>).renderingContent
+            ?.redirect?.url,
         };
       },
     });

--- a/packages/autocomplete-plugin-redirect-url/src/__tests__/createRedirectUrlPlugin.test.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/__tests__/createRedirectUrlPlugin.test.ts
@@ -122,73 +122,12 @@ describe('createRedirectUrlPlugin', () => {
     await waitFor(() => {
       expect(findHitsSection(panelContainer)).not.toBeInTheDocument();
 
-      expect(findDropdownOptions(findRedirectSection(panelContainer)))
-        .toMatchInlineSnapshot(`
-        Array [
-          HTMLCollection [
-            <div
-              class="aa-ItemWrapper"
-            >
-              <div
-                class="aa-ItemContent"
-              >
-                <div
-                  class="aa-ItemIcon aa-ItemIcon--noBorder"
-                >
-                  <svg
-                    fill="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M16.041 15.856c-0.034 0.026-0.067 0.055-0.099 0.087s-0.060 0.064-0.087 0.099c-1.258 1.213-2.969 1.958-4.855 1.958-1.933 0-3.682-0.782-4.95-2.050s-2.050-3.017-2.050-4.95 0.782-3.682 2.050-4.95 3.017-2.050 4.95-2.050 3.682 0.782 4.95 2.050 2.050 3.017 2.050 4.95c0 1.886-0.745 3.597-1.959 4.856zM21.707 20.293l-3.675-3.675c1.231-1.54 1.968-3.493 1.968-5.618 0-2.485-1.008-4.736-2.636-6.364s-3.879-2.636-6.364-2.636-4.736 1.008-6.364 2.636-2.636 3.879-2.636 6.364 1.008 4.736 2.636 6.364 3.879 2.636 6.364 2.636c2.125 0 4.078-0.737 5.618-1.968l3.675 3.675c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="aa-ItemContentBody"
-                >
-                  <div
-                    class="aa-ItemContentTitle"
-                  >
-                    <a
-                      class="aa-ItemLink"
-                      href="https://www.algolia.com"
-                    >
-                      redirect item
-                    </a>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="aa-ItemActions"
-              >
-                <div
-                  class="aa-ItemActionButton"
-                >
-                  <svg
-                    fill="none"
-                    stroke="currentColor"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    viewBox="0 0 24 24"
-                  >
-                    <line
-                      x1="5"
-                      x2="19"
-                      y1="12"
-                      y2="12"
-                    />
-                    <polyline
-                      points="12 5 19 12 12 19"
-                    />
-                  </svg>
-                </div>
-              </div>
-            </div>,
-          ],
-        ]
-      `);
+      const dropdownOptions = findDropdownOptions(
+        findRedirectSection(panelContainer)
+      );
+
+      expect(dropdownOptions).toHaveLength(1);
+      expect(dropdownOptions[0].item(0)).toHaveTextContent(REDIRECT_QUERY);
     });
   });
 
@@ -222,18 +161,24 @@ describe('createRedirectUrlPlugin', () => {
     await waitFor(() => {
       expect(findHitsSection(panelContainer)).not.toBeInTheDocument();
 
-      const dropdownText = findDropdownOptions(
+      const dropdownOptions = findDropdownOptions(
         findRedirectSection(panelContainer)
-      )[0].item(0)?.textContent;
+      );
 
-      expect(dropdownText).toBe('My custom option: redirect item');
+      expect(dropdownOptions).toHaveLength(1);
+      expect(dropdownOptions[0].item(0)).toHaveTextContent(
+        'My custom option: redirect item'
+      );
     });
   });
 
   test('does not render a redirect item when the query from the state does not match the response', async () => {
     const redirectUrlPlugin = createRedirectUrlPlugin({
       transformResponse(response) {
-        return (response as Record<string, any>).customRedirect?.url;
+        return {
+          queryUsed: REDIRECT_QUERY,
+          redirectUrl: (response as Record<string, any>).customRedirect?.url,
+        };
       },
     });
 
@@ -293,11 +238,14 @@ describe('createRedirectUrlPlugin', () => {
     fireEvent.input(input, { target: { value: query } });
 
     await waitFor(() => {
-      const dropdownText = findDropdownOptions(
+      const dropdownOptions = findDropdownOptions(
         findHitsSection(panelContainer)
-      )[0].item(0)?.textContent;
+      );
 
-      expect(dropdownText).toBe('not a redirect item');
+      expect(dropdownOptions).toHaveLength(1);
+      expect(dropdownOptions[0].item(0)).toHaveTextContent(
+        'not a redirect item'
+      );
 
       expect(findRedirectSection(panelContainer)).not.toBeInTheDocument();
     });
@@ -345,11 +293,11 @@ describe('createRedirectUrlPlugin', () => {
       );
 
       expect(dropdownOptions).toHaveLength(3);
-      expect(dropdownOptions[0].item(0)?.textContent).toBe(REDIRECT_QUERY);
-      expect(dropdownOptions[1].item(0)?.textContent).toBe(
+      expect(dropdownOptions[0].item(0)).toHaveTextContent(REDIRECT_QUERY);
+      expect(dropdownOptions[1].item(0)).toHaveTextContent(
         'not a redirect item 1'
       );
-      expect(dropdownOptions[2].item(0)?.textContent).toBe(
+      expect(dropdownOptions[2].item(0)).toHaveTextContent(
         'not a redirect item 2'
       );
     });
@@ -399,10 +347,10 @@ describe('createRedirectUrlPlugin', () => {
         findHitsSection(panelContainer)
       );
       expect(dropdownOptions).toHaveLength(2);
-      expect(dropdownOptions[0].item(0)?.textContent).toBe(
+      expect(dropdownOptions[0].item(0)).toHaveTextContent(
         'not a redirect item 1'
       );
-      expect(dropdownOptions[1].item(0)?.textContent).toBe(
+      expect(dropdownOptions[1].item(0)).toHaveTextContent(
         'not a redirect item 2'
       );
     });
@@ -468,15 +416,18 @@ describe('createRedirectUrlPlugin', () => {
 
     fireEvent.input(input, { target: { value: REDIRECT_QUERY } });
     await waitFor(() => {
-      expect(
-        findDropdownOptions(findRedirectSection(panelContainer))[0][0]
-      ).toHaveTextContent(REDIRECT_QUERY);
+      const dropdownOptions = findDropdownOptions(
+        findRedirectSection(panelContainer)
+      );
+
+      expect(dropdownOptions).toHaveLength(1);
+      expect(dropdownOptions[0].item(0)).toHaveTextContent(REDIRECT_QUERY);
     });
 
     fireEvent.submit(input);
 
     await waitFor(() => {
-      expect(input.value).toBe(REDIRECT_QUERY);
+      expect(input).toHaveValue(REDIRECT_QUERY);
       expect(navigator.navigate).toHaveBeenCalledTimes(1);
     });
   });
@@ -534,95 +485,25 @@ describe('createRedirectUrlPlugin', () => {
 
     await waitFor(() => {
       expect(findRedirectSection(panelContainer)).not.toBeInTheDocument();
-      expect(findDropdownOptions(findHitsSection(panelContainer)))
-        .toMatchInlineSnapshot(`
-        Array [
-          HTMLCollection [
-            <a>
-              something else
-            </a>,
-          ],
-          HTMLCollection [
-            <a>
-              redirect item
-            </a>,
-          ],
-        ]
-      `);
+      const dropdownOptions = findDropdownOptions(
+        findHitsSection(panelContainer)
+      );
+      expect(dropdownOptions).toHaveLength(2);
+      expect(dropdownOptions[0].item(0)).toHaveTextContent('something else');
+      expect(dropdownOptions[1].item(0)).toHaveTextContent(REDIRECT_QUERY);
     });
 
     fireEvent.click(findDropdownOptions(panelContainer)[1][0]);
 
     await waitFor(() => {
-      expect(input.value).toBe(REDIRECT_QUERY);
+      expect(input).toHaveValue(REDIRECT_QUERY);
       expect(findHitsSection(panelContainer)).not.toBeInTheDocument();
-      expect(findDropdownOptions(findRedirectSection(panelContainer)))
-        .toMatchInlineSnapshot(`
-        Array [
-          HTMLCollection [
-            <div
-              class="aa-ItemWrapper"
-            >
-              <div
-                class="aa-ItemContent"
-              >
-                <div
-                  class="aa-ItemIcon aa-ItemIcon--noBorder"
-                >
-                  <svg
-                    fill="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M16.041 15.856c-0.034 0.026-0.067 0.055-0.099 0.087s-0.060 0.064-0.087 0.099c-1.258 1.213-2.969 1.958-4.855 1.958-1.933 0-3.682-0.782-4.95-2.050s-2.050-3.017-2.050-4.95 0.782-3.682 2.050-4.95 3.017-2.050 4.95-2.050 3.682 0.782 4.95 2.050 2.050 3.017 2.050 4.95c0 1.886-0.745 3.597-1.959 4.856zM21.707 20.293l-3.675-3.675c1.231-1.54 1.968-3.493 1.968-5.618 0-2.485-1.008-4.736-2.636-6.364s-3.879-2.636-6.364-2.636-4.736 1.008-6.364 2.636-2.636 3.879-2.636 6.364 1.008 4.736 2.636 6.364 3.879 2.636 6.364 2.636c2.125 0 4.078-0.737 5.618-1.968l3.675 3.675c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="aa-ItemContentBody"
-                >
-                  <div
-                    class="aa-ItemContentTitle"
-                  >
-                    <a
-                      class="aa-ItemLink"
-                      href="https://www.algolia.com"
-                    >
-                      redirect item
-                    </a>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="aa-ItemActions"
-              >
-                <div
-                  class="aa-ItemActionButton"
-                >
-                  <svg
-                    fill="none"
-                    stroke="currentColor"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    viewBox="0 0 24 24"
-                  >
-                    <line
-                      x1="5"
-                      x2="19"
-                      y1="12"
-                      y2="12"
-                    />
-                    <polyline
-                      points="12 5 19 12 12 19"
-                    />
-                  </svg>
-                </div>
-              </div>
-            </div>,
-          ],
-        ]
-      `);
+      const dropdownOptions = findDropdownOptions(
+        findRedirectSection(panelContainer)
+      );
+
+      expect(dropdownOptions).toHaveLength(1);
+      expect(dropdownOptions[0].item(0)).toHaveTextContent(REDIRECT_QUERY);
     });
 
     fireEvent.submit(input);
@@ -712,7 +593,7 @@ describe('createRedirectUrlPlugin', () => {
 
     fireEvent.submit(input);
     await waitFor(() => {
-      expect(input.value).toBe(REDIRECT_QUERY);
+      expect(input).toHaveValue(REDIRECT_QUERY);
       expect(navigator.navigate).toHaveBeenCalledWith(
         expect.objectContaining({
           item: {
@@ -786,7 +667,7 @@ describe('createRedirectUrlPlugin', () => {
 
     fireEvent.submit(input);
     await waitFor(() => {
-      expect(input.value).toBe(REDIRECT_QUERY);
+      expect(input).toHaveValue(REDIRECT_QUERY);
       expect(navigator.navigate).toHaveBeenCalledWith(
         expect.objectContaining({
           item: {

--- a/packages/autocomplete-plugin-redirect-url/src/__tests__/createRedirectUrlPlugin.test.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/__tests__/createRedirectUrlPlugin.test.ts
@@ -372,7 +372,6 @@ describe('createRedirectUrlPlugin', () => {
           createMockSource({
             results: [
               {
-                query: REDIRECT_QUERY,
                 ...RESPONSE,
                 hits: [
                   { name: REDIRECT_QUERY },

--- a/packages/autocomplete-plugin-redirect-url/src/__tests__/createRedirectUrlPlugin.test.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/__tests__/createRedirectUrlPlugin.test.ts
@@ -42,7 +42,7 @@ function createMockSource({
     },
     templates: {
       item({ item, html }) {
-        return html`<a>${item.query}</a>`;
+        return html`<a>${item.name}</a>`;
       },
     },
     ...props,
@@ -284,7 +284,7 @@ describe('createRedirectUrlPlugin', () => {
       panelContainer,
       plugins: [redirectUrlPlugin],
       getSources() {
-        return [createMockSource({ results: [{ hits: [{ query }] }] })];
+        return [createMockSource({ results: [{ hits: [{ name: query }] }] })];
       },
     });
 
@@ -293,16 +293,11 @@ describe('createRedirectUrlPlugin', () => {
     fireEvent.input(input, { target: { value: query } });
 
     await waitFor(() => {
-      expect(findDropdownOptions(findHitsSection(panelContainer)))
-        .toMatchInlineSnapshot(`
-        Array [
-          HTMLCollection [
-            <a>
-              not a redirect item
-            </a>,
-          ],
-        ]
-      `);
+      const dropdownText = findDropdownOptions(
+        findHitsSection(panelContainer)
+      )[0].item(0)?.textContent;
+
+      expect(dropdownText).toBe('not a redirect item');
 
       expect(findRedirectSection(panelContainer)).not.toBeInTheDocument();
     });
@@ -327,9 +322,9 @@ describe('createRedirectUrlPlugin', () => {
               {
                 ...RESPONSE,
                 hits: [
-                  { query: 'redirect item' },
-                  { query: 'not a redirect item 1' },
-                  { query: 'not a redirect item 2' },
+                  { name: 'redirect item' },
+                  { name: 'not a redirect item 1' },
+                  { name: 'not a redirect item 2' },
                 ],
               },
             ],
@@ -345,26 +340,18 @@ describe('createRedirectUrlPlugin', () => {
     await waitFor(() => {
       expect(findRedirectSection(panelContainer)).toBeInTheDocument();
 
-      expect(findDropdownOptions(findHitsSection(panelContainer)))
-        .toMatchInlineSnapshot(`
-        Array [
-          HTMLCollection [
-            <a>
-              redirect item
-            </a>,
-          ],
-          HTMLCollection [
-            <a>
-              not a redirect item 1
-            </a>,
-          ],
-          HTMLCollection [
-            <a>
-              not a redirect item 2
-            </a>,
-          ],
-        ]
-      `);
+      const dropdownOptions = findDropdownOptions(
+        findHitsSection(panelContainer)
+      );
+
+      expect(dropdownOptions).toHaveLength(3);
+      expect(dropdownOptions[0].item(0)?.textContent).toBe(REDIRECT_QUERY);
+      expect(dropdownOptions[1].item(0)?.textContent).toBe(
+        'not a redirect item 1'
+      );
+      expect(dropdownOptions[2].item(0)?.textContent).toBe(
+        'not a redirect item 2'
+      );
     });
   });
 
@@ -385,16 +372,17 @@ describe('createRedirectUrlPlugin', () => {
           createMockSource({
             results: [
               {
+                query: REDIRECT_QUERY,
                 ...RESPONSE,
                 hits: [
-                  { query: 'redirect item' },
-                  { query: 'not a redirect item 1' },
-                  { query: 'not a redirect item 2' },
+                  { name: REDIRECT_QUERY },
+                  { name: 'not a redirect item 1' },
+                  { name: 'not a redirect item 2' },
                 ],
               },
             ],
             getItemInputValue({ item }) {
-              return item.query;
+              return item.name;
             },
           }),
         ];
@@ -408,21 +396,16 @@ describe('createRedirectUrlPlugin', () => {
     await waitFor(() => {
       expect(findRedirectSection(panelContainer)).toBeInTheDocument();
 
-      expect(findDropdownOptions(findHitsSection(panelContainer)))
-        .toMatchInlineSnapshot(`
-        Array [
-          HTMLCollection [
-            <a>
-              not a redirect item 1
-            </a>,
-          ],
-          HTMLCollection [
-            <a>
-              not a redirect item 2
-            </a>,
-          ],
-        ]
-      `);
+      const dropdownOptions = findDropdownOptions(
+        findHitsSection(panelContainer)
+      );
+      expect(dropdownOptions).toHaveLength(2);
+      expect(dropdownOptions[0].item(0)?.textContent).toBe(
+        'not a redirect item 1'
+      );
+      expect(dropdownOptions[1].item(0)?.textContent).toBe(
+        'not a redirect item 2'
+      );
     });
   });
 
@@ -520,7 +503,8 @@ describe('createRedirectUrlPlugin', () => {
               query === REDIRECT_QUERY
                 ? [
                     {
-                      hits: [{ query: REDIRECT_QUERY }],
+                      hits: [{ name: REDIRECT_QUERY }],
+                      query: REDIRECT_QUERY,
                       renderingContent: {
                         redirect: {
                           url: 'https://www.algolia.com',
@@ -531,13 +515,14 @@ describe('createRedirectUrlPlugin', () => {
                 : [
                     {
                       hits: [
-                        { query: 'something else' },
-                        { query: REDIRECT_QUERY },
+                        { name: 'something else' },
+                        { name: REDIRECT_QUERY },
                       ],
+                      query: 'something else',
                     },
                   ],
             getItemInputValue({ item }) {
-              return item.query;
+              return item.name;
             },
           }),
         ];

--- a/packages/autocomplete-plugin-redirect-url/src/__tests__/createRedirectUrlPlugin.test.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/__tests__/createRedirectUrlPlugin.test.ts
@@ -175,11 +175,11 @@ describe('createRedirectUrlPlugin', () => {
   test('does not render a redirect item when the query from the state does not match the response', async () => {
     const redirectUrlPlugin = createRedirectUrlPlugin({
       transformResponse(response) {
-        return {
-          queryUsed: 'different query',
-          redirectUrl: (response as Record<string, any>).renderingContent
-            ?.redirect?.url,
-        };
+        return (response as Record<string, any>).renderingContent?.redirect
+          ?.url;
+      },
+      transformResponseToQuery() {
+        return 'different query';
       },
     });
 

--- a/packages/autocomplete-plugin-redirect-url/src/createRedirectUrlPlugin.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/createRedirectUrlPlugin.ts
@@ -12,13 +12,18 @@ import {
   OnRedirectOptions,
   RedirectUrlItem,
   RedirectUrlPlugin as RedirectUrlPluginData,
-  TransformResponseParams,
+  Response,
+  TransformResponse,
 } from './types';
 
 function defaultTransformResponse<THit>(
-  response: TransformResponseParams<THit>
-): string | undefined {
-  return (response as Record<string, any>).renderingContent?.redirect?.url;
+  response: Response<THit>
+): TransformResponse | undefined {
+  return {
+    queryUsed: (response as Record<string, any>).query,
+    redirectUrl: (response as Record<string, any>).renderingContent?.redirect
+      ?.url,
+  };
 }
 
 function defaultOnRedirect(
@@ -67,7 +72,7 @@ export function createRedirectUrlPlugin<TItem extends BaseItem>(
     const redirect: RedirectUrlItem = {
       sourceId: source.sourceId,
       urls: results
-        .map((result) => transformResponse(result))
+        .map((result) => transformResponse(result)?.redirectUrl)
         .filter((url) => url !== undefined),
     };
 
@@ -94,9 +99,11 @@ export function createRedirectUrlPlugin<TItem extends BaseItem>(
     name: 'aa.redirectUrlPlugin',
     subscribe({ onResolve, onSelect, setContext, setIsOpen }) {
       onResolve(({ results, source, state }) => {
-        // Since searches can be resolved in any order, verify the query from the search
-        // matches the input query to ensure a redirect item accurately reflects the input
-        if (results[0].query !== state.query) {
+        // Ensure the resolved response matches the input query text before processing redirects.
+        const hasMatchedQuery = (results as any).some(
+          (result) => transformResponse(result)?.queryUsed === state.query
+        );
+        if (!hasMatchedQuery) {
           return;
         }
 

--- a/packages/autocomplete-plugin-redirect-url/src/createRedirectUrlPlugin.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/createRedirectUrlPlugin.ts
@@ -103,10 +103,10 @@ export function createRedirectUrlPlugin<TItem extends BaseItem>(
     subscribe({ onResolve, onSelect, setContext, setIsOpen }) {
       onResolve(({ results, source, state }) => {
         // Ensure the resolved response matches the input query text before processing redirects.
-        const hasMatchedQuery = (results as any).some(
+        const matchesCurrentQuery = (results as any).some(
           (result) => transformResponseToQuery(result) === state.query
         );
-        if (!hasMatchedQuery) {
+        if (!matchesCurrentQuery) {
           return;
         }
 

--- a/packages/autocomplete-plugin-redirect-url/src/createRedirectUrlPlugin.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/createRedirectUrlPlugin.ts
@@ -94,6 +94,12 @@ export function createRedirectUrlPlugin<TItem extends BaseItem>(
     name: 'aa.redirectUrlPlugin',
     subscribe({ onResolve, onSelect, setContext, setIsOpen }) {
       onResolve(({ results, source, state }) => {
+        // Since searches can be resolved in any order, verify the query from the search
+        // matches the input query to ensure a redirect item accurately reflects the input
+        if (results[0].query !== state.query) {
+          return;
+        }
+
         setContext({
           ...state.context,
           redirectUrlPlugin: {

--- a/packages/autocomplete-plugin-redirect-url/src/createRedirectUrlPlugin.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/createRedirectUrlPlugin.ts
@@ -12,17 +12,17 @@ import {
   OnRedirectOptions,
   RedirectUrlItem,
   RedirectUrlPlugin as RedirectUrlPluginData,
-  Response,
+  TransformResponseParams,
 } from './types';
 
 function defaultTransformResponse<THit>(
-  response: Response<THit>
+  response: TransformResponseParams<THit>
 ): string | undefined {
   return (response as Record<string, any>).renderingContent?.redirect?.url;
 }
 
 function defaultTransformResponseToQuery<THit>(
-  response: Response<THit>
+  response: TransformResponseParams<THit>
 ): string | undefined {
   return (response as Record<string, any>).query;
 }

--- a/packages/autocomplete-plugin-redirect-url/src/createRedirectUrlPlugin.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/createRedirectUrlPlugin.ts
@@ -13,17 +13,18 @@ import {
   RedirectUrlItem,
   RedirectUrlPlugin as RedirectUrlPluginData,
   Response,
-  TransformResponse,
 } from './types';
 
 function defaultTransformResponse<THit>(
   response: Response<THit>
-): TransformResponse | undefined {
-  return {
-    queryUsed: (response as Record<string, any>).query,
-    redirectUrl: (response as Record<string, any>).renderingContent?.redirect
-      ?.url,
-  };
+): string | undefined {
+  return (response as Record<string, any>).renderingContent?.redirect?.url;
+}
+
+function defaultTransformResponseToQuery<THit>(
+  response: Response<THit>
+): string | undefined {
+  return (response as Record<string, any>).query;
 }
 
 function defaultOnRedirect(
@@ -51,6 +52,7 @@ function getOptions<TItem extends BaseItem>(
 ) {
   return {
     transformResponse: defaultTransformResponse,
+    transformResponseToQuery: defaultTransformResponseToQuery,
     templates: defaultTemplates,
     onRedirect: defaultOnRedirect,
     ...options,
@@ -66,13 +68,14 @@ function getRedirectData({ state }) {
 export function createRedirectUrlPlugin<TItem extends BaseItem>(
   options: CreateRedirectUrlPluginParams<TItem> = {}
 ): AutocompletePlugin<RedirectUrlItem, undefined> {
-  const { transformResponse, templates, onRedirect } = getOptions(options);
+  const { transformResponse, transformResponseToQuery, templates, onRedirect } =
+    getOptions(options);
 
   function createRedirects({ results, source, state }): RedirectUrlItem[] {
     const redirect: RedirectUrlItem = {
       sourceId: source.sourceId,
       urls: results
-        .map((result) => transformResponse(result)?.redirectUrl)
+        .map((result) => transformResponse(result))
         .filter((url) => url !== undefined),
     };
 
@@ -101,7 +104,7 @@ export function createRedirectUrlPlugin<TItem extends BaseItem>(
       onResolve(({ results, source, state }) => {
         // Ensure the resolved response matches the input query text before processing redirects.
         const hasMatchedQuery = (results as any).some(
-          (result) => transformResponse(result)?.queryUsed === state.query
+          (result) => transformResponseToQuery(result) === state.query
         );
         if (!hasMatchedQuery) {
           return;

--- a/packages/autocomplete-plugin-redirect-url/src/types/Redirect.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/types/Redirect.ts
@@ -27,9 +27,22 @@ export type OnRedirectOptions<TItem extends RedirectUrlItem> = {
   state: AutocompleteState<TItem>;
 };
 
+/**
+ * Used to map response data into values required by the plugin.
+ */
 export interface TransformResponse {
-  url: string | undefined;
-  query: string | undefined;
+  /**
+   * The query used in the request.
+   *
+   * This is needed to accurately match the redirect with the correct query.
+   * Otherwise, there is a risk of the last request reflecting a different query value.
+   * (ex: typing "shoes" quickly risks mismatching the redirect item with "sho" instead)
+   */
+  queryUsed: string | undefined;
+  /**
+   * The redirect url to use from the response data.
+   */
+  redirectUrl: string | undefined;
 }
 
 export type Response<TItem> =
@@ -42,9 +55,7 @@ export type CreateRedirectUrlPluginParams<TItem extends BaseItem> = {
    *
    * Supports Algolia results out of the box.
    */
-  transformResponse?(
-    response: Response<TItem>
-  ): TransformResponse | string | undefined;
+  transformResponse?(response: Response<TItem>): TransformResponse;
   /**
    * Handles the navigation logic once a redirect is triggered
    *
@@ -59,7 +70,7 @@ export type CreateRedirectUrlPluginParams<TItem extends BaseItem> = {
    */
   templates?: SourceTemplates<RedirectUrlItem>;
   /**
-   * Waits for all pending requests to complete before handling a form submission .
+   * Waits for all pending requests to complete before handling a form submission.
    * (ex: pressing the "enter" key in the input)
    *
    * A boolean return value will wait for all pending requests to resolve.

--- a/packages/autocomplete-plugin-redirect-url/src/types/Redirect.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/types/Redirect.ts
@@ -24,7 +24,7 @@ export type OnRedirectOptions<TItem extends RedirectUrlItem> = {
   state: AutocompleteState<TItem>;
 };
 
-export type Response<TItem> =
+export type TransformResponseParams<TItem> =
   | SearchResponse<TItem>
   | SearchForFacetValuesResponse;
 
@@ -34,7 +34,9 @@ export type CreateRedirectUrlPluginParams<TItem extends BaseItem> = {
    *
    * Already supports Algolia results by default.
    */
-  transformResponse?(response: Response<TItem>): string | undefined;
+  transformResponse?(
+    response: TransformResponseParams<TItem>
+  ): string | undefined;
   /**
    * Maps the query used in the request to match with the redirect.
    * Without this mapping, there is a risk of the race condition when processing
@@ -43,7 +45,9 @@ export type CreateRedirectUrlPluginParams<TItem extends BaseItem> = {
    *
    * Already supports Algolia results by default.
    */
-  transformResponseToQuery?(response: Response<TItem>): string | undefined;
+  transformResponseToQuery?(
+    response: TransformResponseParams<TItem>
+  ): string | undefined;
   /**
    * Handles the navigation logic once a redirect is triggered.
    *

--- a/packages/autocomplete-plugin-redirect-url/src/types/Redirect.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/types/Redirect.ts
@@ -45,7 +45,7 @@ export type CreateRedirectUrlPluginParams<TItem extends BaseItem> = {
    */
   transformResponseToQuery?(response: Response<TItem>): string | undefined;
   /**
-   * Handles the navigation logic once a redirect is triggered
+   * Handles the navigation logic once a redirect is triggered.
    *
    * Already supports Algolia results by default.
    */

--- a/packages/autocomplete-plugin-redirect-url/src/types/Redirect.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/types/Redirect.ts
@@ -4,7 +4,10 @@ import {
   InternalAutocompleteOptions,
 } from '@algolia/autocomplete-core';
 import { SourceTemplates } from '@algolia/autocomplete-js';
-import { SearchForFacetValuesResponse } from '@algolia/autocomplete-preset-algolia';
+import {
+  SearchForFacetValuesResponse,
+  TransformedRequesterResponse,
+} from '@algolia/autocomplete-preset-algolia';
 import type { SearchResponse } from '@algolia/autocomplete-shared';
 
 export interface RedirectUrlPlugin {
@@ -24,18 +27,43 @@ export type OnRedirectOptions<TItem extends RedirectUrlItem> = {
   state: AutocompleteState<TItem>;
 };
 
-export type TransformResponseParams<TItem> =
+export interface TransformResponse {
+  url: string | undefined;
+  query: string | undefined;
+}
+
+export type Response<TItem> =
   | SearchResponse<TItem>
   | SearchForFacetValuesResponse;
 
 export type CreateRedirectUrlPluginParams<TItem extends BaseItem> = {
+  /**
+   * Map the response to values that can be interpreted by the plugin to correctly parse redirects.
+   *
+   * Supports Algolia results out of the box.
+   */
   transformResponse?(
-    response: TransformResponseParams<TItem>
-  ): string | undefined;
+    response: Response<TItem>
+  ): TransformResponse | string | undefined;
+  /**
+   * Handles the navigation logic once a redirect is triggered
+   *
+   * Supports Algolia results out of the box.
+   */
   onRedirect?(
     redirects: RedirectUrlItem[],
     options: OnRedirectOptions<RedirectUrlItem>
   ): void;
+  /**
+   * The template used to render injected redirect dropdown items.
+   */
   templates?: SourceTemplates<RedirectUrlItem>;
+  /**
+   * Waits for all pending requests to complete before handling a form submission .
+   * (ex: pressing the "enter" key in the input)
+   *
+   * A boolean return value will wait for all pending requests to resolve.
+   * A number value will achieve the above with a timeout (in ms) to exit if it takes too long.
+   */
   awaitSubmit?: () => boolean | number;
 };

--- a/packages/autocomplete-plugin-redirect-url/src/types/Redirect.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/types/Redirect.ts
@@ -4,10 +4,7 @@ import {
   InternalAutocompleteOptions,
 } from '@algolia/autocomplete-core';
 import { SourceTemplates } from '@algolia/autocomplete-js';
-import {
-  SearchForFacetValuesResponse,
-  TransformedRequesterResponse,
-} from '@algolia/autocomplete-preset-algolia';
+import { SearchForFacetValuesResponse } from '@algolia/autocomplete-preset-algolia';
 import type { SearchResponse } from '@algolia/autocomplete-shared';
 
 export interface RedirectUrlPlugin {

--- a/packages/autocomplete-plugin-redirect-url/src/types/Redirect.ts
+++ b/packages/autocomplete-plugin-redirect-url/src/types/Redirect.ts
@@ -24,39 +24,30 @@ export type OnRedirectOptions<TItem extends RedirectUrlItem> = {
   state: AutocompleteState<TItem>;
 };
 
-/**
- * Used to map response data into values required by the plugin.
- */
-export interface TransformResponse {
-  /**
-   * The query used in the request.
-   *
-   * This is needed to accurately match the redirect with the correct query.
-   * Otherwise, there is a risk of the last request reflecting a different query value.
-   * (ex: typing "shoes" quickly risks mismatching the redirect item with "sho" instead)
-   */
-  queryUsed: string | undefined;
-  /**
-   * The redirect url to use from the response data.
-   */
-  redirectUrl: string | undefined;
-}
-
 export type Response<TItem> =
   | SearchResponse<TItem>
   | SearchForFacetValuesResponse;
 
 export type CreateRedirectUrlPluginParams<TItem extends BaseItem> = {
   /**
-   * Map the response to values that can be interpreted by the plugin to correctly parse redirects.
+   * Maps the response to the redirect url that will be used by the plugin.
    *
-   * Supports Algolia results out of the box.
+   * Already supports Algolia results by default.
    */
-  transformResponse?(response: Response<TItem>): TransformResponse;
+  transformResponse?(response: Response<TItem>): string | undefined;
+  /**
+   * Maps the query used in the request to match with the redirect.
+   * Without this mapping, there is a risk of the race condition when processing
+   * redirect items where the last-resolved response can reflect an earlier query value.
+   * (ex: typing "shoes" quickly risks mismatching the redirect item with "sho" instead)
+   *
+   * Already supports Algolia results by default.
+   */
+  transformResponseToQuery?(response: Response<TItem>): string | undefined;
   /**
    * Handles the navigation logic once a redirect is triggered
    *
-   * Supports Algolia results out of the box.
+   * Already supports Algolia results by default.
    */
   onRedirect?(
     redirects: RedirectUrlItem[],


### PR DESCRIPTION
**Summary**

There is a race condition caused by requests being resolved without concern for order. For example, here's a local example with the redirect plugin missing the redirect item with the correct query. The first two logged strings in each log are the query stored in the state (which the redirect plugin leverages) and the query from the resolved request. The last log is the response actually used by autocomplete and the plugin though we would expect the second from last one as it has a matched query from the state and response. Side note: the playground in the screenshot was modified to keep the dropdown open, which normally will not happen.

![image](https://github.com/user-attachments/assets/fc5d92d4-137c-483e-b782-c00679dafdb9)

**Result**
This is a bit of a mixed PR as having to touch more of the redirect plugin has exposed some opportunity for test and typing cleanup.

- Updates the redirect plugin's hook into `onResolve` to return early if the query used in the state (i.e. the input query value) does not match the query returned in the resolved response
  - Accomplished by updating the `transformResponse` function to return an object instead of the redirect url as a string
  - This means defaulting to an Algolia source should work out of the box, but custom sources should be overridable from this function--which was needed anyway for the redirect url mapping
- Cleans up the unit tests for the redirect url plugin since I had to make updates in there anyway
  - Relying on checking values directly instead of relying on inline snapshots
  - Uses `expect({}).toHaveTextContent(...)` instead of `expect({}.textContent).toBe(...)`
  - Change the confusingly named hit "query" value to "name" to differentiate from the actual query values
- Adds doc comments to the new and some of the existing redirect types

**Testing**
This happens especially with Safari, though still not always. See the video recording shared in the CR ticket: https://algolia.atlassian.net/browse/CR-8225

1. Open up Safari for the redirect url example currently available (not running this PRs code), have the network tab open to track the last resolved requests, and type "algolia" very quickly into the input.
2. With enough tries (you may have to close and reopen the tab/window to reproduce), you should see the dropdown briefly show the redirect item and then disappear. I personally really struggled with the existing app config and opted to borrow the customer's appId, apiKey, and index to test with. I think there's got to be something with the shorter "faq" text to type as it is faster to type after focusing the input. Feel free to reach out to me or grab the info from the customer's site link on the CR ticket linked above.

https://github.com/user-attachments/assets/b3806625-3cde-480b-b597-7cd1f2fd90ba


3. Now try to reproduce using the redirect url example running the code from this PR. You should no longer see the issue.