### PR TITLE
fix(styling): revert 1.19.7

### DIFF
--- a/packages/autocomplete-js/src/__tests__/panelPlacement.test.ts
+++ b/packages/autocomplete-js/src/__tests__/panelPlacement.test.ts
@@ -26,42 +26,6 @@ describe('panelPlacement', () => {
     toJSON: () => {},
   });
 
-  function mockPosition() {
-    // Mock `getBoundingClientRect` for elements used in the panel placement calculation
-    document.querySelector('.aa-Form').getBoundingClientRect =
-      mockedGetBoundingClientRect;
-    Object.defineProperty(document.querySelector('.aa-Form'), 'offsetLeft', {
-      get() {
-        return LEFT;
-      },
-    });
-    Object.defineProperty(document.querySelector('.aa-Form'), 'offsetTop', {
-      get() {
-        return TOP;
-      },
-    });
-    document.querySelector('.aa-Autocomplete').getBoundingClientRect =
-      mockedGetBoundingClientRect;
-    Object.defineProperty(
-      document.querySelector('.aa-Autocomplete'),
-      'offsetLeft',
-      {
-        get() {
-          return LEFT;
-        },
-      }
-    );
-    Object.defineProperty(
-      document.querySelector('.aa-Autocomplete'),
-      'offsetTop',
-      {
-        get() {
-          return TOP;
-        },
-      }
-    );
-  }
-
   beforeAll(() => {
     Object.defineProperty(document.documentElement, 'clientWidth', {
       get() {
@@ -103,7 +67,11 @@ describe('panelPlacement', () => {
         },
       });
 
-      mockPosition();
+      // Mock `getBoundingClientRect` for elements used in the panel placement calculation
+      document.querySelector('.aa-Form').getBoundingClientRect =
+        mockedGetBoundingClientRect;
+      document.querySelector('.aa-Autocomplete').getBoundingClientRect =
+        mockedGetBoundingClientRect;
 
       await waitFor(() => {
         expect(document.querySelector('.aa-Panel')).toHaveStyle({
@@ -127,11 +95,15 @@ describe('panelPlacement', () => {
 
       fireEvent.scroll(document.body, { target: { scrollTop: SCROLL } });
 
-      mockPosition();
+      // Mock `getBoundingClientRect` for elements used in the panel placement calculation
+      document.querySelector('.aa-Form').getBoundingClientRect =
+        mockedGetBoundingClientRect;
+      document.querySelector('.aa-Autocomplete').getBoundingClientRect =
+        mockedGetBoundingClientRect;
 
       await waitFor(() => {
         expect(document.querySelector('.aa-Panel')).toHaveStyle({
-          top: '24px', // TOP + HEIGHT
+          top: '124px', // TOP + HEIGHT + SCROLL
           left: '11px', // LEFT
           right: '1890px', // CLIENT_WIDTH - (LEFT + WIDTH)
           width: 'unset',
@@ -151,7 +123,11 @@ describe('panelPlacement', () => {
         },
       });
 
-      mockPosition();
+      // Mock `getBoundingClientRect` for elements used in the panel placement calculation
+      document.querySelector('.aa-Form').getBoundingClientRect =
+        mockedGetBoundingClientRect;
+      document.querySelector('.aa-Autocomplete').getBoundingClientRect =
+        mockedGetBoundingClientRect;
 
       await waitFor(() => {
         expect(document.querySelector('.aa-Panel')).toHaveStyle({
@@ -172,11 +148,15 @@ describe('panelPlacement', () => {
 
       fireEvent.scroll(document.body, { target: { scrollTop: SCROLL } });
 
-      mockPosition();
+      // Mock `getBoundingClientRect` for elements used in the panel placement calculation
+      document.querySelector('.aa-Form').getBoundingClientRect =
+        mockedGetBoundingClientRect;
+      document.querySelector('.aa-Autocomplete').getBoundingClientRect =
+        mockedGetBoundingClientRect;
 
       await waitFor(() => {
         expect(document.querySelector('.aa-Panel')).toHaveStyle({
-          top: '24px', // TOP + HEIGHT
+          top: '124px', // TOP + HEIGHT + SCROLL
           left: '11px', // LEFT
         });
       });
@@ -193,7 +173,11 @@ describe('panelPlacement', () => {
         },
       });
 
-      mockPosition();
+      // Mock `getBoundingClientRect` for elements used in the panel placement calculation
+      document.querySelector('.aa-Form').getBoundingClientRect =
+        mockedGetBoundingClientRect;
+      document.querySelector('.aa-Autocomplete').getBoundingClientRect =
+        mockedGetBoundingClientRect;
 
       await waitFor(() => {
         expect(document.querySelector('.aa-Panel')).toHaveStyle({
@@ -214,11 +198,15 @@ describe('panelPlacement', () => {
 
       fireEvent.scroll(document.body, { target: { scrollTop: SCROLL } });
 
-      mockPosition();
+      // Mock `getBoundingClientRect` for elements used in the panel placement calculation
+      document.querySelector('.aa-Form').getBoundingClientRect =
+        mockedGetBoundingClientRect;
+      document.querySelector('.aa-Autocomplete').getBoundingClientRect =
+        mockedGetBoundingClientRect;
 
       await waitFor(() => {
         expect(document.querySelector('.aa-Panel')).toHaveStyle({
-          top: '24px', // TOP + HEIGHT
+          top: '124px', // TOP + HEIGHT + SCROLL
           right: '1890px', // CLIENT_WIDTH - (LEFT + WIDTH)
         });
       });
@@ -235,7 +223,11 @@ describe('panelPlacement', () => {
         },
       });
 
-      mockPosition();
+      // Mock `getBoundingClientRect` for elements used in the panel placement calculation
+      document.querySelector('.aa-Form').getBoundingClientRect =
+        mockedGetBoundingClientRect;
+      document.querySelector('.aa-Autocomplete').getBoundingClientRect =
+        mockedGetBoundingClientRect;
 
       await waitFor(() => {
         expect(document.querySelector('.aa-Panel')).toHaveStyle({
@@ -259,11 +251,15 @@ describe('panelPlacement', () => {
 
       fireEvent.scroll(document.body, { target: { scrollTop: SCROLL } });
 
-      mockPosition();
+      // Mock `getBoundingClientRect` for elements used in the panel placement calculation
+      document.querySelector('.aa-Form').getBoundingClientRect =
+        mockedGetBoundingClientRect;
+      document.querySelector('.aa-Autocomplete').getBoundingClientRect =
+        mockedGetBoundingClientRect;
 
       await waitFor(() => {
         expect(document.querySelector('.aa-Panel')).toHaveStyle({
-          top: '24px', // TOP + HEIGHT
+          top: '124px', // TOP + HEIGHT + SCROLL
           left: 0,
           right: 0,
           width: 'unset',
@@ -281,7 +277,11 @@ describe('panelPlacement', () => {
       },
     });
 
-    mockPosition();
+    // Mock `getBoundingClientRect` for elements used in the panel placement calculation
+    document.querySelector('.aa-Form').getBoundingClientRect =
+      mockedGetBoundingClientRect;
+    document.querySelector('.aa-Autocomplete').getBoundingClientRect =
+      mockedGetBoundingClientRect;
 
     await waitFor(() => {
       expect(document.querySelector('.aa-Panel')).toHaveStyle({
@@ -332,11 +332,15 @@ describe('panelPlacement', () => {
 
     fireEvent.scroll(document.body, { target: { scrollTop: SCROLL } });
 
-    mockPosition();
+    // Mock `getBoundingClientRect` for elements used in the panel placement calculation
+    document.querySelector('.aa-Form').getBoundingClientRect =
+      mockedGetBoundingClientRect;
+    document.querySelector('.aa-Autocomplete').getBoundingClientRect =
+      mockedGetBoundingClientRect;
 
     await waitFor(() => {
       expect(document.querySelector('.aa-Panel')).toHaveStyle({
-        top: '24px', // TOP + HEIGHT
+        top: '124px', // TOP + HEIGHT + SCROLL
         left: '11px', // LEFT
         right: '1890px', // CLIENT_WIDTH - (LEFT + WIDTH)
         width: 'unset',

--- a/packages/autocomplete-js/src/__tests__/positioning.test.ts
+++ b/packages/autocomplete-js/src/__tests__/positioning.test.ts
@@ -101,41 +101,6 @@ describe('Panel positioning', () => {
     document.body.innerHTML = '';
   });
 
-  function mockPosition(
-    _rootPosition = rootPosition,
-    _formPosition = formPosition
-  ) {
-    const root = document.querySelector<HTMLDivElement>('.aa-Autocomplete');
-    root.getBoundingClientRect = jest.fn().mockReturnValue(_rootPosition);
-    Object.defineProperty(root, 'offsetLeft', {
-      get() {
-        return _rootPosition.left;
-      },
-      configurable: true,
-    });
-    Object.defineProperty(root, 'offsetTop', {
-      get() {
-        return _rootPosition.top;
-      },
-      configurable: true,
-    });
-
-    const form = document.querySelector<HTMLFormElement>('.aa-Form');
-    form.getBoundingClientRect = jest.fn().mockReturnValue(_formPosition);
-    Object.defineProperty(form, 'offsetLeft', {
-      get() {
-        return _formPosition.left;
-      },
-      configurable: true,
-    });
-    Object.defineProperty(form, 'offsetTop', {
-      get() {
-        return _formPosition.top;
-      },
-      configurable: true,
-    });
-  }
-
   test('positions the panel below the root element', async () => {
     const container = document.createElement('div');
     const panelContainer = document.body;
@@ -148,7 +113,10 @@ describe('Panel positioning', () => {
       plugins: [querySuggestionsFixturePlugin],
     });
 
-    mockPosition();
+    const root = document.querySelector<HTMLDivElement>('.aa-Autocomplete');
+    root.getBoundingClientRect = jest.fn().mockReturnValue(rootPosition);
+    const form = document.querySelector<HTMLFormElement>('.aa-Form');
+    form.getBoundingClientRect = jest.fn().mockReturnValue(formPosition);
 
     const input = document.querySelector<HTMLInputElement>('.aa-Input');
     userEvent.type(input, 'a');
@@ -174,7 +142,10 @@ describe('Panel positioning', () => {
       plugins: [querySuggestionsFixturePlugin],
     });
 
-    mockPosition();
+    const root = document.querySelector<HTMLDivElement>('.aa-Autocomplete');
+    root.getBoundingClientRect = jest.fn().mockReturnValue(rootPosition);
+    const form = document.querySelector<HTMLFormElement>('.aa-Form');
+    form.getBoundingClientRect = jest.fn().mockReturnValue(formPosition);
 
     const input = document.querySelector<HTMLInputElement>('.aa-Input');
     userEvent.type(input, 'a');
@@ -184,7 +155,7 @@ describe('Panel positioning', () => {
     await waitFor(() => getByTestId(panelContainer, 'panel'));
 
     expect(getByTestId(panelContainer, 'panel')).toHaveStyle({
-      top: '40px',
+      top: '140px',
       left: '300px',
       right: '1020px',
     });
@@ -204,7 +175,10 @@ describe('Panel positioning', () => {
       plugins: [querySuggestionsFixturePlugin],
     });
 
-    mockPosition();
+    const root = document.querySelector<HTMLDivElement>('.aa-Autocomplete');
+    root.getBoundingClientRect = jest.fn().mockReturnValue(rootPosition);
+    const form = document.querySelector<HTMLFormElement>('.aa-Form');
+    form.getBoundingClientRect = jest.fn().mockReturnValue(formPosition);
 
     const input = document.querySelector<HTMLInputElement>('.aa-Input');
     userEvent.type(input, 'a');
@@ -220,7 +194,9 @@ describe('Panel positioning', () => {
     userEvent.click(document.body);
 
     // Move the root vertically
-    mockPosition({ ...rootPosition, top: 90 });
+    root.getBoundingClientRect = jest
+      .fn()
+      .mockReturnValue({ ...rootPosition, top: 90 });
 
     input.focus();
 

--- a/packages/autocomplete-js/src/getPanelPlacementStyle.ts
+++ b/packages/autocomplete-js/src/getPanelPlacementStyle.ts
@@ -15,16 +15,20 @@ export function getPanelPlacementStyle({
   environment,
 }: GetPanelPlacementStyleParams) {
   const containerRect = container.getBoundingClientRect();
-  const offsetParent =
-    container.offsetParent || environment.document.documentElement;
-
-  const top = container.offsetTop + containerRect.height;
+  // Some browsers have specificities to retrieve the document scroll position.
+  // See https://stackoverflow.com/a/28633515/9940315
+  const scrollTop =
+    (environment.pageYOffset as number) ||
+    environment.document.documentElement.scrollTop ||
+    environment.document.body.scrollTop ||
+    0;
+  const top = scrollTop + containerRect.top + containerRect.height;
 
   switch (panelPlacement) {
     case 'start': {
       return {
         top,
-        left: container.offsetLeft,
+        left: containerRect.left,
       };
     }
 
@@ -32,8 +36,8 @@ export function getPanelPlacementStyle({
       return {
         top,
         right:
-          offsetParent.clientWidth -
-          (container.offsetLeft + containerRect.width),
+          environment.document.documentElement.clientWidth -
+          (containerRect.left + containerRect.width),
       };
     }
 
@@ -52,8 +56,10 @@ export function getPanelPlacementStyle({
 
       return {
         top,
-        left: form.offsetLeft,
-        right: offsetParent.clientWidth - (form.offsetLeft + formRect.width),
+        left: formRect.left,
+        right:
+          environment.document.documentElement.clientWidth -
+          (formRect.left + formRect.width),
         width: 'unset',
         maxWidth: 'unset',
       };


### PR DESCRIPTION
The PRs https://github.com/algolia/autocomplete/pull/1338 and https://github.com/algolia/autocomplete/pull/1336 were very promising, but caused some regressions in positioned containers. Therefore for now i'll revert them.

@salomvary, if you could reimplement these changes, but taking the relative positioning in account, that would be ideal.

fixes https://github.com/algolia/autocomplete/issues/1342