### PR TITLE
fix(a11y): add aria-label to div (algolia#963)

### DIFF
--- a/packages/autocomplete-js/src/createAutocompleteDom.ts
+++ b/packages/autocomplete-js/src/createAutocompleteDom.ts
@@ -160,6 +160,7 @@ export function createAutocompleteDom<TItem extends BaseItem>({
   if (isDetached) {
     const detachedSearchButtonIcon = createDomElement('div', {
       class: classNames.detachedSearchButtonIcon,
+      ariaLabel: translations.detachedSearchButtonTitle,
       children: [SearchIcon({ environment })],
     });
     const detachedSearchButton = createDomElement('button', {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues, references or RFCs?
-->

(I'm project lead on [Quarto](https://quarto.org)) We use `autocomplete` in our websites, and it's great! However, axe-core complains about a missing aria-label in the outer `div` element.

This one-line PR should fix that. 

I should note that I haven't validated the fix directly because we use the UMD distribution of autocomplete we get from unpkg. However, I've verified that the code change made here causes the build to change precisely how we need it to.

**Result**

When running axe-core checks, we no longer see the "Ensure every ARIA input field has an accessible name" violation.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
