### PR TITLE
fix(preset-algolia): keep separator highlight when reverse-highlight siblings disagree

### DIFF
--- a/packages/autocomplete-preset-algolia/src/highlight/__tests__/isPartHighlighted.test.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/__tests__/isPartHighlighted.test.ts
@@ -16,6 +16,23 @@ describe('isPartHighlighted', () => {
     ).toEqual(true);
   });
 
+  test('does not inherit sibling state when siblings disagree', () => {
+    // The separator (index 1) sits between a highlighted ("Amazon") and a
+    // non-highlighted ("Fire") part. Since the siblings disagree, the separator
+    // must keep its own `isHighlighted` value rather than being treated as
+    // highlighted-from-siblings.
+    expect(
+      isPartHighlighted(
+        [
+          { isHighlighted: true, value: 'Amazon' },
+          { isHighlighted: false, value: ' - ' },
+          { isHighlighted: false, value: 'Fire' },
+        ],
+        1
+      )
+    ).toEqual(false);
+  });
+
   test('returns the isHighlighted value with both siblings', () => {
     expect(
       isPartHighlighted(

--- a/packages/autocomplete-preset-algolia/src/highlight/isPartHighlighted.ts
+++ b/packages/autocomplete-preset-algolia/src/highlight/isPartHighlighted.ts
@@ -25,8 +25,8 @@ function unescape(value: string): string {
 
 export function isPartHighlighted(parts: ParsedAttribute[], i: number) {
   const current = parts[i];
-  const isNextHighlighted = parts[i + 1]?.isHighlighted || true;
-  const isPreviousHighlighted = parts[i - 1]?.isHighlighted || true;
+  const isNextHighlighted = parts[i + 1]?.isHighlighted ?? true;
+  const isPreviousHighlighted = parts[i - 1]?.isHighlighted ?? true;
 
   if (
     !hasLetterOrNumber.test(unescape(current.value)) &&


### PR DESCRIPTION
## What's broken

In the reverse-highlight / reverse-snippet "sibling strategy", `isPartHighlighted` computes neighbor state with `||`:

```js
const isNextHighlighted = parts[i + 1]?.isHighlighted || true;
const isPreviousHighlighted = parts[i - 1]?.isHighlighted || true;
```

`X || true` is always `true`, even when the neighbor exists and is genuinely `false`. So the `isPreviousHighlighted === isNextHighlighted` guard is always true, and every separator part between mismatched neighbors is wrongly treated as highlighted-from-siblings. For a value where a separator sits between a highlighted and a non-highlighted segment, the reverse-highlight output is wrong.

## Why it happens

`||` was used where a "default only when the neighbor is missing" was intended — the `?.` optional chaining shows the intent. `false || true` collapses a real `false` neighbor to `true`.

## Fix

Use `??` so the `true` default applies only when the neighbor is absent (`undefined`).

## Test

Added a case: a separator between a highlighted and a non-highlighted segment keeps its own state; fails before, passes after. Full `autocomplete-preset-algolia` suite stays green.
