### PR TITLE
fix(perf): pause animations when not displayed

### DIFF
--- a/packages/autocomplete-js/src/render.tsx
+++ b/packages/autocomplete-js/src/render.tsx
@@ -57,18 +57,7 @@ export function renderSearchBox<TItem extends BaseItem>({
   );
   setProperties(dom.label, { hidden: state.status === 'stalled' });
   setProperties(dom.loadingIndicator, { hidden: state.status !== 'stalled' });
-  // Safari will animate the SVG even when it's hidden. We need to pause the
-  // animation manually. See:
-  // - https://github.com/algolia/autocomplete/issues/1322
-  // - https://bugs.webkit.org/show_bug.cgi?id=298217
-  if (dom.loadingIndicator.firstChild?.nodeName === 'svg') {
-    const svgElement = dom.loadingIndicator.firstChild as SVGSVGElement;
-    if (state.status === 'stalled') {
-      svgElement?.unpauseAnimations();
-    } else {
-      svgElement?.pauseAnimations();
-    }
-  }
+  toggleAnimation(dom.loadingIndicator, state.status === 'stalled');
 
   setProperties(dom.clearButton, { hidden: !state.query });
   setProperties(dom.detachedSearchButtonQuery, {
@@ -77,6 +66,30 @@ export function renderSearchBox<TItem extends BaseItem>({
   setProperties(dom.detachedSearchButtonPlaceholder, {
     hidden: Boolean(state.query),
   });
+}
+
+// Safari will animate the SVG even when it's hidden. We need to pause the
+// animation manually. See:
+// - https://github.com/algolia/autocomplete/issues/1322
+// - https://bugs.webkit.org/show_bug.cgi?id=298217
+function toggleAnimation(element: HTMLElement, isActive: boolean) {
+  const svgElement =
+    element.firstChild?.nodeName === 'svg'
+      ? (element.firstChild as SVGSVGElement)
+      : null;
+  if (
+    !svgElement ||
+    !svgElement.pauseAnimations ||
+    !svgElement.unpauseAnimations
+  ) {
+    return;
+  }
+
+  if (isActive) {
+    svgElement.unpauseAnimations();
+  } else {
+    svgElement.pauseAnimations();
+  }
 }
 
 export function renderPanel<TItem extends BaseItem>(

--- a/packages/autocomplete-js/src/render.tsx
+++ b/packages/autocomplete-js/src/render.tsx
@@ -62,10 +62,11 @@ export function renderSearchBox<TItem extends BaseItem>({
   // - https://github.com/algolia/autocomplete/issues/1322
   // - https://bugs.webkit.org/show_bug.cgi?id=298217
   if (dom.loadingIndicator.firstChild?.nodeName === 'svg') {
+    const svgElement = dom.loadingIndicator.firstChild as SVGSVGElement;
     if (state.status === 'stalled') {
-      (dom.loadingIndicator.firstChild as SVGSVGElement).unpauseAnimations();
+      svgElement?.unpauseAnimations();
     } else {
-      (dom.loadingIndicator.firstChild as SVGSVGElement).pauseAnimations();
+      svgElement?.pauseAnimations();
     }
   }
 

--- a/packages/autocomplete-js/src/render.tsx
+++ b/packages/autocomplete-js/src/render.tsx
@@ -57,6 +57,18 @@ export function renderSearchBox<TItem extends BaseItem>({
   );
   setProperties(dom.label, { hidden: state.status === 'stalled' });
   setProperties(dom.loadingIndicator, { hidden: state.status !== 'stalled' });
+  // Safari will animate the SVG even when it's hidden. We need to pause the
+  // animation manually. See:
+  // - https://github.com/algolia/autocomplete/issues/1322
+  // - https://bugs.webkit.org/show_bug.cgi?id=298217
+  if (dom.loadingIndicator.firstChild?.nodeName === 'svg') {
+    if (state.status === 'stalled') {
+      (dom.loadingIndicator.firstChild as SVGSVGElement).unpauseAnimations();
+    } else {
+      (dom.loadingIndicator.firstChild as SVGSVGElement).pauseAnimations();
+    }
+  }
+
   setProperties(dom.clearButton, { hidden: !state.query });
   setProperties(dom.detachedSearchButtonQuery, {
     textContent: state.query,


### PR DESCRIPTION
Safari still calculates rendering for animations that are set with animateTransform, even if they aren't being displayed (svg or parent is `hidden`). This causes performance issues on older devices.

We work around this by manually pausing or unpausing the svg depending on whether it's displayed.

https://bugs.webkit.org/show_bug.cgi?id=298217
closes #1322

before|after
---|---
<img width="599" height="311" alt="Screenshot 2025-09-02 at 10 21 38" src="https://github.com/user-attachments/assets/ca1eec51-38e4-455c-a6c7-67e7afb1de72" /> | <img width="523" height="302" alt="Screenshot 2025-09-02 at 10 21 23" src="https://github.com/user-attachments/assets/39acbe17-aa23-4106-8307-1012d2c243dc" />

