### PR TITLE
fix(autocomplete-preset-algolia): support Unicode in ReverseHighlight

### DIFF
--- a/packages/autocomplete-preset-algolia/src/highlight/__tests__/isPartHighlighted.test.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/__tests__/isPartHighlighted.test.ts
@@ -30,4 +30,92 @@ describe('isPartHighlighted', () => {
       )
     ).toEqual(true);
   });
+
+  // Japanese (俺はジャイアン): start / middle / end
+
+  test('does not treat Japanese text as a separator at the start (俺はジャイアン)', () => {
+    expect(
+      isPartHighlighted(
+        [
+          { isHighlighted: false, value: '俺は' },
+          { isHighlighted: false, value: ' ' },
+          { isHighlighted: true, value: 'ジャイアン' },
+        ],
+        0
+      )
+    ).toEqual(false);
+  });
+
+  test('does not treat Japanese text as a separator in the middle (俺はジャイアンだ)', () => {
+    expect(
+      isPartHighlighted(
+        [
+          { isHighlighted: true, value: '俺は' },
+          { isHighlighted: false, value: ' ' },
+          { isHighlighted: false, value: 'ジャイアン' },
+          { isHighlighted: false, value: ' ' },
+          { isHighlighted: true, value: 'だ' },
+        ],
+        2
+      )
+    ).toEqual(false);
+  });
+
+  test('does not treat Japanese text as a separator at the end (俺はジャイアンだ)', () => {
+    expect(
+      isPartHighlighted(
+        [
+          { isHighlighted: true, value: '俺は' },
+          { isHighlighted: false, value: ' ' },
+          { isHighlighted: true, value: 'ジャイアン' },
+          { isHighlighted: false, value: ' ' },
+          { isHighlighted: false, value: 'だ' },
+        ],
+        4
+      )
+    ).toEqual(false);
+  });
+
+  // Cyrillic (regression #1317): start / middle / end
+
+  test('does not treat Cyrillic text as a separator at the start (regression #1317)', () => {
+    expect(
+      isPartHighlighted(
+        [
+          { isHighlighted: false, value: 'привет' },
+          { isHighlighted: false, value: ' ' },
+          { isHighlighted: true, value: 'мир' },
+        ],
+        0
+      )
+    ).toEqual(false);
+  });
+
+  test('does not treat Cyrillic text as a separator in the middle (regression #1317)', () => {
+    expect(
+      isPartHighlighted(
+        [
+          { isHighlighted: true, value: 'привет' },
+          { isHighlighted: false, value: ' ' },
+          { isHighlighted: false, value: 'мир' },
+          { isHighlighted: false, value: ' ' },
+          { isHighlighted: true, value: 'привет' },
+        ],
+        2
+      )
+    ).toEqual(false);
+  });
+
+  test('does not treat Cyrillic text as a separator at the end (regression #1317)', () => {
+    expect(
+      isPartHighlighted(
+        [
+          { isHighlighted: true, value: 'привет' },
+          { isHighlighted: false, value: ' ' },
+          { isHighlighted: false, value: 'мир' },
+        ],
+        2
+      )
+    ).toEqual(false);
+  });
 });

--- a/packages/autocomplete-preset-algolia/src/highlight/isPartHighlighted.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/isPartHighlighted.ts
@@ -7,7 +7,13 @@ const htmlEscapes = {
   '&quot;': '"',
   '&#39;': "'",
 };
-const hasAlphanumeric = new RegExp(/\w/i);
+const hasLetterOrNumber = (() => {
+  try {
+    return new RegExp('[\\p{L}\\p{N}_]', 'u');
+  } catch {
+    return new RegExp(/\w/i);
+  }
+})();
 const regexEscapedHtml = /&(amp|quot|lt|gt|#39);/g;
 const regexHasEscapedHtml = RegExp(regexEscapedHtml.source);
 
@@ -23,7 +29,7 @@ export function isPartHighlighted(parts: ParsedAttribute[], i: number) {
   const isPreviousHighlighted = parts[i - 1]?.isHighlighted || true;
 
   if (
-    !hasAlphanumeric.test(unescape(current.value)) &&
+    !hasLetterOrNumber.test(unescape(current.value)) &&
     isPreviousHighlighted === isNextHighlighted
   ) {
     return isPreviousHighlighted;


### PR DESCRIPTION
**Summary**

This PR fixes ReverseHighlight behavior for non-ASCII queries (e.g., Japanese and Cyrillic) in `@algolia/autocomplete-preset-algolia`.

`isPartHighlighted` previously used an ASCII-only `\w` check to detect "word characters". In JavaScript, `\w` matches `[A-Za-z0-9_]` and **does not match Unicode letters**. As a result, Unicode text could be treated as a "separator" by the normalization logic, which could lead to incorrect ReverseHighlight output (see #1317).

This change replaces the ASCII-only check with a Unicode-aware check (Unicode property escapes) and renames the variable accordingly. A fallback to the previous `\w` behavior is kept for environments where Unicode property escapes are unavailable.

**Result**

```bash
npm test -- --testPathPattern=isPartHighlighted\.test\.ts
```

Output: 

```
 PASS  packages/autocomplete-preset-algolia/src/highlight/__tests__/isPartHighlighted.test.ts
  isPartHighlighted
    ✓ returns the isHighlighted value with a missing sibling (1 ms)
    ✓ returns the isHighlighted value with both siblings (1 ms)
    ✓ does not treat Japanese text as a separator at the start (俺はジャイアン)
    ✓ does not treat Japanese text as a separator in the middle (俺はジャイアンだ)
    ✓ does not treat Japanese text as a separator at the end (俺はジャイアンだ)
    ✓ does not treat Cyrillic text as a separator at the start (regression #1317)
    ✓ does not treat Cyrillic text as a separator in the middle (regression #1317)
    ✓ does not treat Cyrillic text as a separator at the end (regression #1317)

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        0.493 s, estimated 1 s
```

fixes #1317

### UI Evidence (Before / After)

**Before (current behavior)**
- Query: `音声`
- ReverseHighlight does not highlight the non-matching suffix part as expected.  
<img width="719" height="548" alt="image" src="https://github.com/user-attachments/assets/2bad8703-27a1-4817-9782-d263a46c260b" />

**After (this PR)**
- Query: `音声`
- ReverseHighlight highlights the non-matching suffix (e.g., "dl book") while keeping the matching prefix unhighlighted.
<img width="723" height="556" alt="image" src="https://github.com/user-attachments/assets/bc0ca41a-a390-45df-97c1-381496342d13" />
