### PR TITLE
fix(perf): pause loading icon animation on initial load

### DIFF
--- a/packages/autocomplete-js/src/elements/LoadingIcon.ts
+++ b/packages/autocomplete-js/src/elements/LoadingIcon.ts
@@ -44,7 +44,9 @@ export const LoadingIcon: AutocompleteElement<
     element.pauseAnimations();
   };
 
-  pauseAnimations();
+  if ('pauseAnimations' in element) {
+    pauseAnimations();
+  }
 
   return element;
 };

--- a/packages/autocomplete-js/src/elements/LoadingIcon.ts
+++ b/packages/autocomplete-js/src/elements/LoadingIcon.ts
@@ -34,5 +34,17 @@ export const LoadingIcon: AutocompleteElement<
   />
 </circle>`;
 
+  const pauseAnimations = () => {
+    // Wait until the element is in the DOM.
+    if (!element.parentElement) {
+      setTimeout(pauseAnimations, 0);
+      return;
+    }
+
+    element.pauseAnimations();
+  };
+
+  pauseAnimations();
+
   return element;
 };


### PR DESCRIPTION
**Summary**

#1323 aimed to pause the loading icon animation to prevent performance issues in Safari, but while it worked well after user interaction, it didn't pause it on initial load. This was because the request to pause the animations was done before the element was added to the DOM. This PR adds that behavior.

closes #1322 more