### PR TITLE
feat(dom): announce results updates with a live region

### DIFF
--- a/packages/autocomplete-js/src/createAutocompleteDom.ts
+++ b/packages/autocomplete-js/src/createAutocompleteDom.ts
@@ -108,6 +108,10 @@ export function createAutocompleteDom<TItem extends BaseItem>({
     isDetached,
   });
 
+  const inputLiveRegion = createDomElement('div', {
+    ariaLive: 'assertive',
+    hidden: true,
+  });
   const inputWrapperPrefix = createDomElement('div', {
     class: classNames.inputWrapperPrefix,
     children: [label, loadingIndicator],
@@ -118,7 +122,7 @@ export function createAutocompleteDom<TItem extends BaseItem>({
   });
   const inputWrapper = createDomElement('div', {
     class: classNames.inputWrapper,
-    children: [input],
+    children: [input, inputLiveRegion],
   });
 
   const formProps = propGetters.getFormProps({
@@ -207,6 +211,7 @@ export function createAutocompleteDom<TItem extends BaseItem>({
     detachedOverlay,
     detachedSearchButtonQuery,
     detachedSearchButtonPlaceholder,
+    inputLiveRegion,
     inputWrapper,
     input,
     root,

--- a/packages/autocomplete-js/src/render.tsx
+++ b/packages/autocomplete-js/src/render.tsx
@@ -66,6 +66,12 @@ export function renderSearchBox<TItem extends BaseItem>({
   setProperties(dom.detachedSearchButtonPlaceholder, {
     hidden: Boolean(state.query),
   });
+
+  // FIXME: Should leverage `translations`
+  dom.inputLiveRegion.innerText = ((count) =>
+    count > 0 ? `${count} results available` : 'No results available')(
+    state.collections.reduce((count, { items }) => count + items.length, 0)
+  );
 }
 
 // Safari will animate the SVG even when it's hidden. We need to pause the

--- a/packages/autocomplete-js/src/types/AutocompleteDom.ts
+++ b/packages/autocomplete-js/src/types/AutocompleteDom.ts
@@ -1,4 +1,5 @@
 export type AutocompleteDom = {
+  inputLiveRegion: HTMLDivElement;
   inputWrapper: HTMLDivElement;
   input: HTMLInputElement;
   root: HTMLDivElement;


### PR DESCRIPTION
**Summary**

This PR inserts an [ARIA live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions) in the input wrapper, that helps screen reader know and announce when results change due to user interaction.

[CR-9975]

[CR-9975]: https://algolia.atlassian.net/browse/CR-9975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ